### PR TITLE
iss Response Parameter

### DIFF
--- a/src/IdentityServer/Extensions/AuthorizeResponseExtensions.cs
+++ b/src/IdentityServer/Extensions/AuthorizeResponseExtensions.cs
@@ -59,6 +59,11 @@ namespace Duende.IdentityServer.Models
             {
                 collection.Add("session_state", response.SessionState);
             }
+            
+            if (response.Issuer.IsPresent())
+            {
+                collection.Add("iss", response.Issuer);
+            }
 
             return collection;
         }

--- a/src/IdentityServer/ResponseHandling/Default/AuthorizeResponseGenerator.cs
+++ b/src/IdentityServer/ResponseHandling/Default/AuthorizeResponseGenerator.cs
@@ -14,6 +14,7 @@ using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services;
 using Duende.IdentityServer.Validation;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
 
 namespace Duende.IdentityServer.ResponseHandling
 {
@@ -23,6 +24,11 @@ namespace Duende.IdentityServer.ResponseHandling
     /// <seealso cref="IAuthorizeResponseGenerator" />
     public class AuthorizeResponseGenerator : IAuthorizeResponseGenerator
     {
+        /// <summary>
+        /// The HTTP context accessor
+        /// </summary>
+        protected readonly IHttpContextAccessor HttpContextAccessor;
+
         /// <summary>
         /// The token service
         /// </summary>
@@ -57,6 +63,7 @@ namespace Duende.IdentityServer.ResponseHandling
         /// Initializes a new instance of the <see cref="AuthorizeResponseGenerator"/> class.
         /// </summary>
         /// <param name="clock">The clock.</param>
+        /// <param name="httpContextAccessor">The HTTP context accessor</param>
         /// <param name="logger">The logger.</param>
         /// <param name="tokenService">The token service.</param>
         /// <param name="keyMaterialService"></param>
@@ -67,9 +74,11 @@ namespace Duende.IdentityServer.ResponseHandling
             ITokenService tokenService,
             IKeyMaterialService keyMaterialService,
             IAuthorizationCodeStore authorizationCodeStore,
+            IHttpContextAccessor httpContextAccessor,
             ILogger<AuthorizeResponseGenerator> logger,
             IEventService events)
         {
+            HttpContextAccessor = httpContextAccessor;
             Clock = clock;
             TokenService = tokenService;
             KeyMaterialService = keyMaterialService;
@@ -135,6 +144,7 @@ namespace Duende.IdentityServer.ResponseHandling
 
             var response = new AuthorizeResponse
             {
+                Issuer = HttpContextAccessor.HttpContext.GetIdentityServerIssuerUri(),
                 Request = request,
                 Code = id,
                 SessionState = request.GenerateSessionStateValue()

--- a/src/IdentityServer/ResponseHandling/Default/AuthorizeResponseGenerator.cs
+++ b/src/IdentityServer/ResponseHandling/Default/AuthorizeResponseGenerator.cs
@@ -25,11 +25,6 @@ namespace Duende.IdentityServer.ResponseHandling
     public class AuthorizeResponseGenerator : IAuthorizeResponseGenerator
     {
         /// <summary>
-        /// The HTTP context accessor
-        /// </summary>
-        protected readonly IHttpContextAccessor HttpContextAccessor;
-
-        /// <summary>
         /// The token service
         /// </summary>
         protected readonly ITokenService TokenService;
@@ -63,7 +58,6 @@ namespace Duende.IdentityServer.ResponseHandling
         /// Initializes a new instance of the <see cref="AuthorizeResponseGenerator"/> class.
         /// </summary>
         /// <param name="clock">The clock.</param>
-        /// <param name="httpContextAccessor">The HTTP context accessor</param>
         /// <param name="logger">The logger.</param>
         /// <param name="tokenService">The token service.</param>
         /// <param name="keyMaterialService"></param>
@@ -74,11 +68,9 @@ namespace Duende.IdentityServer.ResponseHandling
             ITokenService tokenService,
             IKeyMaterialService keyMaterialService,
             IAuthorizationCodeStore authorizationCodeStore,
-            IHttpContextAccessor httpContextAccessor,
             ILogger<AuthorizeResponseGenerator> logger,
             IEventService events)
         {
-            HttpContextAccessor = httpContextAccessor;
             Clock = clock;
             TokenService = tokenService;
             KeyMaterialService = keyMaterialService;
@@ -144,7 +136,7 @@ namespace Duende.IdentityServer.ResponseHandling
 
             var response = new AuthorizeResponse
             {
-                Issuer = HttpContextAccessor.HttpContext.GetIdentityServerIssuerUri(),
+                Issuer = request.IssuerName,
                 Request = request,
                 Code = id,
                 SessionState = request.GenerateSessionStateValue()

--- a/src/IdentityServer/ResponseHandling/Default/DiscoveryResponseGenerator.cs
+++ b/src/IdentityServer/ResponseHandling/Default/DiscoveryResponseGenerator.cs
@@ -327,6 +327,9 @@ namespace Duende.IdentityServer.ResponseHandling
                     entries.Add(OidcConstants.Discovery.RequestUriParameterSupported, true);
                 }
             }
+            
+            // todo: switch to constant once finalized
+            entries.Add("authorization_response_iss_parameter_supported", true);
 
             if (Options.MutualTls.Enabled)
             {

--- a/src/IdentityServer/ResponseHandling/Models/AuthorizeResponse.cs
+++ b/src/IdentityServer/ResponseHandling/Models/AuthorizeResponse.cs
@@ -21,6 +21,7 @@ namespace Duende.IdentityServer.ResponseHandling
         public int AccessTokenLifetime { get; set; }
         public string Code { get; set; }
         public string SessionState { get; set; }
+        public string Issuer { get; set; }
 
         public string Error { get; set; }
         public string ErrorDescription { get; set; }


### PR DESCRIPTION
Adds support for the `iss` response parameter for authorization code flows. This helps clients mitigate the "AS Mix-up Attack".

https://www.ietf.org/archive/id/draft-meyerzuselhausen-oauth-iss-auth-resp-02.html