### PR TITLE
Enable data protection on persisted grants

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -31,6 +31,7 @@
     <PackageReference Update="xunit.runner.visualstudio" Version="2.4.3" PrivateAssets="All" />
 
     <!--microsoft extensions -->
+    <PackageReference Update="System.Text.Json" Version="5.0.0" />
     <PackageReference Update="Microsoft.Extensions.Caching.Memory" Version="$(ExtensionsVersion)" />
     <PackageReference Update="Microsoft.Extensions.Http" Version="$(ExtensionsVersion)" />
     <PackageReference Update="Microsoft.Extensions.Http.Polly" Version="$(ExtensionsVersion)" />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -37,7 +37,7 @@
     <PackageReference Update="Microsoft.Extensions.Logging" Version="$(ExtensionsVersion)" />
     <PackageReference Update="Microsoft.Extensions.Logging.Console" Version="$(ExtensionsVersion)" />
     <PackageReference Update="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(ExtensionsVersion)" />
-    
+
     <!--misc -->
     <PackageReference Update="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Update="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="$(WilsonVersion)" />
@@ -46,6 +46,7 @@
     <PackageReference Update="Serilog.AspNetCore" Version="3.4.0" />     
     
     <!--microsoft asp.net core -->
+    <PackageReference Update="Microsoft.AspNetCore.DataProtection.Abstractions" Version="$(FrameworkVersion)" />
     <PackageReference Update="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="$(FrameworkVersion)" />
     <PackageReference Update="Microsoft.AspNetCore.TestHost" Version="$(FrameworkVersion)" />
     <PackageReference Update="Microsoft.AspNetCore.Identity" Version="$(FrameworkVersion)" />

--- a/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -48,6 +48,8 @@ namespace Microsoft.Extensions.DependencyInjection
             builder.Services.AddOptions();
             builder.Services.AddSingleton(
                 resolver => resolver.GetRequiredService<IOptions<IdentityServerOptions>>().Value);
+            builder.Services.AddSingleton(
+                resolver => resolver.GetRequiredService<IOptions<IdentityServerOptions>>().Value.PersistentGrants);
             builder.Services.AddHttpClient();
 
             return builder;

--- a/src/IdentityServer/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
@@ -2,6 +2,8 @@
 // See LICENSE in the project root for license information.
 
 
+using Duende.IdentityServer.Stores.Serialization;
+
 namespace Duende.IdentityServer.Configuration
 {
     /// <summary>
@@ -140,5 +142,10 @@ namespace Duende.IdentityServer.Configuration
         /// Gets or sets the signing key management options.
         /// </summary>
         public KeyManagementOptions KeyManagement { get; set; } = new KeyManagementOptions();
+
+        /// <summary>
+        /// Options for persisted grants.
+        /// </summary>
+        public PersistentGrantOptions PersistentGrants { get; set; } = new PersistentGrantOptions();
     }
 }

--- a/src/IdentityServer/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
@@ -148,6 +148,7 @@ namespace Duende.IdentityServer.Configuration
         /// </summary>
         public PersistentGrantOptions PersistentGrants { get; set; } = new PersistentGrantOptions();
 
+        /// <summary>
         /// Gets or sets the license key.
         /// </summary>
         public string LicenseKey { get; set; }

--- a/src/Storage/Duende.IdentityServer.Storage.csproj
+++ b/src/Storage/Duende.IdentityServer.Storage.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="IdentityModel" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/src/Storage/Duende.IdentityServer.Storage.csproj
+++ b/src/Storage/Duende.IdentityServer.Storage.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="IdentityModel" />
+    <PackageReference Include="System.Text.Json" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.Abstractions" />
   </ItemGroup>
 

--- a/src/Storage/Stores/Serialization/ClaimConverter.cs
+++ b/src/Storage/Stores/Serialization/ClaimConverter.cs
@@ -1,41 +1,35 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 
-using Newtonsoft.Json;
 using System;
 using System.Security.Claims;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 #pragma warning disable 1591
 
 namespace Duende.IdentityServer.Stores.Serialization
 {
-    public class ClaimConverter : JsonConverter
+    public class ClaimConverter : JsonConverter<Claim>
     {
-        public override bool CanConvert(Type objectType)
+        public override Claim Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return typeof(Claim) == objectType;
-        }
-
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
-        {
-            var source = serializer.Deserialize<ClaimLite>(reader);
+            var source = JsonSerializer.Deserialize<ClaimLite>(ref reader, options);
             var target = new Claim(source.Type, source.Value, source.ValueType);
             return target;
         }
 
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        public override void Write(Utf8JsonWriter writer, Claim value, JsonSerializerOptions options)
         {
-            var source = (Claim)value;
-
             var target = new ClaimLite
             {
-                Type = source.Type,
-                Value = source.Value,
-                ValueType = source.ValueType
+                Type = value.Type,
+                Value = value.Value,
+                ValueType = value.ValueType
             };
 
-            serializer.Serialize(writer, target);
+            JsonSerializer.Serialize(writer, target, options);
         }
     }
 }

--- a/src/Storage/Stores/Serialization/ClaimsPrincipalConverter.cs
+++ b/src/Storage/Stores/Serialization/ClaimsPrincipalConverter.cs
@@ -3,25 +3,21 @@
 
 
 using IdentityModel;
-using Newtonsoft.Json;
 using System;
 using System.Linq;
 using System.Security.Claims;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 #pragma warning disable 1591
 
 namespace Duende.IdentityServer.Stores.Serialization
 {
-    public class ClaimsPrincipalConverter : JsonConverter
+    public class ClaimsPrincipalConverter : JsonConverter<ClaimsPrincipal>
     {
-        public override bool CanConvert(Type objectType)
+        public override ClaimsPrincipal Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return typeof(ClaimsPrincipal) == objectType;
-        }
-
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
-        {
-            var source = serializer.Deserialize<ClaimsPrincipalLite>(reader);
+            var source = JsonSerializer.Deserialize<ClaimsPrincipalLite>(ref reader, options);
             if (source == null) return null;
 
             var claims = source.Claims.Select(x => new Claim(x.Type, x.Value, x.ValueType));
@@ -30,16 +26,14 @@ namespace Duende.IdentityServer.Stores.Serialization
             return target;
         }
 
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        public override void Write(Utf8JsonWriter writer, ClaimsPrincipal value, JsonSerializerOptions options)
         {
-            var source = (ClaimsPrincipal)value;
-
             var target = new ClaimsPrincipalLite
             {
-                AuthenticationType = source.Identity.AuthenticationType,
-                Claims = source.Claims.Select(x => new ClaimLite { Type = x.Type, Value = x.Value, ValueType = x.ValueType }).ToArray()
+                AuthenticationType = value.Identity.AuthenticationType,
+                Claims = value.Claims.Select(x => new ClaimLite { Type = x.Type, Value = x.Value, ValueType = x.ValueType }).ToArray()
             };
-            serializer.Serialize(writer, target);
+            JsonSerializer.Serialize(writer, target, options);
         }
     }
 }


### PR DESCRIPTION
This makes the "Data" column for the persisted grant store a generic container capable of having metadata without changing the entire table structure. The actual payload is now a value inside the container. 

The first real feature this allows is data protection of the payload itself.