### PR TITLE
Create JTI on each new access token

### DIFF
--- a/src/Storage/Models/Token.cs
+++ b/src/Storage/Models/Token.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 
@@ -104,7 +104,12 @@ namespace Duende.IdentityServer.Models
         /// The description.
         /// </value>
         public string Description { get; set; }
-        
+
+        /// <summary>
+        /// Indicates if the token should have a 'jti' claim value.
+        /// </summary>
+        public bool IncludeJwtId { get; set; }
+
         /// <summary>
         /// Gets or sets the claims.
         /// </summary>
@@ -119,7 +124,7 @@ namespace Duende.IdentityServer.Models
         /// <value>
         /// The version.
         /// </value>
-        public int Version { get; set; } = 4;
+        public int Version { get; set; } = 5;
 
         /// <summary>
         /// Gets the subject identifier.

--- a/test/IdentityServer.UnitTests/Common/MockTokenCreationService.cs
+++ b/test/IdentityServer.UnitTests/Common/MockTokenCreationService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 
@@ -10,11 +10,13 @@ namespace UnitTests.Common
 {
     class MockTokenCreationService : ITokenCreationService
     {
-        public string Token { get; set; }
+        public string TokenResult { get; set; }
+        public Token Token { get; set; }
 
         public Task<string> CreateTokenAsync(Token token)
         {
-            return Task.FromResult(Token);
+            Token = token;
+            return Task.FromResult(TokenResult);
         }
     }
 }


### PR DESCRIPTION
Persisted/Cached access tokens stored in the refresh token persisted grant kept JTI as claim in DB, and new access tokens were not generating new JTI each renewal.

* add property to Token to indicate need for jti
* move jti creation to CreateSecurityTokenAsync and out of CreateAccessTokenAsync
* handle older tokens that do not have new property
