### PR TITLE
Add abstraction for retrieving the issuer name for the current request

### DIFF
--- a/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns></returns>
         public static IIdentityServerBuilder AddRequiredPlatformServices(this IIdentityServerBuilder builder)
         {
-            builder.Services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();            
+            builder.Services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
             builder.Services.AddOptions();
             builder.Services.AddSingleton(
                 resolver => resolver.GetRequiredService<IOptions<IdentityServerOptions>>().Value);
@@ -121,6 +121,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns></returns>
         public static IIdentityServerBuilder AddCoreServices(this IIdentityServerBuilder builder)
         {
+            builder.Services.AddTransient<IIssuerNameService, DefaultIssuerNameService>();
             builder.Services.AddTransient<ISecretsListParser, SecretParser>();
             builder.Services.AddTransient<ISecretsListValidator, SecretValidator>();
             builder.Services.AddTransient<ExtensionGrantValidator>();

--- a/src/IdentityServer/Endpoints/DiscoveryEndpoint.cs
+++ b/src/IdentityServer/Endpoints/DiscoveryEndpoint.cs
@@ -8,6 +8,7 @@ using Duende.IdentityServer.Endpoints.Results;
 using Duende.IdentityServer.Hosting;
 using Duende.IdentityServer.ResponseHandling;
 using Duende.IdentityServer.Extensions;
+using Duende.IdentityServer.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 
@@ -18,16 +19,18 @@ namespace Duende.IdentityServer.Endpoints
         private readonly ILogger _logger;
 
         private readonly IdentityServerOptions _options;
-
+        private readonly IIssuerNameService _issuerNameService;
         private readonly IDiscoveryResponseGenerator _responseGenerator;
 
         public DiscoveryEndpoint(
             IdentityServerOptions options,
+            IIssuerNameService issuerNameService,
             IDiscoveryResponseGenerator responseGenerator,
             ILogger<DiscoveryEndpoint> logger)
         {
             _logger = logger;
             _options = options;
+            _issuerNameService = issuerNameService;
             _responseGenerator = responseGenerator;
         }
 
@@ -51,7 +54,7 @@ namespace Duende.IdentityServer.Endpoints
             }
 
             var baseUrl = context.GetIdentityServerBaseUrl().EnsureTrailingSlash();
-            var issuerUri = context.GetIdentityServerIssuerUri();
+            var issuerUri = await _issuerNameService.GetCurrentAsync();
 
             // generate response
             _logger.LogTrace("Calling into discovery response generator: {type}", _responseGenerator.GetType().FullName);

--- a/src/IdentityServer/Extensions/IdentityServerToolsExtensions.cs
+++ b/src/IdentityServer/Extensions/IdentityServerToolsExtensions.cs
@@ -58,7 +58,9 @@ namespace Duende.IdentityServer
 
             if (options.EmitStaticAudienceClaim)
             {
-                claims.Add(new Claim(JwtClaimTypes.Audience, string.Format(IdentityServerConstants.AccessTokenAudience, tools.ContextAccessor.HttpContext.GetIdentityServerIssuerUri().EnsureTrailingSlash())));
+                claims.Add(new Claim(
+                    JwtClaimTypes.Audience, 
+                    string.Format(IdentityServerConstants.AccessTokenAudience, (await tools.IssuerNameService.GetCurrentAsync()).EnsureTrailingSlash())));
             }
             
             if (!audiences.IsNullOrEmpty())

--- a/src/IdentityServer/IdentityServerTools.cs
+++ b/src/IdentityServer/IdentityServerTools.cs
@@ -21,6 +21,7 @@ namespace Duende.IdentityServer
     public class IdentityServerTools
     {
         internal readonly IHttpContextAccessor ContextAccessor;
+        internal readonly IIssuerNameService IssuerNameService;
         private readonly ITokenCreationService _tokenCreation;
         private readonly ISystemClock _clock;
 
@@ -28,11 +29,13 @@ namespace Duende.IdentityServer
         /// Initializes a new instance of the <see cref="IdentityServerTools" /> class.
         /// </summary>
         /// <param name="contextAccessor">The context accessor.</param>
+        /// <param name="issuerNameService">The issuer name service</param>
         /// <param name="tokenCreation">The token creation service.</param>
         /// <param name="clock">The clock.</param>
-        public IdentityServerTools(IHttpContextAccessor contextAccessor, ITokenCreationService tokenCreation, ISystemClock clock)
+        public IdentityServerTools(IHttpContextAccessor contextAccessor, IIssuerNameService issuerNameService, ITokenCreationService tokenCreation, ISystemClock clock)
         {
             ContextAccessor = contextAccessor;
+            IssuerNameService = issuerNameService;
             _tokenCreation = tokenCreation;
             _clock = clock;
         }
@@ -48,7 +51,7 @@ namespace Duende.IdentityServer
         {
             if (claims == null) throw new ArgumentNullException(nameof(claims));
 
-            var issuer = ContextAccessor.HttpContext.GetIdentityServerIssuerUri();
+            var issuer = await IssuerNameService.GetCurrentAsync();
 
             var token = new Token
             {

--- a/src/IdentityServer/Services/Default/DefaultIssuerNameService.cs
+++ b/src/IdentityServer/Services/Default/DefaultIssuerNameService.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+using System;
+using Duende.IdentityServer.Extensions;
+using Microsoft.AspNetCore.Http;
+
+namespace Duende.IdentityServer.Services
+{
+    /// <summary>
+    /// Abstracts issuer name access
+    /// </summary>
+    public class DefaultIssuerNameService : IIssuerNameService
+    {
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        /// <summary>
+        /// ctor
+        /// </summary>
+        /// <param name="httpContextAccessor"></param>
+        public DefaultIssuerNameService(IHttpContextAccessor httpContextAccessor)
+        {
+            _httpContextAccessor = httpContextAccessor;
+        }
+        
+        /// <inheritdoc />
+        public string GetCurrent()
+        {
+            return _httpContextAccessor.HttpContext.GetIdentityServerIssuerUri();
+        }
+    }
+}

--- a/src/IdentityServer/Services/Default/DefaultIssuerNameService.cs
+++ b/src/IdentityServer/Services/Default/DefaultIssuerNameService.cs
@@ -3,6 +3,7 @@
 
 
 using System;
+using System.Threading.Tasks;
 using Duende.IdentityServer.Extensions;
 using Microsoft.AspNetCore.Http;
 
@@ -18,16 +19,16 @@ namespace Duende.IdentityServer.Services
         /// <summary>
         /// ctor
         /// </summary>
-        /// <param name="httpContextAccessor"></param>
+        /// <param name="httpContextAccessor">The HTTP context accessor</param>
         public DefaultIssuerNameService(IHttpContextAccessor httpContextAccessor)
         {
             _httpContextAccessor = httpContextAccessor;
         }
         
         /// <inheritdoc />
-        public string GetCurrent()
+        public Task<string> GetCurrentAsync()
         {
-            return _httpContextAccessor.HttpContext.GetIdentityServerIssuerUri();
+            return Task.FromResult(_httpContextAccessor.HttpContext.GetIdentityServerIssuerUri());
         }
     }
 }

--- a/src/IdentityServer/Services/Default/DefaultTokenService.cs
+++ b/src/IdentityServer/Services/Default/DefaultTokenService.cs
@@ -154,8 +154,7 @@ namespace Duende.IdentityServer.Services
                 request.IncludeAllIdentityClaims,
                 request.ValidatedRequest));
 
-            var issuer = ContextAccessor.HttpContext.GetIdentityServerIssuerUri();
-
+            var issuer = request.ValidatedRequest.IssuerName;
             var token = new Token(OidcConstants.TokenTypes.IdentityToken)
             {
                 CreationTime = Clock.UtcNow.UtcDateTime,
@@ -193,8 +192,8 @@ namespace Duende.IdentityServer.Services
             {
                 claims.Add(new Claim(JwtClaimTypes.SessionId, request.ValidatedRequest.SessionId));
             }
-            
-            var issuer = ContextAccessor.HttpContext.GetIdentityServerIssuerUri();
+
+            var issuer = request.ValidatedRequest.IssuerName;
             var token = new Token(OidcConstants.TokenTypes.AccessToken)
             {
                 CreationTime = Clock.UtcNow.UtcDateTime,

--- a/src/IdentityServer/Services/Default/KeyManagement/KeyManager.cs
+++ b/src/IdentityServer/Services/Default/KeyManagement/KeyManager.cs
@@ -29,7 +29,7 @@ namespace Duende.IdentityServer.Services.KeyManagement
         private readonly ISystemClock _clock;
         private readonly INewKeyLock _newKeyLock;
         private readonly ILogger<KeyManager> _logger;
-        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly IIssuerNameService _issuerNameService;
 
         /// <summary>
         /// Constructor for KeyManager
@@ -41,7 +41,7 @@ namespace Duende.IdentityServer.Services.KeyManagement
         /// <param name="clock"></param>
         /// <param name="newKeyLock"></param>
         /// <param name="logger"></param>
-        /// <param name="httpContextAccessor"></param>
+        /// <param name="issuerNameService"></param>
         public KeyManager(
             KeyManagementOptions options,
             ISigningKeyStore store,
@@ -50,7 +50,7 @@ namespace Duende.IdentityServer.Services.KeyManagement
             ISystemClock clock,
             INewKeyLock newKeyLock,
             ILogger<KeyManager> logger,
-            IHttpContextAccessor httpContextAccessor = null)
+            IIssuerNameService issuerNameService)
         {
             options.Validate();
 
@@ -61,7 +61,7 @@ namespace Duende.IdentityServer.Services.KeyManagement
             _clock = clock;
             _newKeyLock = newKeyLock;
             _logger = logger;
-            _httpContextAccessor = httpContextAccessor;
+            _issuerNameService = issuerNameService;
         }
 
         /// <inheritdoc />
@@ -264,7 +264,7 @@ namespace Duende.IdentityServer.Services.KeyManagement
             _logger.LogDebug("Creating new key.");
 
             var now = _clock.UtcNow.DateTime;
-            var iss = _httpContextAccessor?.HttpContext?.GetIdentityServerIssuerUri();
+            var iss = await _issuerNameService.GetCurrentAsync();
 
             KeyContainer container = null;
 

--- a/src/IdentityServer/Services/Default/LogoutNotificationService.cs
+++ b/src/IdentityServer/Services/Default/LogoutNotificationService.cs
@@ -19,7 +19,7 @@ namespace Duende.IdentityServer.Services
     public class LogoutNotificationService : ILogoutNotificationService
     {
         private readonly IClientStore _clientStore;
-        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly IIssuerNameService _issuerNameService;
         private readonly ILogger<LogoutNotificationService> _logger;
 
 
@@ -28,11 +28,11 @@ namespace Duende.IdentityServer.Services
         /// </summary>
         public LogoutNotificationService(
             IClientStore clientStore,
-            IHttpContextAccessor httpContextAccessor, 
+            IIssuerNameService issuerNameService,
             ILogger<LogoutNotificationService> logger)
         {
             _clientStore = clientStore;
-            _httpContextAccessor = httpContextAccessor;
+            _issuerNameService = issuerNameService;
             _logger = logger;
         }
 
@@ -55,7 +55,7 @@ namespace Duende.IdentityServer.Services
                             if (client.FrontChannelLogoutSessionRequired)
                             {
                                 url = url.AddQueryString(OidcConstants.EndSessionRequest.Sid, context.SessionId);
-                                url = url.AddQueryString(OidcConstants.EndSessionRequest.Issuer, _httpContextAccessor.HttpContext.GetIdentityServerIssuerUri());
+                                url = url.AddQueryString(OidcConstants.EndSessionRequest.Issuer, await _issuerNameService.GetCurrentAsync());
                             }
                         }
                         else if (client.ProtocolType == IdentityServerConstants.ProtocolTypes.WsFederation)

--- a/src/IdentityServer/Services/IIssuerNameService.cs
+++ b/src/IdentityServer/Services/IIssuerNameService.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+namespace Duende.IdentityServer.Services
+{
+    /// <summary>
+    /// Abstract access to the current issuer name
+    /// </summary>
+    public interface IIssuerNameService
+    {
+        /// <summary>
+        /// Returns the issuer name for the current request
+        /// </summary>
+        /// <returns></returns>
+        string GetCurrent();
+    }
+}

--- a/src/IdentityServer/Services/IIssuerNameService.cs
+++ b/src/IdentityServer/Services/IIssuerNameService.cs
@@ -2,6 +2,8 @@
 // See LICENSE in the project root for license information.
 
 
+using System.Threading.Tasks;
+
 namespace Duende.IdentityServer.Services
 {
     /// <summary>
@@ -13,6 +15,6 @@ namespace Duende.IdentityServer.Services
         /// Returns the issuer name for the current request
         /// </summary>
         /// <returns></returns>
-        string GetCurrent();
+        Task<string> GetCurrentAsync();
     }
 }

--- a/src/IdentityServer/Validation/Default/AuthorizeRequestValidator.cs
+++ b/src/IdentityServer/Validation/Default/AuthorizeRequestValidator.cs
@@ -21,6 +21,7 @@ namespace Duende.IdentityServer.Validation
     internal class AuthorizeRequestValidator : IAuthorizeRequestValidator
     {
         private readonly IdentityServerOptions _options;
+        private readonly IIssuerNameService _issuerNameService;
         private readonly IClientStore _clients;
         private readonly ICustomAuthorizeRequestValidator _customValidator;
         private readonly IRedirectUriValidator _uriValidator;
@@ -35,6 +36,7 @@ namespace Duende.IdentityServer.Validation
 
         public AuthorizeRequestValidator(
             IdentityServerOptions options,
+            IIssuerNameService issuerNameService,
             IClientStore clients,
             ICustomAuthorizeRequestValidator customValidator,
             IRedirectUriValidator uriValidator,
@@ -45,6 +47,7 @@ namespace Duende.IdentityServer.Validation
             ILogger<AuthorizeRequestValidator> logger)
         {
             _options = options;
+            _issuerNameService = issuerNameService;
             _clients = clients;
             _customValidator = customValidator;
             _uriValidator = uriValidator;
@@ -62,6 +65,7 @@ namespace Duende.IdentityServer.Validation
             var request = new ValidatedAuthorizeRequest
             {
                 Options = _options,
+                IssuerName = _issuerNameService.GetCurrent(),
                 Subject = subject ?? Principal.Anonymous,
                 Raw = parameters ?? throw new ArgumentNullException(nameof(parameters))
             };

--- a/src/IdentityServer/Validation/Default/AuthorizeRequestValidator.cs
+++ b/src/IdentityServer/Validation/Default/AuthorizeRequestValidator.cs
@@ -65,7 +65,7 @@ namespace Duende.IdentityServer.Validation
             var request = new ValidatedAuthorizeRequest
             {
                 Options = _options,
-                IssuerName = _issuerNameService.GetCurrent(),
+                IssuerName = await _issuerNameService.GetCurrentAsync(),
                 Subject = subject ?? Principal.Anonymous,
                 Raw = parameters ?? throw new ArgumentNullException(nameof(parameters))
             };

--- a/src/IdentityServer/Validation/Default/PrivateKeyJwtSecretValidator.cs
+++ b/src/IdentityServer/Validation/Default/PrivateKeyJwtSecretValidator.cs
@@ -21,7 +21,7 @@ namespace Duende.IdentityServer.Validation
     /// </summary>
     public class PrivateKeyJwtSecretValidator : ISecretValidator
     {
-        private readonly IHttpContextAccessor _contextAccessor;
+        private readonly IIssuerNameService _issuerNameService;
         private readonly IReplayCache _replayCache;
         private readonly ILogger _logger;
 
@@ -30,9 +30,9 @@ namespace Duende.IdentityServer.Validation
         /// <summary>
         /// Instantiates an instance of private_key_jwt secret validator
         /// </summary>
-        public PrivateKeyJwtSecretValidator(IHttpContextAccessor contextAccessor, IReplayCache replayCache, ILogger<PrivateKeyJwtSecretValidator> logger)
+        public PrivateKeyJwtSecretValidator(IIssuerNameService issuerNameService, IReplayCache replayCache, ILogger<PrivateKeyJwtSecretValidator> logger)
         {
-            _contextAccessor = contextAccessor;
+            _issuerNameService = issuerNameService;
             _replayCache = replayCache;
             _logger = logger;
         }
@@ -81,11 +81,8 @@ namespace Duende.IdentityServer.Validation
 
             var validAudiences = new[]
             {
-                // issuer URI (tbd)
-                //_contextAccessor.HttpContext.GetIdentityServerIssuerUri(),
-                
                 // token endpoint URL
-                string.Concat(_contextAccessor.HttpContext.GetIdentityServerIssuerUri().EnsureTrailingSlash(),
+                string.Concat((await _issuerNameService.GetCurrentAsync()).EnsureTrailingSlash(),
                     Constants.ProtocolRoutePaths.Token)
             };
             

--- a/src/IdentityServer/Validation/Default/TokenRequestValidator.cs
+++ b/src/IdentityServer/Validation/Default/TokenRequestValidator.cs
@@ -24,6 +24,7 @@ namespace Duende.IdentityServer.Validation
     internal class TokenRequestValidator : ITokenRequestValidator
     {
         private readonly IdentityServerOptions _options;
+        private readonly IIssuerNameService _issuerNameService;
         private readonly IAuthorizationCodeStore _authorizationCodeStore;
         private readonly ExtensionGrantValidator _extensionGrantValidator;
         private readonly ICustomTokenRequestValidator _customRequestValidator;
@@ -40,24 +41,9 @@ namespace Duende.IdentityServer.Validation
 
         private ValidatedTokenRequest _validatedRequest;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TokenRequestValidator" /> class.
-        /// </summary>
-        /// <param name="options">The options.</param>
-        /// <param name="authorizationCodeStore">The authorization code store.</param>
-        /// <param name="resourceOwnerValidator">The resource owner validator.</param>
-        /// <param name="profile">The profile.</param>
-        /// <param name="deviceCodeValidator">The device code validator.</param>
-        /// <param name="extensionGrantValidator">The extension grant validator.</param>
-        /// <param name="customRequestValidator">The custom request validator.</param>
-        /// <param name="resourceValidator">The resource validator.</param>
-        /// <param name="resourceStore">The resource store.</param>
-        /// <param name="tokenValidator">The token validator.</param>
-        /// <param name="refreshTokenService"></param>
-        /// <param name="events">The events.</param>
-        /// <param name="clock">The clock.</param>
-        /// <param name="logger">The logger.</param>
-        public TokenRequestValidator(IdentityServerOptions options, 
+        public TokenRequestValidator(
+            IdentityServerOptions options,
+            IIssuerNameService issuerNameService,
             IAuthorizationCodeStore authorizationCodeStore, 
             IResourceOwnerPasswordValidator resourceOwnerValidator, 
             IProfileService profile, 
@@ -74,6 +60,7 @@ namespace Duende.IdentityServer.Validation
         {
             _logger = logger;
             _options = options;
+            _issuerNameService = issuerNameService;
             _clock = clock;
             _authorizationCodeStore = authorizationCodeStore;
             _resourceOwnerValidator = resourceOwnerValidator;
@@ -105,6 +92,7 @@ namespace Duende.IdentityServer.Validation
 
             _validatedRequest = new ValidatedTokenRequest
             {
+                IssuerName = _issuerNameService.GetCurrent(),
                 Raw = parameters ?? throw new ArgumentNullException(nameof(parameters)),
                 Options = _options
             };

--- a/src/IdentityServer/Validation/Default/TokenRequestValidator.cs
+++ b/src/IdentityServer/Validation/Default/TokenRequestValidator.cs
@@ -92,7 +92,7 @@ namespace Duende.IdentityServer.Validation
 
             _validatedRequest = new ValidatedTokenRequest
             {
-                IssuerName = _issuerNameService.GetCurrent(),
+                IssuerName = await _issuerNameService.GetCurrentAsync(),
                 Raw = parameters ?? throw new ArgumentNullException(nameof(parameters)),
                 Options = _options
             };

--- a/src/IdentityServer/Validation/Default/TokenValidator.cs
+++ b/src/IdentityServer/Validation/Default/TokenValidator.cs
@@ -26,7 +26,7 @@ namespace Duende.IdentityServer.Validation
     {
         private readonly ILogger _logger;
         private readonly IdentityServerOptions _options;
-        private readonly IHttpContextAccessor _context;
+        private readonly IIssuerNameService _issuerNameService;
         private readonly IReferenceTokenStore _referenceTokenStore;
         private readonly ICustomTokenValidator _customValidator;
         private readonly IClientStore _clients;
@@ -37,7 +37,7 @@ namespace Duende.IdentityServer.Validation
 
         public TokenValidator(
             IdentityServerOptions options,
-            IHttpContextAccessor context,
+            IIssuerNameService issuerNameService,
             IClientStore clients,
             IProfileService profile,
             IReferenceTokenStore referenceTokenStore,
@@ -48,7 +48,7 @@ namespace Duende.IdentityServer.Validation
             ILogger<TokenValidator> logger)
         {
             _options = options;
-            _context = context;
+            _issuerNameService = issuerNameService;
             _clients = clients;
             _profile = profile;
             _referenceTokenStore = referenceTokenStore;
@@ -250,7 +250,7 @@ namespace Duende.IdentityServer.Validation
 
             var parameters = new TokenValidationParameters
             {
-                ValidIssuer = _context.HttpContext.GetIdentityServerIssuerUri(),
+                ValidIssuer = await _issuerNameService.GetCurrentAsync(),
                 IssuerSigningKeys = validationKeys.Select(k => k.Key),
                 ValidateLifetime = validateLifetime
             };

--- a/src/IdentityServer/Validation/Models/ValidatedRequest.cs
+++ b/src/IdentityServer/Validation/Models/ValidatedRequest.cs
@@ -35,6 +35,11 @@ namespace Duende.IdentityServer.Validation
         public Client Client { get; set; }
 
         /// <summary>
+        /// The name of the issuer for the current request
+        /// </summary>
+        public string IssuerName { get; set; }
+
+        /// <summary>
         /// Gets or sets the secret used to authenticate the client.
         /// </summary>
         /// <value>

--- a/test/IdentityServer.UnitTests/Services/Default/KeyManagement/KeyManagerTests.cs
+++ b/test/IdentityServer.UnitTests/Services/Default/KeyManagement/KeyManagerTests.cs
@@ -10,6 +10,7 @@ using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services.KeyManagement;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
+using UnitTests.Validation.Setup;
 using Xunit;
 
 namespace UnitTests.Services.Default.KeyManagement
@@ -42,7 +43,8 @@ namespace UnitTests.Services.Default.KeyManagement
                 _mockKeyProtector, 
                 _mockClock,
                 new NopKeyLock(),
-                new LoggerFactory().CreateLogger<KeyManager>());
+                new LoggerFactory().CreateLogger<KeyManager>(),
+                new TestIssuerNameService());
         }
 
         KeyContainer CreateKey(TimeSpan? age = null, string alg = "RS256", bool x509 = false)
@@ -90,7 +92,8 @@ namespace UnitTests.Services.Default.KeyManagement
                   _mockKeyProtector,
                   _mockClock,
                   new NopKeyLock(),
-                  new LoggerFactory().CreateLogger<KeyManager>());
+                  new LoggerFactory().CreateLogger<KeyManager>(),
+                  new TestIssuerNameService());
             };
             a.Should().Throw<Exception>();
         }

--- a/test/IdentityServer.UnitTests/Validation/Secrets/PrivateKeyJwtSecretValidation.cs
+++ b/test/IdentityServer.UnitTests/Validation/Secrets/PrivateKeyJwtSecretValidation.cs
@@ -32,15 +32,10 @@ namespace UnitTests.Validation.Secrets
         public PrivateKeyJwtSecretValidation()
         {
             _validator = new PrivateKeyJwtSecretValidator(
-                new MockHttpContextAccessor(
-                    new IdentityServerOptions()
-                        {
-                            IssuerUri = "https://idsrv3.com"
-                        }
-                    ),
-                    new DefaultReplayCache(new TestCache()), 
-                    new LoggerFactory().CreateLogger<PrivateKeyJwtSecretValidator>()
-                );
+                 new TestIssuerNameService("https://idsrv3.com"),
+                 new DefaultReplayCache(new TestCache()), 
+                 new LoggerFactory().CreateLogger<PrivateKeyJwtSecretValidator>());
+            
             _clients = new InMemoryClientStore(ClientValidationTestClients.Get());
         }
 

--- a/test/IdentityServer.UnitTests/Validation/Setup/Factory.cs
+++ b/test/IdentityServer.UnitTests/Validation/Setup/Factory.cs
@@ -29,6 +29,7 @@ namespace UnitTests.Validation.Setup
 
         public static TokenRequestValidator CreateTokenRequestValidator(
             IdentityServerOptions options = null,
+            IIssuerNameService issuerNameService = null,
             IResourceStore resourceStore = null,
             IAuthorizationCodeStore authorizationCodeStore = null,
             IRefreshTokenStore refreshTokenStore = null,
@@ -46,6 +47,11 @@ namespace UnitTests.Validation.Setup
                 options = TestIdentityServerOptions.Create();
             }
 
+            if (issuerNameService == null)
+            {
+                issuerNameService = new TestIssuerNameService(options.IssuerUri);
+            }
+            
             if (resourceStore == null)
             {
                 resourceStore = new InMemoryResourcesStore(TestScopes.GetIdentity(), TestScopes.GetApis(), TestScopes.GetScopes());
@@ -110,6 +116,7 @@ namespace UnitTests.Validation.Setup
 
             return new TokenRequestValidator(
                 options,
+                issuerNameService,
                 authorizationCodeStore,
                 resourceOwnerValidator,
                 profile,
@@ -184,6 +191,7 @@ namespace UnitTests.Validation.Setup
 
         public static AuthorizeRequestValidator CreateAuthorizeRequestValidator(
             IdentityServerOptions options = null,
+            IIssuerNameService issuerNameService = null,
             IResourceStore resourceStore = null,
             IClientStore clients = null,
             IProfileService profile = null,
@@ -196,6 +204,11 @@ namespace UnitTests.Validation.Setup
             if (options == null)
             {
                 options = TestIdentityServerOptions.Create();
+            }
+            
+            if (issuerNameService == null)
+            {
+                issuerNameService = new TestIssuerNameService(options.IssuerUri);
             }
 
             if (resourceStore == null)
@@ -238,6 +251,7 @@ namespace UnitTests.Validation.Setup
 
             return new AuthorizeRequestValidator(
                 options,
+                issuerNameService,
                 clients,
                 customValidator,
                 uriValidator,

--- a/test/IdentityServer.UnitTests/Validation/Setup/Factory.cs
+++ b/test/IdentityServer.UnitTests/Validation/Setup/Factory.cs
@@ -265,33 +265,20 @@ namespace UnitTests.Validation.Setup
         public static TokenValidator CreateTokenValidator(
             IReferenceTokenStore store = null, 
             IRefreshTokenStore refreshTokenStore = null,
-            IProfileService profile = null, 
-            IdentityServerOptions options = null, ISystemClock clock = null)
+            IProfileService profile = null,
+            IIssuerNameService issuerNameService = null,
+            IdentityServerOptions options = null, 
+            ISystemClock clock = null)
         {
-            if (options == null)
-            {
-                options = TestIdentityServerOptions.Create();
-            }
-
-            if (profile == null)
-            {
-                profile = new TestProfileService();
-            }
-
-            if (store == null)
-            {
-                store = CreateReferenceTokenStore();
-            }
-
-            clock = clock ?? new StubClock();
-
-            if (refreshTokenStore == null)
-            {
-                refreshTokenStore = CreateRefreshTokenStore();
-            }
+            options ??= TestIdentityServerOptions.Create();
+            profile ??= new TestProfileService();
+            store ??= CreateReferenceTokenStore();
+            clock ??= new StubClock();
+            refreshTokenStore ??= CreateRefreshTokenStore();
+            issuerNameService ??= new TestIssuerNameService(options.IssuerUri);
 
             var clients = CreateClientStore();
-            var context = new MockHttpContextAccessor(options);
+            
             var logger = TestLogger.Create<TokenValidator>();
 
             var keyInfo = new SecurityKeyInfo
@@ -314,7 +301,7 @@ namespace UnitTests.Validation.Setup
                     ),
                 logger: logger,
                 options: options,
-                context: context);
+                issuerNameService: issuerNameService);
 
             return validator;
         }

--- a/test/IdentityServer.UnitTests/Validation/Setup/TestIssuerNameService.cs
+++ b/test/IdentityServer.UnitTests/Validation/Setup/TestIssuerNameService.cs
@@ -11,7 +11,7 @@ namespace UnitTests.Validation.Setup
     {
         private readonly string _value;
 
-        public TestIssuerNameService(string value)
+        public TestIssuerNameService(string value = null)
         {
             _value = value ?? "https://identityserver";         
         }

--- a/test/IdentityServer.UnitTests/Validation/Setup/TestIssuerNameService.cs
+++ b/test/IdentityServer.UnitTests/Validation/Setup/TestIssuerNameService.cs
@@ -2,22 +2,23 @@
 // See LICENSE in the project root for license information.
 
 
-using System;
+using System.Threading.Tasks;
 using Duende.IdentityServer.Services;
 
 namespace UnitTests.Validation.Setup
 {
     internal class TestIssuerNameService : IIssuerNameService
     {
-        private string _value;
+        private readonly string _value;
 
         public TestIssuerNameService(string value)
         {
             _value = value ?? "https://identityserver";         
         }
-        public string GetCurrent()
+        
+        public Task<string> GetCurrentAsync()
         {
-            return _value;
+            return Task.FromResult(_value);
         }
     }
 }

--- a/test/IdentityServer.UnitTests/Validation/Setup/TestIssuerNameService.cs
+++ b/test/IdentityServer.UnitTests/Validation/Setup/TestIssuerNameService.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+using System;
+using Duende.IdentityServer.Services;
+
+namespace UnitTests.Validation.Setup
+{
+    internal class TestIssuerNameService : IIssuerNameService
+    {
+        private string _value;
+
+        public TestIssuerNameService(string value)
+        {
+            _value = value ?? "https://identityserver";         
+        }
+        public string GetCurrent()
+        {
+            return _value;
+        }
+    }
+}


### PR DESCRIPTION
* Adds the `IIssuerNameService`
* Sets the issuer name for the current request on the `ValidatedRequest` object

This will allow removing direct dependencies on `IHttpContextAccessor` in various places