### PR TITLE
Optimize claims serialization for persisted grants

### DIFF
--- a/src/Storage/Stores/Serialization/ClaimConverter.cs
+++ b/src/Storage/Stores/Serialization/ClaimConverter.cs
@@ -28,6 +28,10 @@ namespace Duende.IdentityServer.Stores.Serialization
                 Value = value.Value,
                 ValueType = value.ValueType
             };
+            if (target.ValueType == ClaimValueTypes.String)
+            {
+                target.ValueType = null;
+            }
 
             JsonSerializer.Serialize(writer, target, options);
         }

--- a/src/Storage/Stores/Serialization/ClaimsPrincipalConverter.cs
+++ b/src/Storage/Stores/Serialization/ClaimsPrincipalConverter.cs
@@ -31,7 +31,15 @@ namespace Duende.IdentityServer.Stores.Serialization
             var target = new ClaimsPrincipalLite
             {
                 AuthenticationType = value.Identity.AuthenticationType,
-                Claims = value.Claims.Select(x => new ClaimLite { Type = x.Type, Value = x.Value, ValueType = x.ValueType }).ToArray()
+                Claims = value.Claims.Select(x =>
+                {
+                    var cl = new ClaimLite { Type = x.Type, Value = x.Value, ValueType = x.ValueType };
+                    if (cl.ValueType == ClaimValueTypes.String)
+                    {
+                        cl.ValueType = null;
+                    }
+                    return cl;
+                }).ToArray()
             };
             JsonSerializer.Serialize(writer, target, options);
         }

--- a/src/Storage/Stores/Serialization/PersistentGrantSerializer.cs
+++ b/src/Storage/Stores/Serialization/PersistentGrantSerializer.cs
@@ -36,7 +36,7 @@ namespace Duende.IdentityServer.Stores.Serialization
             {
                 IgnoreReadOnlyFields = true,
                 IgnoreReadOnlyProperties = true,
-                
+                IgnoreNullValues = true,
             };
             _settings.Converters.Add(new ClaimConverter());
             _settings.Converters.Add(new ClaimsPrincipalConverter());


### PR DESCRIPTION
Do not emit claim value type if it's a string.