### PR TITLE
add feature to cleanup consumed tokens

### DIFF
--- a/hosts/EntityFramework/Startup.cs
+++ b/hosts/EntityFramework/Startup.cs
@@ -38,8 +38,9 @@ namespace IdentityServerHost
                     options.ConfigureDbContext = builder => builder.UseSqlServer(connectionString);
 
                     // this enables automatic token cleanup. this is optional.
-                    options.EnableTokenCleanup = false;
-                    options.TokenCleanupInterval = 60; // interval in seconds
+                    options.EnableTokenCleanup = true;
+                    options.RemoveConsumedTokens = true;
+                    options.TokenCleanupInterval = 10; // interval in seconds
                 });
                 // this is something you will want in production to reduce load on and requests to the DB
                 //.AddConfigurationStoreCache();

--- a/migrations/IdentityServerDb/Migrations/ConfigurationDb.sql
+++ b/migrations/IdentityServerDb/Migrations/ConfigurationDb.sql
@@ -376,7 +376,7 @@ CREATE UNIQUE INDEX [IX_IdentityResources_Name] ON [IdentityResources] ([Name]);
 GO
 
 INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
-VALUES (N'20210113185538_Configuration', N'3.1.0');
+VALUES (N'20210118185536_Configuration', N'3.1.0');
 
 GO
 

--- a/migrations/IdentityServerDb/Migrations/ConfigurationDb/20210118185536_Configuration.Designer.cs
+++ b/migrations/IdentityServerDb/Migrations/ConfigurationDb/20210118185536_Configuration.Designer.cs
@@ -7,10 +7,10 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
-namespace Configuration.Migrations.ConfigurationDb
+namespace IdentityServerDb.Migrations.ConfigurationDb
 {
     [DbContext(typeof(ConfigurationDbContext))]
-    [Migration("20210113185538_Configuration")]
+    [Migration("20210118185536_Configuration")]
     partial class Configuration
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)

--- a/migrations/IdentityServerDb/Migrations/ConfigurationDb/20210118185536_Configuration.cs
+++ b/migrations/IdentityServerDb/Migrations/ConfigurationDb/20210118185536_Configuration.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Microsoft.EntityFrameworkCore.Migrations;
 
-namespace Configuration.Migrations.ConfigurationDb
+namespace IdentityServerDb.Migrations.ConfigurationDb
 {
     public partial class Configuration : Migration
     {

--- a/migrations/IdentityServerDb/Migrations/ConfigurationDb/ConfigurationDbContextModelSnapshot.cs
+++ b/migrations/IdentityServerDb/Migrations/ConfigurationDb/ConfigurationDbContextModelSnapshot.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
-namespace Configuration.Migrations.ConfigurationDb
+namespace IdentityServerDb.Migrations.ConfigurationDb
 {
     [DbContext(typeof(ConfigurationDbContext))]
     partial class ConfigurationDbContextModelSnapshot : ModelSnapshot

--- a/migrations/IdentityServerDb/Migrations/PersistedGrantDb.sql
+++ b/migrations/IdentityServerDb/Migrations/PersistedGrantDb.sql
@@ -66,6 +66,10 @@ CREATE INDEX [IX_Keys_Use] ON [Keys] ([Use]);
 
 GO
 
+CREATE INDEX [IX_PersistedGrants_ConsumedTime] ON [PersistedGrants] ([ConsumedTime]);
+
+GO
+
 CREATE INDEX [IX_PersistedGrants_Expiration] ON [PersistedGrants] ([Expiration]);
 
 GO
@@ -79,7 +83,7 @@ CREATE INDEX [IX_PersistedGrants_SubjectId_SessionId_Type] ON [PersistedGrants] 
 GO
 
 INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
-VALUES (N'20210113185532_Grants', N'3.1.0');
+VALUES (N'20210118185528_Grants', N'3.1.0');
 
 GO
 

--- a/migrations/IdentityServerDb/Migrations/PersistedGrantDb/20210118185528_Grants.Designer.cs
+++ b/migrations/IdentityServerDb/Migrations/PersistedGrantDb/20210118185528_Grants.Designer.cs
@@ -7,10 +7,10 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
-namespace Configuration.Migrations.PersistedGrantDb
+namespace IdentityServerDb.Migrations.PersistedGrantDb
 {
     [DbContext(typeof(PersistedGrantDbContext))]
-    [Migration("20210113185532_Grants")]
+    [Migration("20210118185528_Grants")]
     partial class Grants
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -150,6 +150,8 @@ namespace Configuration.Migrations.PersistedGrantDb
                         .HasMaxLength(50);
 
                     b.HasKey("Key");
+
+                    b.HasIndex("ConsumedTime");
 
                     b.HasIndex("Expiration");
 

--- a/migrations/IdentityServerDb/Migrations/PersistedGrantDb/20210118185528_Grants.cs
+++ b/migrations/IdentityServerDb/Migrations/PersistedGrantDb/20210118185528_Grants.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Microsoft.EntityFrameworkCore.Migrations;
 
-namespace Configuration.Migrations.PersistedGrantDb
+namespace IdentityServerDb.Migrations.PersistedGrantDb
 {
     public partial class Grants : Migration
     {
@@ -79,6 +79,11 @@ namespace Configuration.Migrations.PersistedGrantDb
                 name: "IX_Keys_Use",
                 table: "Keys",
                 column: "Use");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PersistedGrants_ConsumedTime",
+                table: "PersistedGrants",
+                column: "ConsumedTime");
 
             migrationBuilder.CreateIndex(
                 name: "IX_PersistedGrants_Expiration",

--- a/migrations/IdentityServerDb/Migrations/PersistedGrantDb/PersistedGrantDbContextModelSnapshot.cs
+++ b/migrations/IdentityServerDb/Migrations/PersistedGrantDb/PersistedGrantDbContextModelSnapshot.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
-namespace Configuration.Migrations.PersistedGrantDb
+namespace IdentityServerDb.Migrations.PersistedGrantDb
 {
     [DbContext(typeof(PersistedGrantDbContext))]
     partial class PersistedGrantDbContextModelSnapshot : ModelSnapshot
@@ -148,6 +148,8 @@ namespace Configuration.Migrations.PersistedGrantDb
                         .HasMaxLength(50);
 
                     b.HasKey("Key");
+
+                    b.HasIndex("ConsumedTime");
 
                     b.HasIndex("Expiration");
 

--- a/src/EntityFramework.Storage/Extensions/ModelBuilderExtensions.cs
+++ b/src/EntityFramework.Storage/Extensions/ModelBuilderExtensions.cs
@@ -148,6 +148,7 @@ namespace Duende.IdentityServer.EntityFramework.Extensions
                 grant.HasIndex(x => new { x.SubjectId, x.ClientId, x.Type });
                 grant.HasIndex(x => new { x.SubjectId, x.SessionId, x.Type });
                 grant.HasIndex(x => x.Expiration);
+                grant.HasIndex(x => x.ConsumedTime);
             });
 
             modelBuilder.Entity<DeviceFlowCodes>(codes =>

--- a/src/EntityFramework.Storage/Options/OperationalStoreOptions.cs
+++ b/src/EntityFramework.Storage/Options/OperationalStoreOptions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 
@@ -61,6 +61,14 @@ namespace Duende.IdentityServer.EntityFramework.Options
         ///   <c>true</c> if [enable token cleanup]; otherwise, <c>false</c>.
         /// </value>
         public bool EnableTokenCleanup { get; set; } = false;
+        
+        /// <summary>
+        /// Gets or sets a value indicating whether consumed tokens will included in the automatic clean up.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if consumed tokens are to be included in cleanup; otherwise, <c>false</c>.
+        /// </value>
+        public bool RemoveConsumedTokens { get; set; } = false;
 
         /// <summary>
         /// Gets or sets the token cleanup interval (in seconds). The default is 3600 (1 hour).


### PR DESCRIPTION
[Operational Data](https://docs.duendesoftware.com/identityserver/v5/data/operational/) in IdentityServer produces state that is essential to supporting the OIDC and OAuth protocols. Under normal protocol workflows, this state will eventually be marked as [consumed](https://docs.duendesoftware.com/identityserver/v5/data/operational/grants/#grant-expiration-and-consumption), but the record in the store will remain. These records, without intervention, will remain in the store.

When using our [EF integration](https://docs.duendesoftware.com/identityserver/v5/data/ef/) for operational data, an automatic mechanism is provided to cleanup expired records via a [configuration flag](https://docs.duendesoftware.com/identityserver/v5/data/ef/#operationalstoreoptions). This existing feature only removes expired entries, but not consumed entries. Consumed entries would eventually be cleaned up (as they also have an expiration), but once consumed they can be safely removed earlier. The new *RemoveConsumedTokens* flag will enable this more aggressive cleanup for consumed entries.

As part of this update, a new index was added to the EF package (and thus the database). The TSQL version of the index is:

```
CREATE INDEX [IX_PersistedGrants_ConsumedTime] ON [PersistedGrants] ([ConsumedTime]);
```

Original issue: #43