### PR TITLE
Fix misuse DateTimeOffset and UTC in KeyManagement

### DIFF
--- a/src/IdentityServer/Extensions/KeyManagementExtensions.cs
+++ b/src/IdentityServer/Extensions/KeyManagementExtensions.cs
@@ -36,7 +36,7 @@ namespace Duende.IdentityServer.Extensions
 
         internal static TimeSpan GetAge(this ISystemClock clock, DateTime date)
         {
-            var now = clock.UtcNow.DateTime;
+            var now = clock.UtcNow.UtcDateTime;
             if (date > now) now = date;
             return now.Subtract(date);
         }

--- a/src/IdentityServer/Services/Default/DefaultRefreshTokenService.cs
+++ b/src/IdentityServer/Services/Default/DefaultRefreshTokenService.cs
@@ -86,7 +86,7 @@ namespace Duende.IdentityServer.Services
             /////////////////////////////////////////////
             // check if refresh token has expired
             /////////////////////////////////////////////
-            if (refreshToken.CreationTime.HasExceeded(refreshToken.Lifetime, Clock.UtcNow.DateTime))
+            if (refreshToken.CreationTime.HasExceeded(refreshToken.Lifetime, Clock.UtcNow.UtcDateTime))
             {
                 Logger.LogWarning("Refresh token has expired.");
                 return invalidGrant;

--- a/src/IdentityServer/Services/Default/KeyManagement/InMemoryKeyStoreCache.cs
+++ b/src/IdentityServer/Services/Default/KeyManagement/InMemoryKeyStoreCache.cs
@@ -45,7 +45,7 @@ namespace Duende.IdentityServer.Services.KeyManagement
                 keys = _cache;
             }
 
-            if (keys != null && expires >= _clock.UtcNow.DateTime)
+            if (keys != null && expires >= _clock.UtcNow.UtcDateTime)
             {
                 return Task.FromResult(keys);
             }
@@ -63,7 +63,7 @@ namespace Duende.IdentityServer.Services.KeyManagement
         {
             lock (_lock)
             {
-                _expires = _clock.UtcNow.DateTime.Add(duration);
+                _expires = _clock.UtcNow.UtcDateTime.Add(duration);
                 _cache = keys;
             }
 

--- a/src/IdentityServer/Services/Default/KeyManagement/KeyManager.cs
+++ b/src/IdentityServer/Services/Default/KeyManagement/KeyManager.cs
@@ -263,7 +263,7 @@ namespace Duende.IdentityServer.Services.KeyManagement
         {
             _logger.LogDebug("Creating new key.");
 
-            var now = _clock.UtcNow.DateTime;
+            var now = _clock.UtcNow.UtcDateTime;
             var iss = await _issuerNameService.GetCurrentAsync();
 
             KeyContainer container = null;

--- a/test/IdentityServer.UnitTests/Services/Default/KeyManagement/InMemoryKeyStoreCacheTests.cs
+++ b/test/IdentityServer.UnitTests/Services/Default/KeyManagement/InMemoryKeyStoreCacheTests.cs
@@ -23,8 +23,8 @@ namespace UnitTests.Services.Default.KeyManagement
             var now = _mockClock.UtcNow;
 
             var keys = new RsaKeyContainer[] {
-                new RsaKeyContainer() { Created = _mockClock.UtcNow.DateTime.Subtract(TimeSpan.FromMinutes(1)) },
-                new RsaKeyContainer() { Created = _mockClock.UtcNow.DateTime.Subtract(TimeSpan.FromMinutes(2)) },
+                new RsaKeyContainer() { Created = _mockClock.UtcNow.UtcDateTime.Subtract(TimeSpan.FromMinutes(1)) },
+                new RsaKeyContainer() { Created = _mockClock.UtcNow.UtcDateTime.Subtract(TimeSpan.FromMinutes(2)) },
             };
             await _subject.StoreKeysAsync(keys, TimeSpan.FromMinutes(1));
 
@@ -50,8 +50,8 @@ namespace UnitTests.Services.Default.KeyManagement
             var now = _mockClock.UtcNow;
 
             var keys = new RsaKeyContainer[] {
-                new RsaKeyContainer() { Created = _mockClock.UtcNow.DateTime.Subtract(TimeSpan.FromMinutes(1)) },
-                new RsaKeyContainer() { Created = _mockClock.UtcNow.DateTime.Subtract(TimeSpan.FromMinutes(2)) },
+                new RsaKeyContainer() { Created = _mockClock.UtcNow.UtcDateTime.Subtract(TimeSpan.FromMinutes(1)) },
+                new RsaKeyContainer() { Created = _mockClock.UtcNow.UtcDateTime.Subtract(TimeSpan.FromMinutes(2)) },
             };
             await _subject.StoreKeysAsync(keys, TimeSpan.FromMinutes(1));
 

--- a/test/IdentityServer.UnitTests/Services/Default/KeyManagement/KeyManagerTests.cs
+++ b/test/IdentityServer.UnitTests/Services/Default/KeyManagement/KeyManagerTests.cs
@@ -51,7 +51,7 @@ namespace UnitTests.Services.Default.KeyManagement
         {
             var key = _options.CreateRsaSecurityKey();
 
-            var date = _mockClock.UtcNow.DateTime;
+            var date = _mockClock.UtcNow.UtcDateTime;
             if (age.HasValue) date = date.Subtract(age.Value);
 
             var container = x509 ?
@@ -898,7 +898,7 @@ namespace UnitTests.Services.Default.KeyManagement
             _mockKeyProtector.ProtectWasCalled.Should().BeTrue();
             _mockKeyStore.Keys.Count.Should().Be(1);
             _mockKeyStore.Keys.Single().Id.Should().Be(result.Id);
-            result.Created.Should().Be(_mockClock.UtcNow.DateTime);
+            result.Created.Should().Be(_mockClock.UtcNow.UtcDateTime);
             result.Algorithm.Should().Be("RS256");
         }
 


### PR DESCRIPTION
During key management initialization there is an edge case that could cause an unhanded exception with the message "Failed to create and then load new keys.". This could be seen during requests to the discovery and keys endpoint. 

The conditions that would trigger this edge case were when no keys had yet been created, a low rotation interval configured (common when testing), and if the local time zone was after UTC. With typical production settings for the rotation interval, this initialization error would not occur and the normal key management processing would execute properly.

The bug was caused due to an incorrect use of non-UTC DateTimeOffset API, and the fix is to use the correct UTC version of the API.