### PR TITLE
Bug fix for custom redirects from IAuthorizeInteractionResponseGenerator

### DIFF
--- a/src/IdentityServer/Endpoints/Results/CustomRedirectResult.cs
+++ b/src/IdentityServer/Endpoints/Results/CustomRedirectResult.cs
@@ -66,7 +66,7 @@ namespace Duende.IdentityServer.Endpoints.Results
         {
             Init(context);
 
-            var returnUrl = context.GetIdentityServerBasePath().EnsureTrailingSlash() + Constants.ProtocolRoutePaths.Authorize;
+            var returnUrl = context.GetIdentityServerBasePath().EnsureTrailingSlash() + Constants.ProtocolRoutePaths.AuthorizeCallback;
             returnUrl = returnUrl.AddQueryString(_request.Raw.ToQueryString());
 
             if (!_url.IsLocalUrl())


### PR DESCRIPTION
If a custom redirect is returned from the `IAuthorizeInteractionResponseGenerator`'s `ProcessInteractionAsync`, the intent is to allow a custom UI to process the login and possibly the consent workflow. The returnUrl passed to this custom redirect would then allow IdentityServer to complete the workflow, but the wrong returnURl was being used. It would work correctly if the custom redirect simply logged the user in, but if it was also trying to issue any sort of consent response (grant or access denied) then the use of the incorrect callback endpoint was not "looking for" the consent result. This fix changes the return URL to be the same one that the normal login and consent workflows use, thus allowing a custom redirect to work the same.

Fixes #103