### PR TITLE
Added the option for returning the discovery document and JWKS indented

### DIFF
--- a/src/IdentityServer/Configuration/DependencyInjection/Options/DiscoveryOptions.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/Options/DiscoveryOptions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 
@@ -78,5 +78,10 @@ namespace Duende.IdentityServer.Configuration
         /// Adds custom entries to the discovery document
         /// </summary>
         public Dictionary<string, object> CustomEntries { get; set; } = new Dictionary<string, object>();
+
+        /// <summary>
+        /// Should Discovery document return Indented
+        /// </summary>
+        public bool ReturnDiscoveryIndented { get; set; } = false;
     }
 }

--- a/src/IdentityServer/Endpoints/DiscoveryEndpoint.cs
+++ b/src/IdentityServer/Endpoints/DiscoveryEndpoint.cs
@@ -60,7 +60,7 @@ namespace Duende.IdentityServer.Endpoints
             _logger.LogTrace("Calling into discovery response generator: {type}", _responseGenerator.GetType().FullName);
             var response = await _responseGenerator.CreateDiscoveryDocumentAsync(baseUrl, issuerUri);
 
-            return new DiscoveryDocumentResult(response, _options.Discovery.ResponseCacheInterval);
+            return new DiscoveryDocumentResult(response, _options.Discovery.ResponseCacheInterval, _options.Discovery.ReturnDiscoveryIndented);
         }
     }
 }

--- a/src/IdentityServer/Endpoints/DiscoveryKeyEndpoint.cs
+++ b/src/IdentityServer/Endpoints/DiscoveryKeyEndpoint.cs
@@ -53,7 +53,7 @@ namespace Duende.IdentityServer.Endpoints
             _logger.LogTrace("Calling into discovery response generator: {type}", _responseGenerator.GetType().FullName);
             var response = await _responseGenerator.CreateJwkDocumentAsync();
 
-            return new JsonWebKeysResult(response, _options.Discovery.ResponseCacheInterval);
+            return new JsonWebKeysResult(response, _options.Discovery.ResponseCacheInterval, _options.Discovery.ReturnDiscoveryIndented);
         }
     }
 }

--- a/src/IdentityServer/Endpoints/Results/DiscoveryDocumentResult.cs
+++ b/src/IdentityServer/Endpoints/Results/DiscoveryDocumentResult.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 
@@ -34,15 +34,22 @@ namespace Duende.IdentityServer.Endpoints.Results
         public int? MaxAge { get; }
 
         /// <summary>
+        /// Should the result Json be indented 
+        /// </summary>
+        public bool DiscoveryDocumentResultIndented { get; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="DiscoveryDocumentResult" /> class.
         /// </summary>
         /// <param name="entries">The entries.</param>
         /// <param name="maxAge">The maximum age.</param>
+        /// <param name="discoveryDocumentResultIndented">Result Indented or not</param>
         /// <exception cref="System.ArgumentNullException">entries</exception>
-        public DiscoveryDocumentResult(Dictionary<string, object> entries, int? maxAge)
+        public DiscoveryDocumentResult(Dictionary<string, object> entries, int? maxAge, bool discoveryDocumentResultIndented)
         {
             Entries = entries ?? throw new ArgumentNullException(nameof(entries));
             MaxAge = maxAge;
+            DiscoveryDocumentResultIndented = discoveryDocumentResultIndented;
         }
 
         /// <summary>
@@ -57,7 +64,7 @@ namespace Duende.IdentityServer.Endpoints.Results
                 context.Response.SetCache(MaxAge.Value, "Origin");
             }
 
-            return context.Response.WriteJsonAsync(Entries);
+            return context.Response.WriteJsonAsync(Entries,null, serializeIndented:DiscoveryDocumentResultIndented);
         }
     }
 }

--- a/src/IdentityServer/Endpoints/Results/JsonWebKeysResult.cs
+++ b/src/IdentityServer/Endpoints/Results/JsonWebKeysResult.cs
@@ -35,14 +35,21 @@ namespace Duende.IdentityServer.Endpoints.Results
         public int? MaxAge { get; }
 
         /// <summary>
+        /// Should the result Json be indented
+        /// </summary>
+        public bool JsonWebKeyResultIndented { get; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="JsonWebKeysResult" /> class.
         /// </summary>
         /// <param name="webKeys">The web keys.</param>
         /// <param name="maxAge">The maximum age.</param>
-        public JsonWebKeysResult(IEnumerable<JsonWebKey> webKeys, int? maxAge)
+        /// <param name="jsonWebKeysResultIndented">Result Indented or not</param>
+        public JsonWebKeysResult(IEnumerable<JsonWebKey> webKeys, int? maxAge, bool jsonWebKeysResultIndented)
         {
             WebKeys = webKeys ?? throw new ArgumentNullException(nameof(webKeys));
             MaxAge = maxAge;
+            JsonWebKeyResultIndented = jsonWebKeysResultIndented;
         }
 
         /// <summary>
@@ -57,7 +64,7 @@ namespace Duende.IdentityServer.Endpoints.Results
                 context.Response.SetCache(MaxAge.Value, "Origin");
             }
 
-            return context.Response.WriteJsonAsync(new { keys = WebKeys }, "application/json; charset=UTF-8");
+            return context.Response.WriteJsonAsync(new { keys = WebKeys }, "application/json; charset=UTF-8", JsonWebKeyResultIndented);
         }
     }
 }

--- a/src/IdentityServer/Extensions/HttpResponseExtensions.cs
+++ b/src/IdentityServer/Extensions/HttpResponseExtensions.cs
@@ -15,9 +15,9 @@ namespace Duende.IdentityServer.Extensions
 {
     public static class HttpResponseExtensions
     {
-        public static async Task WriteJsonAsync(this HttpResponse response, object o, string contentType = null)
+        public static async Task WriteJsonAsync(this HttpResponse response, object o,  string contentType = null, bool? serializeIndented = null)
         {
-            var json = ObjectSerializer.ToString(o);
+            var json = ObjectSerializer.ToString(o, serializeIndented.GetValueOrDefault(false));
             await response.WriteJsonAsync(json, contentType);
             await response.Body.FlushAsync();
         }

--- a/src/IdentityServer/Infrastructure/ObjectSerializer.cs
+++ b/src/IdentityServer/Infrastructure/ObjectSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 
@@ -12,10 +12,15 @@ namespace Duende.IdentityServer
         {
             IgnoreNullValues = true
         };
-        
-        public static string ToString(object o)
+
+        private static readonly JsonSerializerOptions OptionsIndented = new JsonSerializerOptions
         {
-            return JsonSerializer.Serialize(o, Options);
+            IgnoreNullValues = true,
+            WriteIndented = true
+        };
+        public static string ToString(object o, bool indented = false)
+        {
+            return JsonSerializer.Serialize(o, indented? OptionsIndented : Options);
         }
 
         public static T FromString<T>(string value)


### PR DESCRIPTION
Added the option for returning the discovery document and JWKS json results indented for easy reading 


**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
