### PR TITLE
Preserve user session when same user re-authenticating

### DIFF
--- a/src/IdentityServer/Extensions/AuthenticationPropertiesExtensions.cs
+++ b/src/IdentityServer/Extensions/AuthenticationPropertiesExtensions.cs
@@ -71,6 +71,24 @@ namespace Duende.IdentityServer.Extensions
         }
 
         /// <summary>
+        /// Sets the list of client ids.
+        /// </summary>
+        /// <param name="properties"></param>
+        /// <param name="clientIds"></param>
+        public static void SetClientList(this AuthenticationProperties properties, IEnumerable<string> clientIds)
+        {
+            var value = EncodeList(clientIds);
+            if (value == null)
+            {
+                properties.Items.Remove(ClientListKey);
+            }
+            else
+            {
+                properties.Items[ClientListKey] = value;
+            }
+        }
+
+        /// <summary>
         /// Adds a client to the list of clients the user has signed into during their session.
         /// </summary>
         /// <param name="properties"></param>
@@ -84,16 +102,8 @@ namespace Duende.IdentityServer.Extensions
             {
                 var update = clients.ToList();
                 update.Add(clientId);
-
-                var value = EncodeList(update);
-                if (value == null)
-                {
-                    properties.Items.Remove(ClientListKey);
-                }
-                else
-                {
-                    properties.Items[ClientListKey] = value;
-                }
+                
+                properties.SetClientList(update);
             }
         }
 

--- a/src/IdentityServer/Services/Default/DefaultUserSession.cs
+++ b/src/IdentityServer/Services/Default/DefaultUserSession.cs
@@ -160,9 +160,22 @@ namespace Duende.IdentityServer.Services
             var currentSubjectId = (await GetUserAsync())?.GetSubjectId();
             var newSubjectId = principal.GetSubjectId();
 
-            if (properties.GetSessionId() == null || currentSubjectId != newSubjectId)
+            if (properties.GetSessionId() == null)
             {
-                properties.SetSessionId(CryptoRandom.CreateUniqueId(16, CryptoRandom.OutputFormat.Hex));
+                var currSid = await GetSessionIdAsync();
+                if (newSubjectId == currentSubjectId && currSid != null)
+                {
+                    properties.SetSessionId(currSid);
+                    var clients = Properties.GetClientList();
+                    if (clients.Any())
+                    {
+                        properties.SetClientList(clients);
+                    }
+                }
+                else
+                {
+                    properties.SetSessionId(CryptoRandom.CreateUniqueId(16, CryptoRandom.OutputFormat.Hex));
+                }
             }
 
             var sid = properties.GetSessionId();

--- a/test/IdentityServer.UnitTests/Services/Default/DefaultUserSessionTests.cs
+++ b/test/IdentityServer.UnitTests/Services/Default/DefaultUserSessionTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 
@@ -51,30 +51,30 @@ namespace UnitTests.Services.Default
         }
 
         [Fact]
-        public async Task CreateSessionId_when_user_is_authenticated_should_not_generate_new_sid()
+        public async Task CreateSessionId_should_allow_sid_to_be_indicated_in_properties()
         {
             // this test is needed to allow same session id when cookie is slid
             // IOW, if UI layer passes in same properties dictionary, then we assume it's the same user
 
-            _props.SetSessionId("999");
-            _mockAuthenticationHandler.Result = AuthenticateResult.Success(new AuthenticationTicket(_user, _props, "scheme"));
+            var newProps = new AuthenticationProperties();
+            newProps.SetSessionId("999");
+            await _subject.CreateSessionIdAsync(_user, newProps);
 
-            await _subject.CreateSessionIdAsync(_user, _props);
-
-            _props.GetSessionId().Should().NotBeNull();
-            _props.GetSessionId().Should().Be("999");
+            newProps.GetSessionId().Should().NotBeNull();
+            newProps.GetSessionId().Should().Be("999");
         }
 
         [Fact]
-        public async Task CreateSessionId_when_props_does_not_contain_key_should_generate_new_sid()
+        public async Task CreateSessionId_when_current_props_does_not_contain_key_should_generate_new_sid()
         {
             _mockAuthenticationHandler.Result = AuthenticateResult.Success(new AuthenticationTicket(_user, _props, "scheme"));
 
             _props.GetSessionId().Should().BeNull();
 
-            await _subject.CreateSessionIdAsync(_user, _props);
+            var newProps = new AuthenticationProperties();
+            await _subject.CreateSessionIdAsync(_user, newProps);
 
-            _props.GetSessionId().Should().NotBeNull();
+            newProps.GetSessionId().Should().NotBeNull();
         }
 
         [Fact]
@@ -83,10 +83,24 @@ namespace UnitTests.Services.Default
             _props.SetSessionId("999");
             _mockAuthenticationHandler.Result = AuthenticateResult.Success(new AuthenticationTicket(_user, _props, "scheme"));
 
-            await _subject.CreateSessionIdAsync(new IdentityServerUser("alice").CreatePrincipal(), _props);
+            var newProps = new AuthenticationProperties();
+            await _subject.CreateSessionIdAsync(new IdentityServerUser("alice").CreatePrincipal(), newProps);
 
-            _props.GetSessionId().Should().NotBeNull();
-            _props.GetSessionId().Should().NotBe("999");
+            newProps.GetSessionId().Should().NotBeNull();
+            newProps.GetSessionId().Should().NotBe("999");
+        }
+        
+        [Fact]
+        public async Task CreateSessionId_when_user_is_authenticated_and_same_sub_should_preserve_sid()
+        {
+            _props.SetSessionId("999");
+            _mockAuthenticationHandler.Result = AuthenticateResult.Success(new AuthenticationTicket(_user, _props, "scheme"));
+
+            var newProps = new AuthenticationProperties();
+            await _subject.CreateSessionIdAsync(_user, newProps);
+
+            newProps.GetSessionId().Should().NotBeNull();
+            newProps.GetSessionId().Should().Be("999");
         }
 
         [Fact]


### PR DESCRIPTION
Currently, if a user re-authenticates on the login page then the current `sid` and list of tracked clients (for logout purposes) is overwritten and lost. This change preserves those values.

If there has been any custom code written around setting the `sid` value on the `AuthenticationProperties` when signing in a user in any of your custom login workflows, then it should be tested thoroughly given this change.

Original issue: #45.