### PR TITLE
optimize URLs for JWT request/request URI scenarios

### DIFF
--- a/src/IdentityServer/Endpoints/Results/ConsentPageResult.cs
+++ b/src/IdentityServer/Endpoints/Results/ConsentPageResult.cs
@@ -65,13 +65,13 @@ namespace Duende.IdentityServer.Endpoints.Results
             var returnUrl = context.GetIdentityServerBasePath().EnsureTrailingSlash() + Constants.ProtocolRoutePaths.AuthorizeCallback;
             if (_authorizationParametersMessageStore != null)
             {
-                var msg = new Message<IDictionary<string, string[]>>(_request.Raw.ToFullDictionary());
+                var msg = new Message<IDictionary<string, string[]>>(_request.ToOptimizedFullDictionary());
                 var id = await _authorizationParametersMessageStore.WriteAsync(msg);
                 returnUrl = returnUrl.AddQueryString(Constants.AuthorizationParamsStore.MessageStoreIdParameterName, id);
             }
             else
             {
-                returnUrl = returnUrl.AddQueryString(_request.Raw.ToQueryString());
+                returnUrl = returnUrl.AddQueryString(_request.ToOptimizedQueryString());
             }
 
             var consentUrl = _options.UserInteraction.ConsentUrl;

--- a/src/IdentityServer/Endpoints/Results/CustomRedirectResult.cs
+++ b/src/IdentityServer/Endpoints/Results/CustomRedirectResult.cs
@@ -67,7 +67,7 @@ namespace Duende.IdentityServer.Endpoints.Results
             Init(context);
 
             var returnUrl = context.GetIdentityServerBasePath().EnsureTrailingSlash() + Constants.ProtocolRoutePaths.AuthorizeCallback;
-            returnUrl = returnUrl.AddQueryString(_request.Raw.ToQueryString());
+            returnUrl = returnUrl.AddQueryString(_request.ToOptimizedQueryString());
 
             if (!_url.IsLocalUrl())
             {

--- a/src/IdentityServer/Endpoints/Results/LoginPageResult.cs
+++ b/src/IdentityServer/Endpoints/Results/LoginPageResult.cs
@@ -65,13 +65,13 @@ namespace Duende.IdentityServer.Endpoints.Results
             var returnUrl = context.GetIdentityServerBasePath().EnsureTrailingSlash() + Constants.ProtocolRoutePaths.AuthorizeCallback;
             if (_authorizationParametersMessageStore != null)
             {
-                var msg = new Message<IDictionary<string, string[]>>(_request.Raw.ToFullDictionary());
+                var msg = new Message<IDictionary<string, string[]>>(_request.ToOptimizedFullDictionary());
                 var id = await _authorizationParametersMessageStore.WriteAsync(msg);
                 returnUrl = returnUrl.AddQueryString(Constants.AuthorizationParamsStore.MessageStoreIdParameterName, id);
             }
             else
             {
-                returnUrl = returnUrl.AddQueryString(_request.Raw.ToQueryString());
+                returnUrl = returnUrl.AddQueryString(_request.ToOptimizedQueryString());
             }
 
             var loginUrl = _options.UserInteraction.LoginUrl;

--- a/test/IdentityServer.IntegrationTests/Endpoints/Authorize/JwtRequestAuthorizeTests.cs
+++ b/test/IdentityServer.IntegrationTests/Endpoints/Authorize/JwtRequestAuthorizeTests.cs
@@ -42,7 +42,7 @@ namespace IntegrationTests.Endpoints.Authorize
 
             _rsaKey = CryptoHelper.CreateRsaSecurityKey();
 
-            _mockPipeline.Clients.AddRange(new Client[] 
+            _mockPipeline.Clients.AddRange(new Client[]
             {
                 _client = new Client
                 {
@@ -178,9 +178,9 @@ namespace IntegrationTests.Endpoints.Authorize
             handler.OutboundClaimTypeMap.Clear();
 
             var token = handler.CreateJwtSecurityToken(
-                issuer: issuer, 
-                audience: audience, 
-                signingCredentials: credential, 
+                issuer: issuer,
+                audience: audience,
+                signingCredentials: credential,
                 subject: Identity.Create("pwd", claims));
 
             if (setJwtTyp)
@@ -190,7 +190,7 @@ namespace IntegrationTests.Endpoints.Authorize
 
             return handler.WriteToken(token);
         }
-        
+
         [Fact]
         [Trait("Category", Category)]
         public async Task missing_request_object_should_fail()
@@ -202,7 +202,7 @@ namespace IntegrationTests.Endpoints.Authorize
                 state: "123state",
                 nonce: "123nonce",
                 redirectUri: "https://client/callback");
-            
+
             var response = await _mockPipeline.BrowserClient.GetAsync(url);
 
             _mockPipeline.ErrorMessage.Error.Should().Be("invalid_request");
@@ -353,13 +353,65 @@ namespace IntegrationTests.Endpoints.Authorize
             _mockPipeline.LoginRequest.RequestObjectValues.Single(c => c.Type == "foo" && c.Value == "123foo").Should()
                 .NotBeNull();
         }
-        
+
+        [Fact]
+        [Trait("Category", Category)]
+        public async Task authorize_should_accept_valid_JWT_request_object_and_allow_some_parameters_in_query()
+        {
+            var requestJwt = CreateRequestJwt(
+                issuer: _client.ClientId,
+                audience: IdentityServerPipeline.BaseUrl,
+                credential: new X509SigningCredentials(TestCert.Load()),
+                claims: new[] {
+                    new Claim("client_id", _client.ClientId),
+                    new Claim("response_type", "id_token"),
+                    new Claim("scope", "openid profile"),
+                    new Claim("redirect_uri", "https://client/callback"),
+                    new Claim("acr_values", "acr_1 acr_2 tenant:tenant_value idp:idp_value"),
+                    new Claim("login_hint", "login_hint_value"),
+                    new Claim("display", "popup"),
+                    new Claim("ui_locales", "ui_locale_value"),
+                    new Claim("foo", "123foo"),
+            });
+
+            var url = _mockPipeline.CreateAuthorizeUrl(
+                clientId: _client.ClientId,
+                nonce: "nonce",
+                state: "state",
+                responseType: "id_token",
+                extra: new
+                {
+                    request = requestJwt
+                });
+            var response = await _mockPipeline.BrowserClient.GetAsync(url);
+
+            _mockPipeline.LoginRequest.Should().NotBeNull();
+            _mockPipeline.LoginRequest.Client.ClientId.Should().Be(_client.ClientId);
+            _mockPipeline.LoginRequest.DisplayMode.Should().Be("popup");
+            _mockPipeline.LoginRequest.UiLocales.Should().Be("ui_locale_value");
+            _mockPipeline.LoginRequest.IdP.Should().Be("idp_value");
+            _mockPipeline.LoginRequest.Tenant.Should().Be("tenant_value");
+            _mockPipeline.LoginRequest.LoginHint.Should().Be("login_hint_value");
+            _mockPipeline.LoginRequest.AcrValues.Should().BeEquivalentTo(new string[] { "acr_2", "acr_1" });
+
+            _mockPipeline.LoginRequest.Parameters.AllKeys.Should().Contain("foo");
+            _mockPipeline.LoginRequest.Parameters["foo"].Should().Be("123foo");
+            _mockPipeline.LoginRequest.Parameters["nonce"].Should().Be("nonce");
+            _mockPipeline.LoginRequest.Parameters["state"].Should().Be("state");
+
+            _mockPipeline.LoginRequest.RequestObjectValues.Count().Should().Be(9);
+            _mockPipeline.LoginRequest.RequestObjectValues.Single(c => c.Type == "foo" && c.Value == "123foo").Should()
+                .NotBeNull();
+            _mockPipeline.LoginRequest.RequestObjectValues.SingleOrDefault(c => c.Type == "state").Should().BeNull();
+            _mockPipeline.LoginRequest.RequestObjectValues.SingleOrDefault(c => c.Type == "nonce").Should().BeNull();
+        }
+
         [Fact]
         [Trait("Category", Category)]
         public async Task correct_jwt_typ_should_pass_strict_validation()
         {
             _mockPipeline.Options.StrictJarValidation = true;
-            
+
             var requestJwt = CreateRequestJwt(
                 issuer: _client.ClientId,
                 audience: IdentityServerPipeline.BaseUrl,
@@ -403,13 +455,13 @@ namespace IntegrationTests.Endpoints.Authorize
             _mockPipeline.LoginRequest.RequestObjectValues.Single(c => c.Type == "foo" && c.Value == "123foo").Should()
                 .NotBeNull();
         }
-        
+
         [Fact]
         [Trait("Category", Category)]
         public async Task missing_jwt_typ_should_error()
         {
             _mockPipeline.Options.StrictJarValidation = true;
-            
+
             var requestJwt = CreateRequestJwt(
                 issuer: _client.ClientId,
                 audience: IdentityServerPipeline.BaseUrl,
@@ -440,7 +492,7 @@ namespace IntegrationTests.Endpoints.Authorize
             _mockPipeline.ErrorMessage.Error.Should().Be("invalid_request_object");
             _mockPipeline.LoginRequest.Should().BeNull();
         }
-        
+
         [Fact]
         [Trait("Category", Category)]
         public async Task authorize_should_accept_complex_objects_in_request_object()
@@ -486,11 +538,11 @@ namespace IntegrationTests.Endpoints.Authorize
             var value = _mockPipeline.LoginRequest.Parameters["someObj"];
             var someObj2 = JsonSerializer.Deserialize(value, someObj.GetType());
             someObj.Should().BeEquivalentTo(someObj2);
-            
+
             _mockPipeline.LoginRequest.Parameters["someArr"].Should().NotBeNull();
             var arrValue = _mockPipeline.LoginRequest.Parameters.GetValues("someArr");
             arrValue.Length.Should().Be(3);
-            
+
             _mockPipeline.LoginRequest.RequestObjectValues.Count().Should().Be(15);
             value = _mockPipeline.LoginRequest.RequestObjectValues.Single(c => c.Type == "someObj").Value;
             someObj2 = JsonSerializer.Deserialize(value, someObj.GetType());
@@ -533,7 +585,7 @@ namespace IntegrationTests.Endpoints.Authorize
             _mockPipeline.ErrorMessage.ErrorDescription.Should().Be("Invalid client_id");
             _mockPipeline.LoginRequest.Should().BeNull();
         }
-        
+
         [Fact]
         [Trait("Category", Category)]
         public async Task authorize_should_reject_jwt_request_without_client_id_in_jwt()
@@ -789,7 +841,7 @@ namespace IntegrationTests.Endpoints.Authorize
             _mockPipeline.ErrorMessage.ErrorDescription.Should().Be("Invalid JWT request");
             _mockPipeline.LoginRequest.Should().BeNull();
         }
-        
+
         [Fact]
         [Trait("Category", Category)]
         public async Task authorize_should_ignore_request_uri_when_feature_is_disabled()
@@ -890,7 +942,68 @@ namespace IntegrationTests.Endpoints.Authorize
 
             _mockPipeline.JwtRequestMessageHandler.InvokeWasCalled.Should().BeTrue();
         }
-        
+
+        [Fact]
+        [Trait("Category", Category)]
+        public async Task authorize_should_accept_request_uri_and_allow_some_parameters_in_query()
+        {
+            _mockPipeline.Options.Endpoints.EnableJwtRequestUri = true;
+
+            var requestJwt = CreateRequestJwt(
+                issuer: _client.ClientId,
+                audience: IdentityServerPipeline.BaseUrl,
+                credential: new X509SigningCredentials(TestCert.Load()),
+                claims: new[] {
+                    new Claim("client_id", _client.ClientId),
+                    new Claim("response_type", "id_token"),
+                    new Claim("scope", "openid profile"),
+                    new Claim("redirect_uri", "https://client/callback"),
+                    new Claim("acr_values", "acr_1 acr_2 tenant:tenant_value idp:idp_value"),
+                    new Claim("login_hint", "login_hint_value"),
+                    new Claim("display", "popup"),
+                    new Claim("ui_locales", "ui_locale_value"),
+                    new Claim("foo", "123foo"),
+                    new Claim("bar", "bar1"),
+                    new Claim("bar", "bar2"),
+            });
+            _mockPipeline.JwtRequestMessageHandler.OnInvoke = req =>
+            {
+                req.RequestUri.Should().Be(new Uri("http://client_jwt"));
+                return Task.CompletedTask;
+            };
+            _mockPipeline.JwtRequestMessageHandler.Response.Content = new StringContent(requestJwt);
+
+
+            var url = _mockPipeline.CreateAuthorizeUrl(
+                clientId: _client.ClientId,
+                state: "state",
+                nonce: "nonce",
+                responseType: "id_token",
+                extra: new
+                {
+                    request_uri = "http://client_jwt"
+                });
+            var response = await _mockPipeline.BrowserClient.GetAsync(url);
+
+            _mockPipeline.LoginRequest.Should().NotBeNull();
+            _mockPipeline.LoginRequest.Client.ClientId.Should().Be(_client.ClientId);
+            _mockPipeline.LoginRequest.DisplayMode.Should().Be("popup");
+            _mockPipeline.LoginRequest.UiLocales.Should().Be("ui_locale_value");
+            _mockPipeline.LoginRequest.IdP.Should().Be("idp_value");
+            _mockPipeline.LoginRequest.Tenant.Should().Be("tenant_value");
+            _mockPipeline.LoginRequest.LoginHint.Should().Be("login_hint_value");
+            _mockPipeline.LoginRequest.AcrValues.Should().BeEquivalentTo(new string[] { "acr_2", "acr_1" });
+            _mockPipeline.LoginRequest.Parameters.AllKeys.Should().Contain("foo");
+            _mockPipeline.LoginRequest.Parameters["foo"].Should().Be("123foo");
+            _mockPipeline.LoginRequest.Parameters["nonce"].Should().Be("nonce");
+            _mockPipeline.LoginRequest.Parameters["state"].Should().Be("state");
+            _mockPipeline.LoginRequest.RequestObjectValues.Count().Should().Be(11);
+            _mockPipeline.LoginRequest.RequestObjectValues.Any(x => x.Type == "state").Should().BeFalse();
+            _mockPipeline.LoginRequest.RequestObjectValues.Any(x => x.Type == "nonce").Should().BeFalse();
+
+            _mockPipeline.JwtRequestMessageHandler.InvokeWasCalled.Should().BeTrue();
+        }
+
         [Fact]
         [Trait("Category", Category)]
         public async Task authorize_should_accept_request_uri_with_valid_jwt_and_strict_validation()
@@ -946,7 +1059,7 @@ namespace IntegrationTests.Endpoints.Authorize
 
             _mockPipeline.JwtRequestMessageHandler.InvokeWasCalled.Should().BeTrue();
         }
-        
+
         [Fact]
         [Trait("Category", Category)]
         public async Task authorize_should_reject_request_uri_with_valid_jwt_and_strict_validation_but_invalid_content_type()
@@ -977,8 +1090,8 @@ namespace IntegrationTests.Endpoints.Authorize
                 return Task.CompletedTask;
             };
             _mockPipeline.JwtRequestMessageHandler.Response.Content = new StringContent(requestJwt);
-            
-            
+
+
             var url = _mockPipeline.CreateAuthorizeUrl(
                 clientId: _client.ClientId,
                 responseType: "id_token",
@@ -992,7 +1105,7 @@ namespace IntegrationTests.Endpoints.Authorize
             _mockPipeline.LoginRequest.Should().BeNull();
             _mockPipeline.JwtRequestMessageHandler.InvokeWasCalled.Should().BeTrue();
         }
-        
+
         [Fact]
         [Trait("Category", Category)]
         public async Task request_uri_response_returns_500_should_fail()
@@ -1114,8 +1227,6 @@ namespace IntegrationTests.Endpoints.Authorize
                     new Claim("client_id", _client.ClientId),
                     new Claim("response_type", "id_token"),
                     new Claim("scope", "openid profile"),
-                    new Claim("state", "123state"),
-                    new Claim("nonce", "123nonce"),
                     new Claim("redirect_uri", "https://client/callback"),
                     new Claim("prompt", "login"),
             });
@@ -1123,6 +1234,8 @@ namespace IntegrationTests.Endpoints.Authorize
             var url = _mockPipeline.CreateAuthorizeUrl(
                 clientId: _client.ClientId,
                 responseType: "id_token",
+                state: "state123",
+                nonce: "nonce123",
                 extra: new
                 {
                     request = requestJwt
@@ -1135,6 +1248,7 @@ namespace IntegrationTests.Endpoints.Authorize
             response.StatusCode.Should().Be(HttpStatusCode.Redirect);
             response.Headers.Location.ToString().Should().StartWith("https://client/callback");
             response.Headers.Location.ToString().Should().Contain("id_token=");
+            response.Headers.Location.ToString().Should().Contain("state=state123");
         }
     }
 }

--- a/test/IdentityServer.IntegrationTests/Endpoints/Authorize/JwtRequestAuthorizeTests.cs
+++ b/test/IdentityServer.IntegrationTests/Endpoints/Authorize/JwtRequestAuthorizeTests.cs
@@ -16,10 +16,13 @@ using System.Threading.Tasks;
 using Duende.IdentityServer;
 using Duende.IdentityServer.Configuration;
 using Duende.IdentityServer.Models;
+using Duende.IdentityServer.Stores;
+using Duende.IdentityServer.Stores.Default;
 using Duende.IdentityServer.Test;
 using FluentAssertions;
 using IdentityModel;
 using IntegrationTests.Common;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Logging;
 using Microsoft.IdentityModel.Tokens;
 using Xunit;
@@ -354,10 +357,22 @@ namespace IntegrationTests.Endpoints.Authorize
                 .NotBeNull();
         }
 
-        [Fact]
+        [Theory]
+        [InlineData((Type) null)]
+        [InlineData(typeof(QueryStringAuthorizationParametersMessageStore))]
+        [InlineData(typeof(DistributedCacheAuthorizationParametersMessageStore))]
         [Trait("Category", Category)]
-        public async Task authorize_should_accept_valid_JWT_request_object_and_allow_some_parameters_in_query()
+        public async Task authorize_should_accept_valid_JWT_request_object_and_allow_some_parameters_in_query(Type storeType)
         {
+            if (storeType != null)
+            {
+                _mockPipeline.OnPostConfigureServices += services =>
+                {
+                    services.AddTransient(typeof(IAuthorizationParametersMessageStore), storeType);
+                };
+                _mockPipeline.Initialize();
+            }
+            
             var requestJwt = CreateRequestJwt(
                 issuer: _client.ClientId,
                 audience: IdentityServerPipeline.BaseUrl,
@@ -943,10 +958,22 @@ namespace IntegrationTests.Endpoints.Authorize
             _mockPipeline.JwtRequestMessageHandler.InvokeWasCalled.Should().BeTrue();
         }
 
-        [Fact]
+        [Theory]
+        [InlineData((Type) null)]
+        [InlineData(typeof(QueryStringAuthorizationParametersMessageStore))]
+        [InlineData(typeof(DistributedCacheAuthorizationParametersMessageStore))]
         [Trait("Category", Category)]
-        public async Task authorize_should_accept_request_uri_and_allow_some_parameters_in_query()
+        public async Task authorize_should_accept_request_uri_and_allow_some_parameters_in_query(Type storeType)
         {
+            if (storeType != null)
+            {
+                _mockPipeline.OnPostConfigureServices += services =>
+                {
+                    services.AddTransient(typeof(IAuthorizationParametersMessageStore), storeType);
+                };
+                _mockPipeline.Initialize();
+            }
+
             _mockPipeline.Options.Endpoints.EnableJwtRequestUri = true;
 
             var requestJwt = CreateRequestJwt(
@@ -1213,10 +1240,22 @@ namespace IntegrationTests.Endpoints.Authorize
             _mockPipeline.JwtRequestMessageHandler.InvokeWasCalled.Should().BeFalse();
         }
 
-        [Fact]
+        [Theory]
+        [InlineData((Type) null)]
+        [InlineData(typeof(QueryStringAuthorizationParametersMessageStore))]
+        [InlineData(typeof(DistributedCacheAuthorizationParametersMessageStore))]
         [Trait("Category", Category)]
-        public async Task prompt_login_should_allow_user_to_login_and_complete_authorization()
+        public async Task prompt_login_should_allow_user_to_login_and_complete_authorization(Type storeType)
         {
+            if (storeType != null)
+            {
+                _mockPipeline.OnPostConfigureServices += services =>
+                {
+                    services.AddTransient(typeof(IAuthorizationParametersMessageStore), storeType);
+                };
+                _mockPipeline.Initialize();
+            }
+            
             await _mockPipeline.LoginAsync("bob");
 
             var requestJwt = CreateRequestJwt(


### PR DESCRIPTION
When a JWT request or request URI is used to pass authorize request parameters, internally (after validation of the JWT) we merge those values into the data structure that holds the original query params. When we redirect to any UI page (e.g. the login page) we then create the `returnUrl` to return back to the authorize endpoint from that internal data structure. This ends up with the `request` parameter (which is a sizable JWT) and then all the contents of the JWT as redundant parameters in the `returnUrl`.

This fix optimizes this process by omitting those redundant JWT request object query values in the `returnUrl`.

Original issue: #128 