### PR TITLE
Fix CustomRedirectResult to use IAuthorizationParametersMessageStore if registered

### DIFF
--- a/src/IdentityServer/Endpoints/Results/CustomRedirectResult.cs
+++ b/src/IdentityServer/Endpoints/Results/CustomRedirectResult.cs
@@ -10,6 +10,9 @@ using Duende.IdentityServer.Validation;
 using Microsoft.AspNetCore.Http;
 using Duende.IdentityServer.Extensions;
 using Microsoft.Extensions.DependencyInjection;
+using Duende.IdentityServer.Stores;
+using Duende.IdentityServer.Models;
+using System.Collections.Generic;
 
 namespace Duende.IdentityServer.Endpoints.Results
 {
@@ -44,17 +47,21 @@ namespace Duende.IdentityServer.Endpoints.Results
         internal CustomRedirectResult(
             ValidatedAuthorizeRequest request,
             string url,
-            IdentityServerOptions options) 
+            IdentityServerOptions options,
+            IAuthorizationParametersMessageStore authorizationParametersMessageStore = null) 
             : this(request, url)
         {
             _options = options;
+            _authorizationParametersMessageStore = authorizationParametersMessageStore;
         }
 
         private IdentityServerOptions _options;
+        private IAuthorizationParametersMessageStore _authorizationParametersMessageStore;
 
         private void Init(HttpContext context)
         {
             _options = _options ?? context.RequestServices.GetRequiredService<IdentityServerOptions>();
+            _authorizationParametersMessageStore = _authorizationParametersMessageStore ?? context.RequestServices.GetService<IAuthorizationParametersMessageStore>();
         }
 
         /// <summary>
@@ -62,12 +69,22 @@ namespace Duende.IdentityServer.Endpoints.Results
         /// </summary>
         /// <param name="context">The HTTP context.</param>
         /// <returns></returns>
-        public Task ExecuteAsync(HttpContext context)
+        public async Task ExecuteAsync(HttpContext context)
         {
             Init(context);
 
             var returnUrl = context.GetIdentityServerBasePath().EnsureTrailingSlash() + Constants.ProtocolRoutePaths.AuthorizeCallback;
-            returnUrl = returnUrl.AddQueryString(_request.ToOptimizedQueryString());
+
+            if (_authorizationParametersMessageStore != null)
+            {
+                var msg = new Message<IDictionary<string, string[]>>(_request.ToOptimizedFullDictionary());
+                var id = await _authorizationParametersMessageStore.WriteAsync(msg);
+                returnUrl = returnUrl.AddQueryString(Constants.AuthorizationParamsStore.MessageStoreIdParameterName, id);
+            }
+            else
+            {
+                returnUrl = returnUrl.AddQueryString(_request.ToOptimizedQueryString());
+            }
 
             if (!_url.IsLocalUrl())
             {
@@ -78,8 +95,6 @@ namespace Duende.IdentityServer.Endpoints.Results
 
             var url = _url.AddQueryString(_options.UserInteraction.CustomRedirectReturnUrlParameter, returnUrl);
             context.Response.RedirectToAbsoluteUrl(url);
-
-            return Task.CompletedTask;
         }
     }
 }

--- a/test/IdentityServer.IntegrationTests/Common/IdentityServerPipeline.cs
+++ b/test/IdentityServer.IntegrationTests/Common/IdentityServerPipeline.cs
@@ -177,6 +177,10 @@ namespace IntegrationTests.Common
             {
                 path.Run(ctx => OnConsent(ctx));
             });
+            app.Map("/custom", path =>
+            {
+                path.Run(ctx => OnCustom(ctx));
+            });
             app.Map(Constants.UIConstants.DefaultRoutePaths.Error.EnsureLeadingSlash(), path =>
             {
                 path.Run(ctx => OnError(ctx));
@@ -245,13 +249,11 @@ namespace IntegrationTests.Common
             await ReadConsentMessage(ctx);
             await CreateConsentResponse(ctx);
         }
-
         private async Task ReadConsentMessage(HttpContext ctx)
         {
             var interaction = ctx.RequestServices.GetRequiredService<IIdentityServerInteractionService>();
             ConsentRequest = await interaction.GetAuthorizationContextAsync(ctx.Request.Query["returnUrl"].FirstOrDefault());
         }
-
         private async Task CreateConsentResponse(HttpContext ctx)
         {
             if (ConsentRequest != null && ConsentResponse != null)
@@ -266,6 +268,16 @@ namespace IntegrationTests.Common
                     ctx.Response.Redirect(url);
                 }
             }
+        }
+
+        public bool CustomWasCalled { get; set; }
+        public AuthorizationRequest CustomRequest { get; set; }
+
+        private async Task OnCustom(HttpContext ctx)
+        {
+            CustomWasCalled = true;
+            var interaction = ctx.RequestServices.GetRequiredService<IIdentityServerInteractionService>();
+            CustomRequest = await interaction.GetAuthorizationContextAsync(ctx.Request.Query[Options.UserInteraction.ConsentReturnUrlParameter].FirstOrDefault());
         }
 
         public bool ErrorWasCalled { get; set; }


### PR DESCRIPTION
If a custom redirect is triggered from the authorize endpoint interaction response generator, and if a custom authorize parameter message store is registered, it will not be used. This fix changes it so that a custom redirect will use the store if registered in the same way the login and consent workflows do.

Original issue: #137