### PR TITLE
Fix GetAuthorizationContextAsync to return multiple query values from returnUrl

### DIFF
--- a/src/IdentityServer/Extensions/IReadableStringCollectionExtensions.cs
+++ b/src/IdentityServer/Extensions/IReadableStringCollectionExtensions.cs
@@ -37,7 +37,10 @@ namespace Duende.IdentityServer.Extensions
 
             foreach (var field in collection)
             {
-                nv.Add(field.Key, field.Value.First());
+                foreach (var item in field.Value)
+                {
+                    nv.Add(field.Key, item);
+                }
             }
 
             return nv;

--- a/test/IdentityServer.IntegrationTests/Endpoints/Authorize/AuthorizeTests.cs
+++ b/test/IdentityServer.IntegrationTests/Endpoints/Authorize/AuthorizeTests.cs
@@ -202,7 +202,7 @@ namespace IntegrationTests.Endpoints.Authorize
                     ui_locales = "ui_locale_value",
                     custom_foo = "foo_value"
                 });
-            var response = await _mockPipeline.BrowserClient.GetAsync(url + "&foo=bar");
+            var response = await _mockPipeline.BrowserClient.GetAsync(url + "&foo=foo1&foo=foo2");
 
             _mockPipeline.LoginRequest.Should().NotBeNull();
             _mockPipeline.LoginRequest.Client.ClientId.Should().Be("client1");
@@ -213,7 +213,7 @@ namespace IntegrationTests.Endpoints.Authorize
             _mockPipeline.LoginRequest.LoginHint.Should().Be("login_hint_value");
             _mockPipeline.LoginRequest.AcrValues.Should().BeEquivalentTo(new string[] { "acr_2", "acr_1" });
             _mockPipeline.LoginRequest.Parameters.AllKeys.Should().Contain("foo");
-            _mockPipeline.LoginRequest.Parameters["foo"].Should().Be("bar");
+            _mockPipeline.LoginRequest.Parameters.GetValues("foo").Should().BeEquivalentTo(new[] { "foo1", "foo2" });
         }
 
         [Fact]


### PR DESCRIPTION
Currently `GetAuthorizationContextAsync` does not return multiple query values from returnUrl. For example, if the returnUrl (which is the original authorize request URL) contains multiple `resource` parameters and is passed to `GetAuthorizationContextAsync`, then the resultant `Parameters` will only contain one `resource` value.

This change fixes it so that all query values are returned. The `GetValues` API on the `NameValueCollection` should be used to access the query params when multiple values are possible.

Fixes: #141