### PR TITLE
use SetClient rather than setting Client property directly in end session validator

### DIFF
--- a/src/IdentityServer/Validation/Default/EndSessionRequestValidator.cs
+++ b/src/IdentityServer/Validation/Default/EndSessionRequestValidator.cs
@@ -122,7 +122,7 @@ namespace Duende.IdentityServer.Validation
                     return Invalid("Error validating id token hint", validatedRequest);
                 }
 
-                validatedRequest.Client = tokenValidationResult.Client;
+                validatedRequest.SetClient(tokenValidationResult.Client);
 
                 // validate sub claim against currently logged on user
                 var subClaim = tokenValidationResult.Claims.FirstOrDefault(c => c.Type == JwtClaimTypes.Subject);


### PR DESCRIPTION
`SetClient` copies over additional properties, so this is better so as to be consistent.

Fixes: #185