### PR TITLE
add support for user tenant check in authorize interaction response generator against acr tenant value

### DIFF
--- a/src/IdentityServer/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
@@ -55,6 +55,11 @@ namespace Duende.IdentityServer.Configuration
         public bool StrictJarValidation { get; set; } = false;
 
         /// <summary>
+        /// Specifies if a user's tenant claim is compared to the tenant acr_values parameter value to determine if the login page is displayed. Defaults to false.
+        /// </summary>
+        public bool ValidateTenantOnAuthorization { get; set; } = false;
+
+        /// <summary>
         /// Gets or sets the endpoint configuration.
         /// </summary>
         /// <value>

--- a/src/IdentityServer/Extensions/PrincipalExtensions.cs
+++ b/src/IdentityServer/Extensions/PrincipalExtensions.cs
@@ -205,6 +205,17 @@ namespace Duende.IdentityServer.Extensions
         }
 
         /// <summary>
+        /// Gets the tenant.
+        /// </summary>
+        /// <param name="principal">The principal.</param>
+        /// <returns></returns>
+        [DebuggerStepThrough]
+        public static string GetTenant(this ClaimsPrincipal principal)
+        {
+            return principal.FindFirst(IdentityServerConstants.ClaimTypes.Tenant)?.Value;
+        }
+        
+        /// <summary>
         /// Determines whether this instance is authenticated.
         /// </summary>
         /// <param name="principal">The principal.</param>

--- a/src/IdentityServer/IdentityServerConstants.cs
+++ b/src/IdentityServer/IdentityServerConstants.cs
@@ -165,5 +165,10 @@ namespace Duende.IdentityServer
             public const string JwtRequestUriHttpClient = "IdentityServer:JwtRequestUriClient";
             public const string BackChannelLogoutHttpClient = "IdentityServer:BackChannelLogoutClient";
         }
+
+        public static class ClaimTypes
+        {
+            public const string Tenant = "tenant";
+        }
     }
 }

--- a/src/IdentityServer/IdentityServerUser.cs
+++ b/src/IdentityServer/IdentityServerUser.cs
@@ -32,6 +32,11 @@ namespace Duende.IdentityServer
         public string IdentityProvider { get; set; }
 
         /// <summary>
+        /// Tenant (optional)
+        /// </summary>
+        public string Tenant { get; set; }
+
+        /// <summary>
         /// Authentication methods
         /// </summary>
         public ICollection<string> AuthenticationMethods { get; set; } = new HashSet<string>();
@@ -75,6 +80,11 @@ namespace Duende.IdentityServer
             if (IdentityProvider.IsPresent())
             {
                 claims.Add(new Claim(JwtClaimTypes.IdentityProvider, IdentityProvider));
+            }
+            
+            if (Tenant.IsPresent())
+            {
+                claims.Add(new Claim(IdentityServerConstants.ClaimTypes.Tenant, Tenant));
             }
 
             if (AuthenticationTime.HasValue)

--- a/src/IdentityServer/ResponseHandling/Default/AuthorizeInteractionResponseGenerator.cs
+++ b/src/IdentityServer/ResponseHandling/Default/AuthorizeInteractionResponseGenerator.cs
@@ -160,6 +160,18 @@ namespace Duende.IdentityServer.ResponseHandling
                 return new InteractionResponse { IsLogin = true };
             }
 
+            // check if tenant hint matches current tenant
+            var tenant = request.GetTenant();
+            if (tenant.IsPresent())
+            {
+                var currentTenant = request.Subject.GetTenant();
+                if (tenant != currentTenant)
+                {
+                    Logger.LogInformation("Showing login: Current tenant ({currentTenant}) is not the requested tenant ({tenant})", currentTenant, tenant);
+                    return new InteractionResponse { IsLogin = true };
+                }
+            }
+
             // check current idp
             var currentIdp = request.Subject.GetIdentityProvider();
 

--- a/src/IdentityServer/ResponseHandling/Default/AuthorizeInteractionResponseGenerator.cs
+++ b/src/IdentityServer/ResponseHandling/Default/AuthorizeInteractionResponseGenerator.cs
@@ -12,6 +12,7 @@ using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services;
 using Duende.IdentityServer.Validation;
 using Microsoft.AspNetCore.Authentication;
+using Duende.IdentityServer.Configuration;
 
 namespace Duende.IdentityServer.ResponseHandling
 {
@@ -40,20 +41,28 @@ namespace Duende.IdentityServer.ResponseHandling
         /// The clock
         /// </summary>
         protected readonly ISystemClock Clock;
+        
+        /// <summary>
+        /// The options
+        /// </summary>
+        protected readonly IdentityServerOptions Options;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AuthorizeInteractionResponseGenerator"/> class.
         /// </summary>
+        /// <param name="options"></param>
         /// <param name="clock">The clock.</param>
         /// <param name="logger">The logger.</param>
         /// <param name="consent">The consent.</param>
         /// <param name="profile">The profile.</param>
         public AuthorizeInteractionResponseGenerator(
+            IdentityServerOptions options,
             ISystemClock clock,
             ILogger<AuthorizeInteractionResponseGenerator> logger,
             IConsentService consent, 
             IProfileService profile)
         {
+            Options = options;
             Clock = clock;
             Logger = logger;
             Consent = consent;
@@ -161,14 +170,17 @@ namespace Duende.IdentityServer.ResponseHandling
             }
 
             // check if tenant hint matches current tenant
-            var tenant = request.GetTenant();
-            if (tenant.IsPresent())
+            if (Options.ValidateTenantOnAuthorization)
             {
-                var currentTenant = request.Subject.GetTenant();
-                if (tenant != currentTenant)
+                var tenant = request.GetTenant();
+                if (tenant.IsPresent())
                 {
-                    Logger.LogInformation("Showing login: Current tenant ({currentTenant}) is not the requested tenant ({tenant})", currentTenant, tenant);
-                    return new InteractionResponse { IsLogin = true };
+                    var currentTenant = request.Subject.GetTenant();
+                    if (tenant != currentTenant)
+                    {
+                        Logger.LogInformation("Showing login: Current tenant ({currentTenant}) is not the requested tenant ({tenant})", currentTenant, tenant);
+                        return new InteractionResponse { IsLogin = true };
+                    }
                 }
             }
 

--- a/test/IdentityServer.IntegrationTests/Endpoints/Authorize/AuthorizeTests.cs
+++ b/test/IdentityServer.IntegrationTests/Endpoints/Authorize/AuthorizeTests.cs
@@ -400,6 +400,48 @@ namespace IntegrationTests.Endpoints.Authorize
 
         [Fact]
         [Trait("Category", Category)]
+        public async Task user_idp_does_not_match_acr_idp_should_cause_login_page()
+        {
+            var user = new IdentityServerUser("bob") { IdentityProvider = "idp1" };
+            await _mockPipeline.LoginAsync(user.CreatePrincipal());
+
+            var url = _mockPipeline.CreateAuthorizeUrl(
+                clientId: "client1",
+                responseType: "id_token",
+                scope: "openid profile",
+                redirectUri: "https://client1/callback",
+                state: "123_state",
+                nonce: "123_nonce",
+                acrValues: "idp:idp2");
+            var response = await _mockPipeline.BrowserClient.GetAsync(url);
+
+            _mockPipeline.LoginWasCalled.Should().BeTrue();
+            _mockPipeline.LoginRequest.IdP.Should().Be("idp2");
+        }
+        
+        [Fact]
+        [Trait("Category", Category)]
+        public async Task user_tenant_does_not_match_acr_tenant_should_cause_login_page()
+        {
+            var user = new IdentityServerUser("bob") { Tenant = "t1" };
+            await _mockPipeline.LoginAsync(user.CreatePrincipal());
+
+            var url = _mockPipeline.CreateAuthorizeUrl(
+                clientId: "client1",
+                responseType: "id_token",
+                scope: "openid profile",
+                redirectUri: "https://client1/callback",
+                state: "123_state",
+                nonce: "123_nonce",
+                acrValues: "tenant:t2");
+            var response = await _mockPipeline.BrowserClient.GetAsync(url);
+
+            _mockPipeline.LoginWasCalled.Should().BeTrue();
+            _mockPipeline.LoginRequest.Tenant.Should().Be("t2");
+        }
+
+        [Fact]
+        [Trait("Category", Category)]
         public async Task for_invalid_client_error_page_should_not_receive_client_id()
         {
             await _mockPipeline.LoginAsync("bob");

--- a/test/IdentityServer.IntegrationTests/Endpoints/Authorize/ConsentTests.cs
+++ b/test/IdentityServer.IntegrationTests/Endpoints/Authorize/ConsentTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using Duende.IdentityServer;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Stores;
 using Duende.IdentityServer.Stores.Default;
@@ -132,7 +133,8 @@ namespace IntegrationTests.Endpoints.Authorize
                 _mockPipeline.Initialize();
             }
 
-            await _mockPipeline.LoginAsync("bob");
+            var user = new IdentityServerUser("bob") { Tenant = "tenant_value" };
+            await _mockPipeline.LoginAsync(user.CreatePrincipal());
 
             var url = _mockPipeline.CreateAuthorizeUrl(
                 clientId: "client2",

--- a/test/IdentityServer.UnitTests/ResponseHandling/AuthorizeInteractionResponseGenerator/AuthorizeInteractionResponseGeneratorTests.cs
+++ b/test/IdentityServer.UnitTests/ResponseHandling/AuthorizeInteractionResponseGenerator/AuthorizeInteractionResponseGeneratorTests.cs
@@ -26,6 +26,7 @@ namespace UnitTests.ResponseHandling.AuthorizeInteractionResponseGenerator
         public AuthorizeInteractionResponseGeneratorTests()
         {
             _subject = new Duende.IdentityServer.ResponseHandling.AuthorizeInteractionResponseGenerator(
+                _options,
                 _clock,
                 TestLogger.Create<Duende.IdentityServer.ResponseHandling.AuthorizeInteractionResponseGenerator>(),
                 _mockConsentService,

--- a/test/IdentityServer.UnitTests/ResponseHandling/AuthorizeInteractionResponseGenerator/AuthorizeInteractionResponseGeneratorTests_Consent.cs
+++ b/test/IdentityServer.UnitTests/ResponseHandling/AuthorizeInteractionResponseGenerator/AuthorizeInteractionResponseGeneratorTests_Consent.cs
@@ -93,6 +93,7 @@ namespace UnitTests.ResponseHandling.AuthorizeInteractionResponseGenerator
         public AuthorizeInteractionResponseGeneratorTests_Consent()
         {
             _subject = new Duende.IdentityServer.ResponseHandling.AuthorizeInteractionResponseGenerator(
+                _options,
                 new StubClock(),
                 TestLogger.Create<Duende.IdentityServer.ResponseHandling.AuthorizeInteractionResponseGenerator>(),
                 _mockConsent,

--- a/test/IdentityServer.UnitTests/ResponseHandling/AuthorizeInteractionResponseGenerator/AuthorizeInteractionResponseGeneratorTests_Custom.cs
+++ b/test/IdentityServer.UnitTests/ResponseHandling/AuthorizeInteractionResponseGenerator/AuthorizeInteractionResponseGeneratorTests_Custom.cs
@@ -20,7 +20,12 @@ namespace UnitTests.ResponseHandling.AuthorizeInteractionResponseGenerator
 {
     public class CustomAuthorizeInteractionResponseGenerator : Duende.IdentityServer.ResponseHandling.AuthorizeInteractionResponseGenerator
     {
-        public CustomAuthorizeInteractionResponseGenerator(ISystemClock clock, ILogger<Duende.IdentityServer.ResponseHandling.AuthorizeInteractionResponseGenerator> logger, IConsentService consent, IProfileService profile) : base(clock, logger, consent, profile)
+        public CustomAuthorizeInteractionResponseGenerator(
+            IdentityServerOptions options,
+            ISystemClock clock, 
+            ILogger<Duende.IdentityServer.ResponseHandling.AuthorizeInteractionResponseGenerator> logger, 
+            IConsentService consent, 
+            IProfileService profile) : base(options, clock, logger, consent, profile)
         {
         }
 
@@ -56,6 +61,7 @@ namespace UnitTests.ResponseHandling.AuthorizeInteractionResponseGenerator
         public AuthorizeInteractionResponseGeneratorTests_Custom()
         {
             _subject = new CustomAuthorizeInteractionResponseGenerator(
+                _options,
                 _clock,
                 TestLogger.Create<Duende.IdentityServer.ResponseHandling.AuthorizeInteractionResponseGenerator>(),
                 _mockConsentService,

--- a/test/IdentityServer.UnitTests/ResponseHandling/AuthorizeInteractionResponseGenerator/AuthorizeInteractionResponseGeneratorTests_Login.cs
+++ b/test/IdentityServer.UnitTests/ResponseHandling/AuthorizeInteractionResponseGenerator/AuthorizeInteractionResponseGeneratorTests_Login.cs
@@ -27,6 +27,7 @@ namespace UnitTests.ResponseHandling.AuthorizeInteractionResponseGenerator
         public AuthorizeInteractionResponseGeneratorTests_Login()
         {
             _subject = new Duende.IdentityServer.ResponseHandling.AuthorizeInteractionResponseGenerator(
+                _options,
                 _clock,
                 TestLogger.Create<Duende.IdentityServer.ResponseHandling.AuthorizeInteractionResponseGenerator>(),
                 _mockConsentService,


### PR DESCRIPTION
In the authorize interaction response generator we have special handling for the `idp` claim in the user's session and comparing that against our special `idp:tenant` processing in the acr_values request param, and if it does not match we require the user to login.

This PR adds a similar check (and thus more first class support) for our acr_values `tenant:tenantid` processing. In short, it checks for a `tenant` claim and compares to the acr value and if they don't match it forces the user to re-authenticate. 