### PR TITLE
move consent message store loading to after request validation

### DIFF
--- a/src/IdentityServer/Endpoints/AuthorizeCallbackEndpoint.cs
+++ b/src/IdentityServer/Endpoints/AuthorizeCallbackEndpoint.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
-using System.Collections.Specialized;
 using System.Net;
 using System.Threading.Tasks;
 using Duende.IdentityServer.Configuration;
 using Duende.IdentityServer.Endpoints.Results;
 using Duende.IdentityServer.Hosting;
-using Duende.IdentityServer.Models;
 using Duende.IdentityServer.ResponseHandling;
 using Duende.IdentityServer.Services;
 using Duende.IdentityServer.Stores;
@@ -20,9 +18,6 @@ namespace Duende.IdentityServer.Endpoints
 {
     internal class AuthorizeCallbackEndpoint : AuthorizeEndpointBase
     {
-        private readonly IConsentMessageStore _consentResponseStore;
-        private readonly IAuthorizationParametersMessageStore _authorizationParametersMessageStore;
-
         public AuthorizeCallbackEndpoint(
             IEventService events,
             ILogger<AuthorizeCallbackEndpoint> logger,
@@ -33,10 +28,8 @@ namespace Duende.IdentityServer.Endpoints
             IUserSession userSession,
             IConsentMessageStore consentResponseStore,
             IAuthorizationParametersMessageStore authorizationParametersMessageStore = null)
-            : base(events, logger, options, validator, interactionGenerator, authorizeResponseGenerator, userSession)
+            : base(events, logger, options, validator, interactionGenerator, authorizeResponseGenerator, userSession, consentResponseStore, authorizationParametersMessageStore)
         {
-            _consentResponseStore = consentResponseStore;
-            _authorizationParametersMessageStore = authorizationParametersMessageStore;
         }
 
         public override async Task<IEndpointResult> ProcessAsync(HttpContext context)
@@ -50,39 +43,13 @@ namespace Duende.IdentityServer.Endpoints
             Logger.LogDebug("Start authorize callback request");
 
             var parameters = context.Request.Query.AsNameValueCollection();
-            if (_authorizationParametersMessageStore != null)
-            {
-                var messageStoreId = parameters[Constants.AuthorizationParamsStore.MessageStoreIdParameterName];
-                var entry = await _authorizationParametersMessageStore.ReadAsync(messageStoreId);
-                parameters = entry?.Data.FromFullDictionary() ?? new NameValueCollection();
-
-                await _authorizationParametersMessageStore.DeleteAsync(messageStoreId);
-            }
-
             var user = await UserSession.GetUserAsync();
-            var consentRequest = new ConsentRequest(parameters, user?.GetSubjectId());
-            var consent = await _consentResponseStore.ReadAsync(consentRequest.Id);
 
-            if (consent != null && consent.Data == null)
-            {
-                return await CreateErrorResultAsync("consent message is missing data");
-            }
+            var result = await ProcessAuthorizeRequestAsync(parameters, user, true);
 
-            try
-            {
-                var result = await ProcessAuthorizeRequestAsync(parameters, user, consent?.Data);
+            Logger.LogTrace("End Authorize Request. Result type: {0}", result?.GetType().ToString() ?? "-none-");
 
-                Logger.LogTrace("End Authorize Request. Result type: {0}", result?.GetType().ToString() ?? "-none-");
-
-                return result;
-            }
-            finally
-            {
-                if (consent != null)
-                {
-                    await _consentResponseStore.DeleteAsync(consentRequest.Id);
-                }
-            }
+            return result;
         }
     }
 }

--- a/src/IdentityServer/Endpoints/AuthorizeEndpoint.cs
+++ b/src/IdentityServer/Endpoints/AuthorizeEndpoint.cs
@@ -13,6 +13,7 @@ using Duende.IdentityServer.Validation;
 using Duende.IdentityServer.Extensions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using Duende.IdentityServer.Stores;
 
 namespace Duende.IdentityServer.Endpoints
 {
@@ -25,8 +26,10 @@ namespace Duende.IdentityServer.Endpoints
            IAuthorizeRequestValidator validator,
            IAuthorizeInteractionResponseGenerator interactionGenerator,
            IAuthorizeResponseGenerator authorizeResponseGenerator,
-           IUserSession userSession)
-            : base(events, logger, options, validator, interactionGenerator, authorizeResponseGenerator, userSession)
+           IUserSession userSession,
+           IConsentMessageStore consentResponseStore,
+           IAuthorizationParametersMessageStore authorizationParametersMessageStore = null)
+            : base(events, logger, options, validator, interactionGenerator, authorizeResponseGenerator, userSession, consentResponseStore, authorizationParametersMessageStore)
         {
         }
 
@@ -55,7 +58,7 @@ namespace Duende.IdentityServer.Endpoints
             }
 
             var user = await UserSession.GetUserAsync();
-            var result = await ProcessAuthorizeRequestAsync(values, user, null);
+            var result = await ProcessAuthorizeRequestAsync(values, user);
 
             Logger.LogTrace("End authorize request. result type: {0}", result?.GetType().ToString() ?? "-none-");
 

--- a/src/IdentityServer/Models/Messages/ConsentRequest.cs
+++ b/src/IdentityServer/Models/Messages/ConsentRequest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/test/IdentityServer.IntegrationTests/Common/BrowserHandler.cs
+++ b/test/IdentityServer.IntegrationTests/Common/BrowserHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/test/IdentityServer.UnitTests/Endpoints/Authorize/AuthorizeEndpointTests.cs
+++ b/test/IdentityServer.UnitTests/Endpoints/Authorize/AuthorizeEndpointTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 
@@ -41,6 +41,8 @@ namespace UnitTests.Endpoints.Authorize
 
         private StubAuthorizeInteractionResponseGenerator _stubInteractionGenerator = new StubAuthorizeInteractionResponseGenerator();
 
+        private MockConsentMessageStore _mockUserConsentResponseMessageStore = new MockConsentMessageStore();
+        
         private AuthorizeEndpoint _subject;
 
         private ClaimsPrincipal _user = new IdentityServerUser("bob").CreatePrincipal();
@@ -107,7 +109,8 @@ namespace UnitTests.Endpoints.Authorize
                 _stubAuthorizeRequestValidator,
                 _stubInteractionGenerator,
                 _stubAuthorizeResponseGenerator,
-                _mockUserSession);
+                _mockUserSession,
+                _mockUserConsentResponseMessageStore);
         }
     }
 }

--- a/test/IdentityServer.UnitTests/Endpoints/Authorize/StubAuthorizeRequestValidator.cs
+++ b/test/IdentityServer.UnitTests/Endpoints/Authorize/StubAuthorizeRequestValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 
@@ -15,6 +15,7 @@ namespace UnitTests.Endpoints.Authorize
 
         public Task<AuthorizeRequestValidationResult> ValidateAsync(NameValueCollection parameters, ClaimsPrincipal subject = null)
         {
+            Result.ValidatedRequest.Raw = parameters;
             return Task.FromResult(Result);
         }
     }


### PR DESCRIPTION
When consent is shown, parameters from the authorize request are used to correlate the user's consent to the processing back on the authorize callback endpoint. When using JAR, the parameters are loaded from a different place and thus the correlation breaks. 
This PR moves the consent message store loading to after request validation so that the correct authorize request parameters are used for the correlation.

Fixes: #199