### PR TITLE
Allow full host name to be included in OidcReturnUrlParser's IsValidReturnUrl

### DIFF
--- a/src/IdentityServer/Configuration/DependencyInjection/Options/UserInteractionOptions.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/Options/UserInteractionOptions.cs
@@ -106,5 +106,10 @@ namespace Duende.IdentityServer.Configuration
         /// The device verification user code parameter.
         /// </value>
         public string DeviceVerificationUserCodeParameter { get; set; } = Constants.UIConstants.DefaultRoutePathParams.UserCode;
+
+        /// <summary>
+        /// Flag that allows return URL validation to accept full URL that includes the IdentityServer scheme and host name. Defaults to false.
+        /// </summary>
+        public bool AllowHostInReturnUrl { get; set; }
     }
 }

--- a/src/IdentityServer/Configuration/DependencyInjection/Options/UserInteractionOptions.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/Options/UserInteractionOptions.cs
@@ -108,8 +108,8 @@ namespace Duende.IdentityServer.Configuration
         public string DeviceVerificationUserCodeParameter { get; set; } = Constants.UIConstants.DefaultRoutePathParams.UserCode;
 
         /// <summary>
-        /// Flag that allows return URL validation to accept full URL that includes the IdentityServer scheme and host name. Defaults to false.
+        /// Flag that allows return URL validation to accept full URL that includes the IdentityServer origin. Defaults to false.
         /// </summary>
-        public bool AllowHostInReturnUrl { get; set; }
+        public bool AllowOriginInReturnUrl { get; set; }
     }
 }

--- a/src/IdentityServer/Services/Default/OidcReturnUrlParser.cs
+++ b/src/IdentityServer/Services/Default/OidcReturnUrlParser.cs
@@ -63,18 +63,35 @@ namespace Duende.IdentityServer.Services
 
         public bool IsValidReturnUrl(string returnUrl)
         {
-            var host = _httpContextAccessor.HttpContext.GetIdentityServerHost();
-            if (returnUrl.StartsWith(host, StringComparison.OrdinalIgnoreCase))
+            if (returnUrl != null)
             {
-                returnUrl = returnUrl.Substring(host.Length);
+                if (!Uri.TryCreate(returnUrl, UriKind.RelativeOrAbsolute, out _))
+                {
+                    return false;
+                }
+
+                var host = _httpContextAccessor.HttpContext.GetIdentityServerHost();
+                if (returnUrl.StartsWith(host, StringComparison.OrdinalIgnoreCase) == true)
+                {
+                    returnUrl = returnUrl.Substring(host.Length);
+                }
             }
             
             if (returnUrl.IsLocalUrl())
             {
-                var index = returnUrl.IndexOf('?');
-                if (index >= 0)
                 {
-                    returnUrl = returnUrl.Substring(0, index);
+                    var index = returnUrl.IndexOf('?');
+                    if (index >= 0)
+                    {
+                        returnUrl = returnUrl.Substring(0, index);
+                    }
+                }
+                {
+                    var index = returnUrl.IndexOf('#');
+                    if (index >= 0)
+                    {
+                        returnUrl = returnUrl.Substring(0, index);
+                    }
                 }
 
                 if (returnUrl.EndsWith(Constants.ProtocolRoutePaths.Authorize, StringComparison.Ordinal) ||

--- a/src/IdentityServer/Services/Default/OidcReturnUrlParser.cs
+++ b/src/IdentityServer/Services/Default/OidcReturnUrlParser.cs
@@ -67,7 +67,7 @@ namespace Duende.IdentityServer.Services
 
         public bool IsValidReturnUrl(string returnUrl)
         {
-            if (_options.UserInteraction.AllowHostInReturnUrl && returnUrl != null)
+            if (_options.UserInteraction.AllowOriginInReturnUrl && returnUrl != null)
             {
                 if (!Uri.TryCreate(returnUrl, UriKind.RelativeOrAbsolute, out _))
                 {

--- a/src/IdentityServer/Services/Default/OidcReturnUrlParser.cs
+++ b/src/IdentityServer/Services/Default/OidcReturnUrlParser.cs
@@ -75,10 +75,10 @@ namespace Duende.IdentityServer.Services
                     return false;
                 }
 
-                var host = _httpContextAccessor.HttpContext.GetIdentityServerHost();
-                if (returnUrl.StartsWith(host, StringComparison.OrdinalIgnoreCase) == true)
+                var origin = _httpContextAccessor.HttpContext.GetIdentityServerOrigin();
+                if (returnUrl.StartsWith(origin, StringComparison.OrdinalIgnoreCase) == true)
                 {
-                    returnUrl = returnUrl.Substring(host.Length);
+                    returnUrl = returnUrl.Substring(origin.Length);
                 }
             }
             

--- a/src/IdentityServer/Services/Default/OidcReturnUrlParser.cs
+++ b/src/IdentityServer/Services/Default/OidcReturnUrlParser.cs
@@ -67,6 +67,7 @@ namespace Duende.IdentityServer.Services
             {
                 if (!Uri.TryCreate(returnUrl, UriKind.RelativeOrAbsolute, out _))
                 {
+                    _logger.LogTrace("returnUrl is not valid");
                     return false;
                 }
 

--- a/src/IdentityServer/Services/Default/OidcReturnUrlParser.cs
+++ b/src/IdentityServer/Services/Default/OidcReturnUrlParser.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 
@@ -10,6 +10,7 @@ using System.Collections.Specialized;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Stores;
 using Duende.IdentityServer.Validation;
+using Microsoft.AspNetCore.Http;
 
 namespace Duende.IdentityServer.Services
 {
@@ -17,17 +18,20 @@ namespace Duende.IdentityServer.Services
     {
         private readonly IAuthorizeRequestValidator _validator;
         private readonly IUserSession _userSession;
+        private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly ILogger _logger;
         private readonly IAuthorizationParametersMessageStore _authorizationParametersMessageStore;
 
         public OidcReturnUrlParser(
             IAuthorizeRequestValidator validator,
             IUserSession userSession,
+            IHttpContextAccessor httpContextAccessor,
             ILogger<OidcReturnUrlParser> logger,
             IAuthorizationParametersMessageStore authorizationParametersMessageStore = null)
         {
             _validator = validator;
             _userSession = userSession;
+            _httpContextAccessor = httpContextAccessor;
             _logger = logger;
             _authorizationParametersMessageStore = authorizationParametersMessageStore;
         }
@@ -59,6 +63,12 @@ namespace Duende.IdentityServer.Services
 
         public bool IsValidReturnUrl(string returnUrl)
         {
+            var host = _httpContextAccessor.HttpContext.GetIdentityServerHost();
+            if (returnUrl.StartsWith(host, StringComparison.OrdinalIgnoreCase))
+            {
+                returnUrl = returnUrl.Substring(host.Length);
+            }
+            
             if (returnUrl.IsLocalUrl())
             {
                 var index = returnUrl.IndexOf('?');

--- a/src/IdentityServer/Services/Default/OidcReturnUrlParser.cs
+++ b/src/IdentityServer/Services/Default/OidcReturnUrlParser.cs
@@ -75,10 +75,10 @@ namespace Duende.IdentityServer.Services
                     return false;
                 }
 
-                var origin = _httpContextAccessor.HttpContext.GetIdentityServerOrigin();
-                if (returnUrl.StartsWith(origin, StringComparison.OrdinalIgnoreCase) == true)
+                var host = _httpContextAccessor.HttpContext.GetIdentityServerHost();
+                if (returnUrl.StartsWith(host, StringComparison.OrdinalIgnoreCase) == true)
                 {
-                    returnUrl = returnUrl.Substring(origin.Length);
+                    returnUrl = returnUrl.Substring(host.Length);
                 }
             }
             

--- a/src/IdentityServer/Services/Default/OidcReturnUrlParser.cs
+++ b/src/IdentityServer/Services/Default/OidcReturnUrlParser.cs
@@ -11,11 +11,13 @@ using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Stores;
 using Duende.IdentityServer.Validation;
 using Microsoft.AspNetCore.Http;
+using Duende.IdentityServer.Configuration;
 
 namespace Duende.IdentityServer.Services
 {
     internal class OidcReturnUrlParser : IReturnUrlParser
     {
+        private readonly IdentityServerOptions _options;
         private readonly IAuthorizeRequestValidator _validator;
         private readonly IUserSession _userSession;
         private readonly IHttpContextAccessor _httpContextAccessor;
@@ -23,12 +25,14 @@ namespace Duende.IdentityServer.Services
         private readonly IAuthorizationParametersMessageStore _authorizationParametersMessageStore;
 
         public OidcReturnUrlParser(
+            IdentityServerOptions options,
             IAuthorizeRequestValidator validator,
             IUserSession userSession,
             IHttpContextAccessor httpContextAccessor,
             ILogger<OidcReturnUrlParser> logger,
             IAuthorizationParametersMessageStore authorizationParametersMessageStore = null)
         {
+            _options = options;
             _validator = validator;
             _userSession = userSession;
             _httpContextAccessor = httpContextAccessor;
@@ -63,7 +67,7 @@ namespace Duende.IdentityServer.Services
 
         public bool IsValidReturnUrl(string returnUrl)
         {
-            if (returnUrl != null)
+            if (_options.UserInteraction.AllowHostInReturnUrl && returnUrl != null)
             {
                 if (!Uri.TryCreate(returnUrl, UriKind.RelativeOrAbsolute, out _))
                 {

--- a/test/IdentityServer.UnitTests/Services/Default/OidcReturnUrlParserTests.cs
+++ b/test/IdentityServer.UnitTests/Services/Default/OidcReturnUrlParserTests.cs
@@ -1,0 +1,120 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using Duende.IdentityServer.Services;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace UnitTests.Services.Default
+{
+    public class OidcReturnUrlParserTests
+    {
+        private OidcReturnUrlParser _subject;
+        
+        DefaultHttpContext _httpContext = new DefaultHttpContext();
+
+        public OidcReturnUrlParserTests()
+        {
+            _httpContext.Request.Scheme = "https";
+            _httpContext.Request.Host = new HostString("server");
+
+            _subject = new OidcReturnUrlParser(
+                null, null, 
+                new HttpContextAccessor { HttpContext = _httpContext }, 
+                new LoggerFactory().CreateLogger<OidcReturnUrlParser>());
+        }
+
+        [Theory]
+        [InlineData("/connect/authorize")]
+        [InlineData("/connect/authorize?foo=f1&bar=b1")]
+        [InlineData("/connect/authorize/callback")]
+        [InlineData("/connect/authorize/callback?foo=f1&bar=b1")]
+        [InlineData("/foo/connect/authorize")]
+        [InlineData("/foo/connect/authorize/callback")]
+        public void IsValidReturnUrl_accepts_authorize_or_authorizecallback(string url)
+        {
+            var valid = _subject.IsValidReturnUrl(url);
+            valid.Should().BeTrue();
+        }
+        
+        [Theory]
+        [InlineData(default(string))]
+        [InlineData("")]
+        [InlineData("/")]
+        [InlineData("/path")]
+        [InlineData("//connect/authorize")]
+        [InlineData("/connect/authorizex")]
+        [InlineData("/connect")]
+        [InlineData("/connect/token")]
+        [InlineData("/authorize")]
+        [InlineData("/foo?/connect/authorize")]
+        [InlineData("/foo#/connect/authorize")]
+        [InlineData("/foo?#/connect/authorize")]
+        [InlineData("/foo#?/connect/authorize")]
+        [InlineData("//server/connect/authorize")]
+        public void IsValidReturnUrl_rejects_non_authorize_or_authorizecallback(string url)
+        {
+            var valid = _subject.IsValidReturnUrl(url);
+            valid.Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData("https://server/connect/authorize")]
+        [InlineData("HTTPS://server/connect/authorize")]
+        [InlineData("https://SERVER/connect/authorize")]
+        [InlineData("https://server/foo/connect/authorize")]
+        public void IsValidReturnUrl_accepts_urls_with_current_host(string url)
+        {
+            var valid = _subject.IsValidReturnUrl(url);
+            valid.Should().BeTrue();
+        }
+        
+        [Theory]
+        [InlineData("http://server/connect/authorize")]
+        [InlineData("https:\\/server/connect/authorize")]
+        [InlineData("https:\\\\server/connect/authorize")]
+        [InlineData("https://foo/connect/authorize")]
+        [InlineData("https://serverhttps://server/connect/authorize")]
+        [InlineData("https://serverfoo/connect/authorize")]
+        [InlineData("https://server//foo/connect/authorize")]
+        [InlineData("https://server:443/connect/authorize")]
+        public void IsValidReturnUrl_rejects_urls_with_incorrect_current_host(string url)
+        {
+            var valid = _subject.IsValidReturnUrl(url);
+            valid.Should().BeFalse();
+        }
+
+
+        [Theory]
+        [InlineData("https://server:443/connect/authorize")]
+        [InlineData("HTTPS://server:443/connect/authorize")]
+        [InlineData("https://SERVER:443/connect/authorize")]
+        public void IsValidReturnUrl_accepts_urls_with_current_port(string url)
+        {
+            _httpContext.Request.Host = new HostString("server:443");
+
+            var valid = _subject.IsValidReturnUrl(url);
+            valid.Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData("https://server/connect/authorize")]
+        [InlineData("https://server:80/connect/authorize")]
+        [InlineData("https://server:4/connect/authorize")]
+        [InlineData("https://foo:443/connect/authorize")]
+        [InlineData("https://server:4433/connect/authorize")]
+        [InlineData("https://server:443https://server:443/connect/authorize")]
+        [InlineData("https://serverfoo:443/connect/authorize")]
+        [InlineData("https://server:443foo/connect/authorize")]
+        [InlineData("https://server:443//foo/connect/authorize")]
+        public void IsValidReturnUrl_rejects_urls_with_incorrect_current_port(string url)
+        {
+            _httpContext.Request.Host = new HostString("server:443");
+            
+            var valid = _subject.IsValidReturnUrl(url);
+            valid.Should().BeFalse();
+        }
+    }
+}

--- a/test/IdentityServer.UnitTests/Services/Default/OidcReturnUrlParserTests.cs
+++ b/test/IdentityServer.UnitTests/Services/Default/OidcReturnUrlParserTests.cs
@@ -21,10 +21,6 @@ namespace UnitTests.Services.Default
 
         public OidcReturnUrlParserTests()
         {
-            var services = new ServiceCollection();
-            services.AddSingleton(_options);
-            _httpContext.RequestServices = services.BuildServiceProvider();
-
             _httpContext.Request.Scheme = "https";
             _httpContext.Request.Host = new HostString("server");
 

--- a/test/IdentityServer.UnitTests/Services/Default/OidcReturnUrlParserTests.cs
+++ b/test/IdentityServer.UnitTests/Services/Default/OidcReturnUrlParserTests.cs
@@ -70,7 +70,7 @@ namespace UnitTests.Services.Default
         [InlineData("https://server/foo/connect/authorize")]
         public void IsValidReturnUrl_accepts_urls_with_current_host(string url)
         {
-            _options.UserInteraction.AllowHostInReturnUrl = true;
+            _options.UserInteraction.AllowOriginInReturnUrl = true;
             var valid = _subject.IsValidReturnUrl(url);
             valid.Should().BeTrue();
         }
@@ -78,7 +78,7 @@ namespace UnitTests.Services.Default
         [Fact]
         public void IsValidReturnUrl_when_AllowHostInReturnUrl_disabled_rejects_urls_with_current_host()
         {
-            _options.UserInteraction.AllowHostInReturnUrl = false;
+            _options.UserInteraction.AllowOriginInReturnUrl = false;
             var valid = _subject.IsValidReturnUrl("https://server/connect/authorize");
             valid.Should().BeFalse();
         }
@@ -94,7 +94,7 @@ namespace UnitTests.Services.Default
         [InlineData("https://server:443/connect/authorize")]
         public void IsValidReturnUrl_rejects_urls_with_incorrect_current_host(string url)
         {
-            _options.UserInteraction.AllowHostInReturnUrl = true;
+            _options.UserInteraction.AllowOriginInReturnUrl = true;
             var valid = _subject.IsValidReturnUrl(url);
             valid.Should().BeFalse();
         }
@@ -106,7 +106,7 @@ namespace UnitTests.Services.Default
         [InlineData("https://SERVER:443/connect/authorize")]
         public void IsValidReturnUrl_accepts_urls_with_current_port(string url)
         {
-            _options.UserInteraction.AllowHostInReturnUrl = true;
+            _options.UserInteraction.AllowOriginInReturnUrl = true;
             _httpContext.Request.Host = new HostString("server:443");
 
             var valid = _subject.IsValidReturnUrl(url);
@@ -125,7 +125,7 @@ namespace UnitTests.Services.Default
         [InlineData("https://server:443//foo/connect/authorize")]
         public void IsValidReturnUrl_rejects_urls_with_incorrect_current_port(string url)
         {
-            _options.UserInteraction.AllowHostInReturnUrl = true;
+            _options.UserInteraction.AllowOriginInReturnUrl = true;
             _httpContext.Request.Host = new HostString("server:443");
             
             var valid = _subject.IsValidReturnUrl(url);

--- a/test/IdentityServer.UnitTests/Services/Default/OidcReturnUrlParserTests.cs
+++ b/test/IdentityServer.UnitTests/Services/Default/OidcReturnUrlParserTests.cs
@@ -7,6 +7,7 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using System;
 using Xunit;
 
 namespace UnitTests.Services.Default
@@ -111,7 +112,7 @@ namespace UnitTests.Services.Default
             _options.UserInteraction.AllowOriginInReturnUrl = true;
             _httpContext.Request.Host = new HostString("грант.рф");
 
-            var valid = _subject.IsValidReturnUrl("https://грант.рф/connect/authorize");
+            var valid = _subject.IsValidReturnUrl("https://xn--80af5akm.xn--p1ai/connect/authorize");
             valid.Should().BeTrue();
         }
 

--- a/test/IdentityServer.UnitTests/Services/Default/OidcReturnUrlParserTests.cs
+++ b/test/IdentityServer.UnitTests/Services/Default/OidcReturnUrlParserTests.cs
@@ -5,6 +5,7 @@ using Duende.IdentityServer.Configuration;
 using Duende.IdentityServer.Services;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Xunit;
 
@@ -19,6 +20,10 @@ namespace UnitTests.Services.Default
 
         public OidcReturnUrlParserTests()
         {
+            var services = new ServiceCollection();
+            services.AddSingleton(_options);
+            _httpContext.RequestServices = services.BuildServiceProvider();
+
             _httpContext.Request.Scheme = "https";
             _httpContext.Request.Host = new HostString("server");
 
@@ -99,6 +104,16 @@ namespace UnitTests.Services.Default
             valid.Should().BeFalse();
         }
 
+
+        [Fact]
+        public void IsValidReturnUrl_accepts_urls_with_unicode()
+        {
+            _options.UserInteraction.AllowOriginInReturnUrl = true;
+            _httpContext.Request.Host = new HostString("грант.рф");
+
+            var valid = _subject.IsValidReturnUrl("https://грант.рф/connect/authorize");
+            valid.Should().BeTrue();
+        }
 
         [Theory]
         [InlineData("https://server:443/connect/authorize")]


### PR DESCRIPTION
When validating return URLs we only allowed local paths to be accepted. But there is desire to allow the UI for login to outside the IdentityServer host, thus when they receive the returnUrl on the login page the full URL will be passed (including the host). 

This PR now allows the exact IdentityServer host to be included in the returnUrl for validation.

Fixes: #173