### PR TITLE
Always allow explicit error responses from authorize request

### DIFF
--- a/src/IdentityServer/ResponseHandling/Default/AuthorizeInteractionResponseGenerator.cs
+++ b/src/IdentityServer/ResponseHandling/Default/AuthorizeInteractionResponseGenerator.cs
@@ -79,7 +79,7 @@ namespace Duende.IdentityServer.ResponseHandling
         {
             Logger.LogTrace("ProcessInteractionAsync");
 
-            if (consent != null && consent.Granted == false && consent.Error.HasValue && request.Subject.IsAuthenticated() == false)
+            if (consent != null && consent.Granted == false && consent.Error.HasValue)
             {
                 // special case when anonymous user has issued an error prior to authenticating
                 Logger.LogInformation("Error: User consent result: {error}", consent.Error);


### PR DESCRIPTION
If during the UI workflow a user is logged in, and an explicit authorize error response is expressed via the `IIdentityServerInteractionService` then the IdentityServer internal plumbing would only honor that error if the client is configured for consent. This PR removes that limitation and so now during any UI workflow if an error response is indicated then it will be returned to the client.