### PR TITLE
change the accessibility to public for the dynamic provider cache

### DIFF
--- a/src/IdentityServer/Hosting/DynamicProviders/DynamicSchemes/DynamicAuthenticationScheme.cs
+++ b/src/IdentityServer/Hosting/DynamicProviders/DynamicSchemes/DynamicAuthenticationScheme.cs
@@ -7,14 +7,25 @@ using System;
 
 namespace Duende.IdentityServer.Hosting.DynamicProviders
 {
-    class DynamicAuthenticationScheme : AuthenticationScheme
+    /// <summary>
+    /// Models a dynamic authentication scheme and it's corresponding IdentityProvider data.
+    /// </summary>
+    public class DynamicAuthenticationScheme : AuthenticationScheme
     {
+        /// <summary>
+        /// Ctor
+        /// </summary>
+        /// <param name="idp"></param>
+        /// <param name="handlerType"></param>
         public DynamicAuthenticationScheme(IdentityProvider idp, Type handlerType)
             : base(idp.Scheme, idp.DisplayName, handlerType)
         {
             IdentityProvider = idp;
         }
 
+        /// <summary>
+        /// The corresponding IdentityProvider configuration data.
+        /// </summary>
         public IdentityProvider IdentityProvider { get; set; }
     }
 }

--- a/src/IdentityServer/Hosting/DynamicProviders/DynamicSchemes/DynamicAuthenticationSchemeCache.cs
+++ b/src/IdentityServer/Hosting/DynamicProviders/DynamicSchemes/DynamicAuthenticationSchemeCache.cs
@@ -11,24 +11,40 @@ namespace Duende.IdentityServer.Hosting.DynamicProviders
     // request and made available anywhere else during this request (in case the static cache times out across 
     // 2 calls within the same request)
     // also, we need a non-async version that can be used from within the non-async Configure API in IConfigureNamedOptions<>
-    class DynamicAuthenticationSchemeCache
+
+    /// <summary>
+    /// Cache for DynamicAuthenticationScheme.
+    /// </summary>
+    public class DynamicAuthenticationSchemeCache
     {
         private readonly ConcurrentDictionary<string, DynamicAuthenticationScheme> _cache =
             new ConcurrentDictionary<string, DynamicAuthenticationScheme>();
 
+        /// <summary>
+        /// Adds the scheme.
+        /// </summary>
         public void Add(string name, DynamicAuthenticationScheme item)
         {
             name = name ?? String.Empty;
             _cache.TryAdd(name, item);
         }
 
+        /// <summary>
+        /// Gets the scheme.
+        /// </summary>
         public DynamicAuthenticationScheme Get(string name)
         {
             name = name ?? String.Empty;
             _cache.TryGetValue(name, out var item);
             return item;
         }
-        
+
+        /// <summary>
+        /// Returns the downcast IdentityProvider.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="name"></param>
+        /// <returns></returns>
         public T GetIdentityProvider<T>(string name)
             where T : IdentityProvider
         {


### PR DESCRIPTION
This PR changes the dynamic authentication scheme cache to public. This is needed if a custom dynamic provider needs to have more control in the configure named options code and can't use the built-in ConfigureAuthenticationOptions.