### PR TITLE
add a ToString to the License

### DIFF
--- a/src/IdentityServer/Validation/Default/License.cs
+++ b/src/IdentityServer/Validation/Default/License.cs
@@ -142,5 +142,10 @@ namespace Duende.IdentityServer.Validation
             Starter,
             Community
         }
+
+        public override string ToString()
+        {
+            return ObjectSerializer.ToString(this);
+        }
     }
 }


### PR DESCRIPTION
adds a ToString for the License for better debugging (when not using Serilog)