### PR TITLE
Allow token_endpoint from discovery document as audience for Jwt Bearer Client Authentication

### DIFF
--- a/src/IdentityServer/Validation/Default/PrivateKeyJwtSecretValidator.cs
+++ b/src/IdentityServer/Validation/Default/PrivateKeyJwtSecretValidator.cs
@@ -10,6 +10,7 @@ using Duende.IdentityServer.Configuration;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services;
 using Duende.IdentityServer.Extensions;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;
@@ -21,6 +22,7 @@ namespace Duende.IdentityServer.Validation
     /// </summary>
     public class PrivateKeyJwtSecretValidator : ISecretValidator
     {
+        private readonly IHttpContextAccessor _contextAccessor;
         private readonly IIssuerNameService _issuerNameService;
         private readonly IReplayCache _replayCache;
         private readonly IdentityServerOptions _options;
@@ -32,11 +34,13 @@ namespace Duende.IdentityServer.Validation
         /// Instantiates an instance of private_key_jwt secret validator
         /// </summary>
         public PrivateKeyJwtSecretValidator(
+            IHttpContextAccessor contextAccessor, 
             IIssuerNameService issuerNameService, 
             IReplayCache replayCache,
             IdentityServerOptions options,
             ILogger<PrivateKeyJwtSecretValidator> logger)
         {
+            _contextAccessor = contextAccessor;
             _issuerNameService = issuerNameService;
             _replayCache = replayCache;
             _options = options;
@@ -88,6 +92,8 @@ namespace Duende.IdentityServer.Validation
             var validAudiences = new[]
             {
                 // token endpoint URL
+                string.Concat(_contextAccessor.HttpContext.GetIdentityServerBaseUrl().EnsureTrailingSlash(),
+                    Constants.ProtocolRoutePaths.Token),
                 string.Concat((await _issuerNameService.GetCurrentAsync()).EnsureTrailingSlash(),
                     Constants.ProtocolRoutePaths.Token)
             };

--- a/test/IdentityServer.UnitTests/Validation/Secrets/PrivateKeyJwtSecretValidation.cs
+++ b/test/IdentityServer.UnitTests/Validation/Secrets/PrivateKeyJwtSecretValidation.cs
@@ -32,6 +32,7 @@ namespace UnitTests.Validation.Secrets
         public PrivateKeyJwtSecretValidation()
         {
             _validator = new PrivateKeyJwtSecretValidator(
+                 new MockHttpContextAccessor(),
                  new TestIssuerNameService("https://idsrv3.com"),
                  new DefaultReplayCache(new TestCache()), 
                  new IdentityServerOptions(),


### PR DESCRIPTION
**What issue does this PR address?**

The problem occurs if the Jwt Bearer Client Authentication with the default PrivateKeyJwtSecretValidator in combination with an IdentityServer setup that has different domains for the issuer and the (token) endpoints.

The discovery document generator allows this configuring a different issuer, but the PrivateKeyJwtSecretValidator is constructing the token endpoint for the audience check path by its own, by combining the issuer with the token endpoint path.

This results in the affect that the client can not use the token_endpoint from the discovery document as the audience for the jwt client authentication, since the PrivateKeyJwtSecretValidator is constructing a difference audience during the check.

**To Reproduce**

Setup an IdentityServer where the issuer is configured to a different host and jwt bearer client authentication:
```
var builder = services.AddIdentityServer(options =>
{
    options.IssuerUri = "https://different.host";
})
.AddJwtBearerClientAuthentication();
```

This will result in discovery document:
```
{
   "issuer":"https://different.host",
   "jwks_uri":"https://localhost:5001/.well-known/openid-configuration/jwks",
   "authorization_endpoint":"https://localhost:5001/connect/authorize",
   "token_endpoint":"https://localhost:5001/connect/token",
   ...
}
```

Do a token request with the [JwtBasedClientAuthentication sample](https://github.com/DuendeSoftware/Samples/tree/main/IdentityServer/v5/Basics/JwtBasedClientAuthentication).

Notice that the audience of the request is "https://localhost:5001/connect/token" while the IdentityServer is checking for "https://different.host/connect/token".

From a client perspective this is only fixable by hard coding the right URI.

To prevent any compatibility issues it would be wise to add an additional allowed audience as proposed in this PR.

**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
