### PR TITLE
Add TableConfiguration for "Keys" table in operational EF database

### DIFF
--- a/src/EntityFramework.Storage/Extensions/ModelBuilderExtensions.cs
+++ b/src/EntityFramework.Storage/Extensions/ModelBuilderExtensions.cs
@@ -175,6 +175,8 @@ namespace Duende.IdentityServer.EntityFramework.Extensions
 
             modelBuilder.Entity<Key>(entity =>
             {
+                entity.ToTable(storeOptions.Keys);
+
                 entity.HasKey(x => x.Id);
                 entity.HasIndex(x => x.Use);
                 entity.Property(x => x.Algorithm).HasMaxLength(100).IsRequired();

--- a/src/EntityFramework.Storage/Options/OperationalStoreOptions.cs
+++ b/src/EntityFramework.Storage/Options/OperationalStoreOptions.cs
@@ -51,6 +51,14 @@ namespace Duende.IdentityServer.EntityFramework.Options
         /// The device flow codes.
         /// </value>
         public TableConfiguration DeviceFlowCodes { get; set; } = new TableConfiguration("DeviceCodes");
+        
+        /// <summary>
+        /// Gets or sets the keys table configuration.
+        /// </summary>
+        /// <value>
+        /// The keys.
+        /// </value>
+        public TableConfiguration Keys { get; set; } = new TableConfiguration("Keys");
 
         /// <summary>
         /// Gets or sets a value indicating whether stale entries will be automatically cleaned up from the database.


### PR DESCRIPTION
The "Keys" table in the operational EF database was missing a *TableConfiguration*  to allow changing the table name. This PR adds that option. 

Fixes: https://github.com/DuendeSoftware/IdentityServer/issues/109