### PR TITLE
Add temporarily_unavailable error support for ConsentResponse

### DIFF
--- a/src/IdentityServer/Endpoints/Results/AuthorizeResult.cs
+++ b/src/IdentityServer/Endpoints/Results/AuthorizeResult.cs
@@ -78,7 +78,8 @@ namespace Duende.IdentityServer.Endpoints.Results
                 Response.Error == OidcConstants.AuthorizeErrors.AccountSelectionRequired ||
                 Response.Error == OidcConstants.AuthorizeErrors.LoginRequired ||
                 Response.Error == OidcConstants.AuthorizeErrors.ConsentRequired ||
-                Response.Error == OidcConstants.AuthorizeErrors.InteractionRequired;
+                Response.Error == OidcConstants.AuthorizeErrors.InteractionRequired || 
+                Response.Error == OidcConstants.AuthorizeErrors.TemporarilyUnavailable;
 
             if (isSafeError)
             {

--- a/src/IdentityServer/Models/Messages/ConsentResponse.cs
+++ b/src/IdentityServer/Models/Messages/ConsentResponse.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 
@@ -83,7 +83,12 @@ namespace Duende.IdentityServer.Models
         /// <summary>
         /// Consent required
         /// </summary>
-        ConsentRequired
+        ConsentRequired,
+
+        /// <summary>
+        /// Temporarily unavailable
+        /// </summary>
+        TemporarilyUnavailable,
     }
 
 }

--- a/src/IdentityServer/ResponseHandling/Default/AuthorizeInteractionResponseGenerator.cs
+++ b/src/IdentityServer/ResponseHandling/Default/AuthorizeInteractionResponseGenerator.cs
@@ -90,6 +90,7 @@ namespace Duende.IdentityServer.ResponseHandling
                     AuthorizationError.ConsentRequired => OidcConstants.AuthorizeErrors.ConsentRequired,
                     AuthorizationError.InteractionRequired => OidcConstants.AuthorizeErrors.InteractionRequired,
                     AuthorizationError.LoginRequired => OidcConstants.AuthorizeErrors.LoginRequired,
+                    AuthorizationError.TemporarilyUnavailable => OidcConstants.AuthorizeErrors.TemporarilyUnavailable,
                     _ => OidcConstants.AuthorizeErrors.AccessDenied
                 };
                 
@@ -306,6 +307,7 @@ namespace Duende.IdentityServer.ResponseHandling
                             AuthorizationError.ConsentRequired => OidcConstants.AuthorizeErrors.ConsentRequired,
                             AuthorizationError.InteractionRequired => OidcConstants.AuthorizeErrors.InteractionRequired,
                             AuthorizationError.LoginRequired => OidcConstants.AuthorizeErrors.LoginRequired,
+                            AuthorizationError.TemporarilyUnavailable => OidcConstants.AuthorizeErrors.TemporarilyUnavailable,
                             _ => OidcConstants.AuthorizeErrors.AccessDenied
                         };
                         


### PR DESCRIPTION
In a custom login or consent page, there's not way to trigger a general error to be returned back to the client other than errors related to the user choosing to fail the request (for example, access denied). This PR add a *TemporarilyUnavailable* to the *AuthorizationError* enum to allow a custom UI to return a general error/failure message when using the *ConsentRequest* due to some condition happening in the custom UI workflow. This will return the "temporarily_unavailable" error directly back to the client.

For more context: https://github.com/DuendeSoftware/IdentityServer/discussions/203

Fixes: #205