### PR TITLE
Fix inconsistency in CustomRedirectResult vs Login and ConsentPageResult

### DIFF
--- a/src/IdentityServer/Endpoints/Results/CustomRedirectResult.cs
+++ b/src/IdentityServer/Endpoints/Results/CustomRedirectResult.cs
@@ -90,7 +90,7 @@ namespace Duende.IdentityServer.Endpoints.Results
             {
                 // this converts the relative redirect path to an absolute one if we're 
                 // redirecting to a different server
-                returnUrl = context.GetIdentityServerBaseUrl().EnsureTrailingSlash() + returnUrl.RemoveLeadingSlash();
+                returnUrl = context.GetIdentityServerHost().EnsureTrailingSlash() + returnUrl.RemoveLeadingSlash();
             }
 
             var url = _url.AddQueryString(_options.UserInteraction.CustomRedirectReturnUrlParameter, returnUrl);


### PR DESCRIPTION
*CustomRedirectResult* was using a different API to construct the *returnUrl* which did not work quite right in some hosting scenarios. This changes it to use the same approach the *LoginPageResult* and *ConsentPageResult* use.

This might cause a breaking change for some uses of *CustomRedirectResult* depending on how your IdentityServer is hosted.