### PR TITLE
Replace Uri.TryCreate with Uri.IsWellformedUriString

### DIFF
--- a/src/IdentityServer/Extensions/ResourceExtensions.cs
+++ b/src/IdentityServer/Extensions/ResourceExtensions.cs
@@ -146,7 +146,7 @@ namespace Duende.IdentityServer.Models
             {
                 foreach (var item in list)
                 {
-                    if (!Uri.TryCreate(item, UriKind.Absolute, out _))
+                    if (!Uri.IsWellFormedUriString(item, UriKind.Absolute))
                     {
                         logger.LogDebug("Resource indicator {resource} is not a valid URI.", item);
                         return false;

--- a/src/IdentityServer/Services/Default/OidcReturnUrlParser.cs
+++ b/src/IdentityServer/Services/Default/OidcReturnUrlParser.cs
@@ -69,7 +69,7 @@ namespace Duende.IdentityServer.Services
         {
             if (_options.UserInteraction.AllowOriginInReturnUrl && returnUrl != null)
             {
-                if (!Uri.TryCreate(returnUrl, UriKind.RelativeOrAbsolute, out _))
+                if (!Uri.IsWellFormedUriString(returnUrl, UriKind.RelativeOrAbsolute))
                 {
                     _logger.LogTrace("returnUrl is not valid");
                     return false;

--- a/src/IdentityServer/Validation/Default/AuthorizeRequestValidator.cs
+++ b/src/IdentityServer/Validation/Default/AuthorizeRequestValidator.cs
@@ -339,7 +339,7 @@ namespace Duende.IdentityServer.Validation
                 return Invalid(request, description: "Invalid redirect_uri");
             }
 
-            if (!Uri.TryCreate(redirectUri, UriKind.Absolute, out _))
+            if (!Uri.IsWellFormedUriString(redirectUri, UriKind.Absolute))
             {
                 LogError("malformed redirect_uri", redirectUri, request);
                 return Invalid(request, description: "Invalid redirect_uri");

--- a/src/IdentityServer/Validation/Default/DefaultClientConfigurationValidator.cs
+++ b/src/IdentityServer/Validation/Default/DefaultClientConfigurationValidator.cs
@@ -151,8 +151,10 @@ namespace Duende.IdentityServer.Validation
                 {
                     var fail = true;
 
-                    if (!string.IsNullOrWhiteSpace(origin) && Uri.TryCreate(origin, UriKind.Absolute, out var uri))
+                    if (!string.IsNullOrWhiteSpace(origin) && Uri.IsWellFormedUriString(origin, UriKind.Absolute))
                     {
+                        var uri = new Uri(origin);
+                        
                         if (uri.AbsolutePath == "/" && !origin.EndsWith("/"))
                         {
                             fail = false;

--- a/test/IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ProtocolValidation_Invalid.cs
+++ b/test/IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ProtocolValidation_Invalid.cs
@@ -157,14 +157,16 @@ namespace UnitTests.Validation.AuthorizeRequest_Validation
             result.Error.Should().Be(OidcConstants.AuthorizeErrors.InvalidRequest);
         }
 
-        [Fact]
+        [Theory]
+        [InlineData("malformed")]
+        [InlineData("/malformed")]
         [Trait("Category", Category)]
-        public async Task Malformed_RedirectUri()
+        public async Task Malformed_RedirectUri(string redirectUri)
         {
             var parameters = new NameValueCollection();
             parameters.Add(OidcConstants.AuthorizeRequest.ClientId, "client");
             parameters.Add(OidcConstants.AuthorizeRequest.Scope, "openid");
-            parameters.Add(OidcConstants.AuthorizeRequest.RedirectUri, "malformed");
+            parameters.Add(OidcConstants.AuthorizeRequest.RedirectUri, redirectUri);
             parameters.Add(OidcConstants.AuthorizeRequest.ResponseType, OidcConstants.ResponseTypes.Code);
 
             var validator = Factory.CreateAuthorizeRequestValidator();


### PR DESCRIPTION
Uri.TryCreate has unexpected behavior on non-Windows machines. It does accept relative URI as absolute ones (and turns them into `file://` URIs..