### PR TITLE
Add option to make grant version delimiter configurable

### DIFF
--- a/src/IdentityServer/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
@@ -167,5 +167,13 @@ namespace Duende.IdentityServer.Configuration
         /// Options for dynamic external providers.
         /// </summary>
         public DynamicProviderOptions DynamicProviders { get; set; } = new DynamicProviderOptions();
+
+        /// <summary>
+        /// Gets or sets a value that is used as a delimiter for versioning handles used by the grant store.
+        /// The value used should not be used in the output produced by the IHandleGenerationService.
+        /// For example, if a custom IHandleGenerationService generates a value that contains the "-" character (e.g. a GUID), 
+        /// then a delimiter of "-" should not be used and some other value that will not appear should be used instead (e.g. ":").
+        /// </summary>
+        public string GrantVersionDelimiter { get; set; } = "-";
     }
 }

--- a/src/IdentityServer/Stores/Default/DefaultAuthorizationCodeStore.cs
+++ b/src/IdentityServer/Stores/Default/DefaultAuthorizationCodeStore.cs
@@ -8,6 +8,7 @@ using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Stores.Serialization;
 using Microsoft.Extensions.Logging;
 using Duende.IdentityServer.Extensions;
+using Duende.IdentityServer.Configuration;
 
 namespace Duende.IdentityServer.Stores
 {
@@ -19,16 +20,18 @@ namespace Duende.IdentityServer.Stores
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultAuthorizationCodeStore"/> class.
         /// </summary>
+        /// <param name="identityServerOptions"></param>
         /// <param name="store">The store.</param>
         /// <param name="serializer">The serializer.</param>
         /// <param name="handleGenerationService">The handle generation service.</param>
         /// <param name="logger">The logger.</param>
         public DefaultAuthorizationCodeStore(
+            IdentityServerOptions identityServerOptions,
             IPersistedGrantStore store,
             IPersistentGrantSerializer serializer,
             IHandleGenerationService handleGenerationService,
             ILogger<DefaultAuthorizationCodeStore> logger)
-            : base(IdentityServerConstants.PersistedGrantTypes.AuthorizationCode, store, serializer, handleGenerationService, logger)
+            : base(IdentityServerConstants.PersistedGrantTypes.AuthorizationCode, identityServerOptions, store, serializer, handleGenerationService, logger)
         {
         }
 

--- a/src/IdentityServer/Stores/Default/DefaultReferenceTokenStore.cs
+++ b/src/IdentityServer/Stores/Default/DefaultReferenceTokenStore.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 
@@ -7,6 +7,7 @@ using Duende.IdentityServer.Services;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Stores.Serialization;
 using Microsoft.Extensions.Logging;
+using Duende.IdentityServer.Configuration;
 
 namespace Duende.IdentityServer.Stores
 {
@@ -18,16 +19,18 @@ namespace Duende.IdentityServer.Stores
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultReferenceTokenStore"/> class.
         /// </summary>
+        /// <param name="identityServerOptions"></param>
         /// <param name="store">The store.</param>
         /// <param name="serializer">The serializer.</param>
         /// <param name="handleGenerationService">The handle generation service.</param>
         /// <param name="logger">The logger.</param>
         public DefaultReferenceTokenStore(
+            IdentityServerOptions identityServerOptions,
             IPersistedGrantStore store, 
             IPersistentGrantSerializer serializer,
             IHandleGenerationService handleGenerationService,
             ILogger<DefaultReferenceTokenStore> logger) 
-            : base(IdentityServerConstants.PersistedGrantTypes.ReferenceToken, store, serializer, handleGenerationService, logger)
+            : base(IdentityServerConstants.PersistedGrantTypes.ReferenceToken, identityServerOptions, store, serializer, handleGenerationService, logger)
         {
         }
 

--- a/src/IdentityServer/Stores/Default/DefaultRefreshTokenStore.cs
+++ b/src/IdentityServer/Stores/Default/DefaultRefreshTokenStore.cs
@@ -7,6 +7,7 @@ using Duende.IdentityServer.Services;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Stores.Serialization;
 using Microsoft.Extensions.Logging;
+using Duende.IdentityServer.Configuration;
 
 namespace Duende.IdentityServer.Stores
 {
@@ -18,16 +19,18 @@ namespace Duende.IdentityServer.Stores
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultRefreshTokenStore"/> class.
         /// </summary>
+        /// <param name="identityServerOptions"></param>
         /// <param name="store">The store.</param>
         /// <param name="serializer">The serializer.</param>
         /// <param name="handleGenerationService">The handle generation service.</param>
         /// <param name="logger">The logger.</param>
         public DefaultRefreshTokenStore(
+            IdentityServerOptions identityServerOptions,
             IPersistedGrantStore store, 
             IPersistentGrantSerializer serializer, 
             IHandleGenerationService handleGenerationService,
             ILogger<DefaultRefreshTokenStore> logger) 
-            : base(IdentityServerConstants.PersistedGrantTypes.RefreshToken, store, serializer, handleGenerationService, logger)
+            : base(IdentityServerConstants.PersistedGrantTypes.RefreshToken, identityServerOptions, store, serializer, handleGenerationService, logger)
         {
         }
 

--- a/src/IdentityServer/Stores/Default/DefaultUserConsentStore.cs
+++ b/src/IdentityServer/Stores/Default/DefaultUserConsentStore.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 
@@ -7,6 +7,7 @@ using Duende.IdentityServer.Services;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Stores.Serialization;
 using Microsoft.Extensions.Logging;
+using Duende.IdentityServer.Configuration;
 
 namespace Duende.IdentityServer.Stores
 {
@@ -18,16 +19,18 @@ namespace Duende.IdentityServer.Stores
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultUserConsentStore"/> class.
         /// </summary>
+        /// <param name="identityServerOptions"></param>
         /// <param name="store">The store.</param>
         /// <param name="serializer">The serializer.</param>
         /// <param name="handleGenerationService">The handle generation service.</param>
         /// <param name="logger">The logger.</param>
         public DefaultUserConsentStore(
+            IdentityServerOptions identityServerOptions,
             IPersistedGrantStore store, 
             IPersistentGrantSerializer serializer,
             IHandleGenerationService handleGenerationService,
             ILogger<DefaultUserConsentStore> logger) 
-            : base(IdentityServerConstants.PersistedGrantTypes.UserConsent, store, serializer, handleGenerationService, logger)
+            : base(IdentityServerConstants.PersistedGrantTypes.UserConsent, identityServerOptions, store, serializer, handleGenerationService, logger)
         {
         }
 

--- a/test/IdentityServer.UnitTests/Common/TestUserConsentStore.cs
+++ b/test/IdentityServer.UnitTests/Common/TestUserConsentStore.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 
@@ -18,6 +18,7 @@ namespace UnitTests.Common
         public TestUserConsentStore()
         {
             _userConsentStore = new DefaultUserConsentStore(
+                new Duende.IdentityServer.Configuration.IdentityServerOptions(),
                _grantStore,
                new PersistentGrantSerializer(),
                 new DefaultHandleGenerationService(),

--- a/test/IdentityServer.UnitTests/Services/Default/DefaultPersistedGrantServiceTests.cs
+++ b/test/IdentityServer.UnitTests/Services/Default/DefaultPersistedGrantServiceTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Duende.IdentityServer;
+using Duende.IdentityServer.Configuration;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services;
 using Duende.IdentityServer.Stores;
@@ -26,6 +27,7 @@ namespace UnitTests.Services.Default
         private IRefreshTokenStore _refreshTokens;
         private IReferenceTokenStore _referenceTokens;
         private IUserConsentStore _userConsent;
+        private IdentityServerOptions _options = new IdentityServerOptions();
 
         private ClaimsPrincipal _user = new IdentityServerUser("123").CreatePrincipal();
 
@@ -35,19 +37,26 @@ namespace UnitTests.Services.Default
                 _store, 
                 new PersistentGrantSerializer(), 
                 TestLogger.Create<DefaultPersistedGrantService>());
-            _codes = new DefaultAuthorizationCodeStore(_store,
+            _codes = new DefaultAuthorizationCodeStore(
+                _options, 
+                _store,
                 new PersistentGrantSerializer(),
                 new DefaultHandleGenerationService(),
                 TestLogger.Create<DefaultAuthorizationCodeStore>());
-            _refreshTokens = new DefaultRefreshTokenStore(_store,
+            _refreshTokens = new DefaultRefreshTokenStore(
+                _options, 
+                _store,
                 new PersistentGrantSerializer(),
                 new DefaultHandleGenerationService(),
                 TestLogger.Create<DefaultRefreshTokenStore>());
-            _referenceTokens = new DefaultReferenceTokenStore(_store,
+            _referenceTokens = new DefaultReferenceTokenStore(_options, 
+                _store,
                 new PersistentGrantSerializer(),
                 new DefaultHandleGenerationService(),
                 TestLogger.Create<DefaultReferenceTokenStore>());
-            _userConsent = new DefaultUserConsentStore(_store,
+            _userConsent = new DefaultUserConsentStore(
+                _options,
+                _store,
                 new PersistentGrantSerializer(),
                 new DefaultHandleGenerationService(),
                 TestLogger.Create<DefaultUserConsentStore>());

--- a/test/IdentityServer.UnitTests/Services/Default/DefaultRefreshTokenServiceTests.cs
+++ b/test/IdentityServer.UnitTests/Services/Default/DefaultRefreshTokenServiceTests.cs
@@ -14,6 +14,7 @@ using Duende.IdentityServer.Stores.Serialization;
 using FluentAssertions;
 using UnitTests.Validation.Setup;
 using Xunit;
+using Duende.IdentityServer.Configuration;
 
 namespace UnitTests.Services.Default
 {
@@ -21,6 +22,7 @@ namespace UnitTests.Services.Default
     {
         private DefaultRefreshTokenService _subject;
         private DefaultRefreshTokenStore _store;
+        private IdentityServerOptions _options = new IdentityServerOptions();
 
         private ClaimsPrincipal _user = new IdentityServerUser("123").CreatePrincipal();
         private StubClock _clock = new StubClock();
@@ -28,6 +30,7 @@ namespace UnitTests.Services.Default
         public DefaultRefreshTokenServiceTests()
         {
             _store = new DefaultRefreshTokenStore(
+                _options,
                 new InMemoryPersistedGrantStore(),
                 new PersistentGrantSerializer(),
                 new DefaultHandleGenerationService(),

--- a/test/IdentityServer.UnitTests/Stores/Default/DefaultPersistedGrantStoreTests.cs
+++ b/test/IdentityServer.UnitTests/Stores/Default/DefaultPersistedGrantStoreTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Duende.IdentityServer;
+using Duende.IdentityServer.Configuration;
 using Duende.IdentityServer.Extensions;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Stores;
@@ -26,24 +27,29 @@ namespace UnitTests.Stores.Default
         private IReferenceTokenStore _referenceTokens;
         private IUserConsentStore _userConsent;
         private StubHandleGenerationService _stubHandleGenerationService = new StubHandleGenerationService();
+        private IdentityServerOptions _options = new IdentityServerOptions();
 
         private ClaimsPrincipal _user = new IdentityServerUser("123").CreatePrincipal();
 
         public DefaultPersistedGrantStoreTests()
         {
-            _codes = new DefaultAuthorizationCodeStore(_store,
+            _codes = new DefaultAuthorizationCodeStore(_options, 
+                _store,
                 new PersistentGrantSerializer(),
                 _stubHandleGenerationService,
                 TestLogger.Create<DefaultAuthorizationCodeStore>());
-            _refreshTokens = new DefaultRefreshTokenStore(_store,
+            _refreshTokens = new DefaultRefreshTokenStore(_options, 
+                _store,
                 new PersistentGrantSerializer(),
                 _stubHandleGenerationService,
                 TestLogger.Create<DefaultRefreshTokenStore>());
-            _referenceTokens = new DefaultReferenceTokenStore(_store,
+            _referenceTokens = new DefaultReferenceTokenStore(_options, 
+                _store,
                 new PersistentGrantSerializer(),
                 _stubHandleGenerationService,
                 TestLogger.Create<DefaultReferenceTokenStore>());
-            _userConsent = new DefaultUserConsentStore(_store,
+            _userConsent = new DefaultUserConsentStore(_options, 
+                _store,
                 new PersistentGrantSerializer(),
                 _stubHandleGenerationService,
                 TestLogger.Create<DefaultUserConsentStore>());
@@ -375,10 +381,10 @@ namespace UnitTests.Stores.Default
                 RequestedScopes = new string[] { "quux1", "quux2" }
             });
 
-            // the -1 is needed because internally we append a version/suffix the handle for encoding
-            (await _codes.GetAuthorizationCodeAsync("key-1")).Lifetime.Should().Be(30);
-            (await _refreshTokens.GetRefreshTokenAsync("key-1")).Lifetime.Should().Be(20);
-            (await _referenceTokens.GetReferenceTokenAsync("key-1")).Lifetime.Should().Be(10);
+            // the suffix is needed because internally we append a version/suffix the handle for encoding
+            (await _codes.GetAuthorizationCodeAsync("key" + _options.GrantVersionDelimiter + "1")).Lifetime.Should().Be(30);
+            (await _refreshTokens.GetRefreshTokenAsync("key" + _options.GrantVersionDelimiter + "1")).Lifetime.Should().Be(20);
+            (await _referenceTokens.GetReferenceTokenAsync("key" + _options.GrantVersionDelimiter + "1")).Lifetime.Should().Be(10);
         }
     }
 }

--- a/test/IdentityServer.UnitTests/Validation/Setup/Factory.cs
+++ b/test/IdentityServer.UnitTests/Validation/Setup/Factory.cs
@@ -88,12 +88,12 @@ namespace UnitTests.Validation.Setup
 
             if (authorizationCodeStore == null)
             {
-                authorizationCodeStore = CreateAuthorizationCodeStore();
+                authorizationCodeStore = CreateAuthorizationCodeStore(options);
             }
 
             if (refreshTokenStore == null)
             {
-                refreshTokenStore = CreateRefreshTokenStore();
+                refreshTokenStore = CreateRefreshTokenStore(options);
             }
 
             if (resourceValidator == null)
@@ -344,25 +344,37 @@ namespace UnitTests.Validation.Setup
             return new ClientSecretValidator(clients, parser, validator, new TestEventService(), TestLogger.Create<ClientSecretValidator>());
         }
 
-        public static IAuthorizationCodeStore CreateAuthorizationCodeStore()
+        public static IAuthorizationCodeStore CreateAuthorizationCodeStore(IdentityServerOptions options = null)
         {
-            return new DefaultAuthorizationCodeStore(new InMemoryPersistedGrantStore(),
+            options ??= new IdentityServerOptions();
+            
+            return new DefaultAuthorizationCodeStore(
+                options,
+                new InMemoryPersistedGrantStore(),
                 new PersistentGrantSerializer(),
                 new DefaultHandleGenerationService(),
                 TestLogger.Create<DefaultAuthorizationCodeStore>());
         }
         
-        public static IRefreshTokenStore CreateRefreshTokenStore()
+        public static IRefreshTokenStore CreateRefreshTokenStore(IdentityServerOptions options = null)
         {
-            return new DefaultRefreshTokenStore(new InMemoryPersistedGrantStore(),
+            options ??= new IdentityServerOptions();
+            
+            return new DefaultRefreshTokenStore(
+                options,
+                new InMemoryPersistedGrantStore(),
                 new PersistentGrantSerializer(),
                 new DefaultHandleGenerationService(),
                 TestLogger.Create<DefaultRefreshTokenStore>());
         }
         
-        public static IReferenceTokenStore CreateReferenceTokenStore()
+        public static IReferenceTokenStore CreateReferenceTokenStore(IdentityServerOptions options = null)
         {
-            return new DefaultReferenceTokenStore(new InMemoryPersistedGrantStore(),
+            options ??= new IdentityServerOptions();
+            
+            return new DefaultReferenceTokenStore(
+                options,
+                new InMemoryPersistedGrantStore(),
                 new PersistentGrantSerializer(),
                 new DefaultHandleGenerationService(),
                 TestLogger.Create<DefaultReferenceTokenStore>());
@@ -373,9 +385,13 @@ namespace UnitTests.Validation.Setup
             return new DefaultDeviceFlowCodeService(new InMemoryDeviceFlowStore(), new DefaultHandleGenerationService());
         }
         
-        public static IUserConsentStore CreateUserConsentStore()
+        public static IUserConsentStore CreateUserConsentStore(IdentityServerOptions options = null)
         {
-            return new DefaultUserConsentStore(new InMemoryPersistedGrantStore(),
+            options ??= new IdentityServerOptions();
+
+            return new DefaultUserConsentStore(
+                options,
+                new InMemoryPersistedGrantStore(),
                 new PersistentGrantSerializer(),
                 new DefaultHandleGenerationService(),
                 TestLogger.Create<DefaultUserConsentStore>());


### PR DESCRIPTION
It might make sense to make the grant version delimiter configurable in the case where a custom token handle generator service uses characters that conflict with our default. 