### PR TITLE
Suppress EF warning about split query behavior

### DIFF
--- a/hosts/EntityFramework/Startup.cs
+++ b/hosts/EntityFramework/Startup.cs
@@ -31,15 +31,12 @@ namespace IdentityServerHost
                 // this adds the config data from DB (clients, resources, CORS)
                 .AddConfigurationStore(options =>
                 {
-                    options.ConfigureDbContext = builder =>
-                        builder.UseSqlServer(connectionString)
-                            .ConfigureWarnings(w => w.Ignore(new EventId[] { RelationalEventId.MultipleCollectionIncludeWarning }));
+                    options.ConfigureDbContext = builder => builder.UseSqlServer(connectionString);
                 })
                 // this adds the operational data from DB (codes, tokens, consents)
                 .AddOperationalStore(options =>
                 {
-                    options.ConfigureDbContext = builder => builder.UseSqlServer(connectionString)
-                        .ConfigureWarnings(w => w.Ignore(new EventId[] { RelationalEventId.MultipleCollectionIncludeWarning }));
+                    options.ConfigureDbContext = builder => builder.UseSqlServer(connectionString);
 
                     // this enables automatic token cleanup. this is optional.
                     options.EnableTokenCleanup = true;

--- a/src/EntityFramework.Storage/DbContexts/ConfigurationDbContext.cs
+++ b/src/EntityFramework.Storage/DbContexts/ConfigurationDbContext.cs
@@ -8,7 +8,9 @@ using Duende.IdentityServer.EntityFramework.Extensions;
 using Duende.IdentityServer.EntityFramework.Interfaces;
 using Duende.IdentityServer.EntityFramework.Options;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.Logging;
 
 namespace Duende.IdentityServer.EntityFramework.DbContexts
 {
@@ -123,6 +125,13 @@ namespace Duende.IdentityServer.EntityFramework.DbContexts
             modelBuilder.ConfigureIdentityProviderContext(storeOptions);
 
             base.OnModelCreating(modelBuilder);
+        }
+
+        /// <inheritdoc/>
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            base.OnConfiguring(optionsBuilder);
+            optionsBuilder.ConfigureWarnings(w => w.Ignore(new EventId[] { RelationalEventId.MultipleCollectionIncludeWarning }));
         }
     }
 }


### PR DESCRIPTION
Now with split queries as a feature in EF, if your query is not explicit on the behavior then EF emits a warning. This suppresses the warning in the DbContext itself.

This [issue](https://github.com/DuendeSoftware/IdentityServer/issues/298) is relevant.