### PR TITLE
Reduce usage of HttpContext extension methods

### DIFF
--- a/hosts/AspNetIdentity/Pages/Extensions.cs
+++ b/hosts/AspNetIdentity/Pages/Extensions.cs
@@ -3,14 +3,28 @@
 
 
 using System;
+using System.Threading.Tasks;
 using Duende.IdentityServer.Models;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace IdentityServerHost.Pages
 {
     public static class Extensions
     {
+        /// <summary>
+        /// Determines if the scheme support signout.
+        /// </summary>
+        public static async Task<bool> GetSchemeSupportsSignOutAsync(this HttpContext context, string scheme)
+        {
+            var provider = context.RequestServices.GetRequiredService<IAuthenticationHandlerProvider>();
+            var handler = await provider.GetHandlerAsync(context, scheme);
+            return (handler is IAuthenticationSignOutHandler);
+        }
+        
         /// <summary>
         /// Checks if the redirect URI is for a native client.
         /// </summary>

--- a/hosts/EntityFramework/Pages/Extensions.cs
+++ b/hosts/EntityFramework/Pages/Extensions.cs
@@ -3,14 +3,28 @@
 
 
 using System;
+using System.Threading.Tasks;
 using Duende.IdentityServer.Models;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace IdentityServerHost.Pages
 {
     public static class Extensions
     {
+        /// <summary>
+        /// Determines if the scheme support signout.
+        /// </summary>
+        public static async Task<bool> GetSchemeSupportsSignOutAsync(this HttpContext context, string scheme)
+        {
+            var provider = context.RequestServices.GetRequiredService<IAuthenticationHandlerProvider>();
+            var handler = await provider.GetHandlerAsync(context, scheme);
+            return (handler is IAuthenticationSignOutHandler);
+        }
+        
         /// <summary>
         /// Checks if the redirect URI is for a native client.
         /// </summary>

--- a/hosts/main/Pages/Consent/InputModel.cs
+++ b/hosts/main/Pages/Consent/InputModel.cs
@@ -3,7 +3,6 @@
 
 
 using System.Collections.Generic;
-using System.Linq;
 
 namespace IdentityServerHost.Pages.Consent
 {

--- a/hosts/main/Pages/Device/InputModel.cs
+++ b/hosts/main/Pages/Device/InputModel.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 
 namespace IdentityServerHost.Pages.Device
 {

--- a/hosts/main/Pages/Extensions.cs
+++ b/hosts/main/Pages/Extensions.cs
@@ -3,14 +3,28 @@
 
 
 using System;
+using System.Threading.Tasks;
 using Duende.IdentityServer.Models;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace IdentityServerHost.Pages
 {
     public static class Extensions
     {
+        /// <summary>
+        /// Determines if the authentication scheme support signout.
+        /// </summary>
+        public static async Task<bool> GetSchemeSupportsSignOutAsync(this HttpContext context, string scheme)
+        {
+            var provider = context.RequestServices.GetRequiredService<IAuthenticationHandlerProvider>();
+            var handler = await provider.GetHandlerAsync(context, scheme);
+            return (handler is IAuthenticationSignOutHandler);
+        }
+
         /// <summary>
         /// Checks if the redirect URI is for a native client.
         /// </summary>
@@ -27,7 +41,7 @@ namespace IdentityServerHost.Pages
         {
             page.HttpContext.Response.StatusCode = 200;
             page.HttpContext.Response.Headers["Location"] = "";
-            
+
             return page.RedirectToPage("/Redirect/Index", new { RedirectUri = redirectUri });
         }
     }

--- a/hosts/main/Pages/SecurityHeadersAttribute.cs
+++ b/hosts/main/Pages/SecurityHeadersAttribute.cs
@@ -2,7 +2,6 @@
 // See LICENSE in the project root for license information.
 
 
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 

--- a/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -123,6 +123,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns></returns>
         public static IIdentityServerBuilder AddCoreServices(this IIdentityServerBuilder builder)
         {
+            builder.Services.AddTransient<IServerUrls, DefaultServerUrls>();
             builder.Services.AddTransient<IIssuerNameService, DefaultIssuerNameService>();
             builder.Services.AddTransient<ISecretsListParser, SecretParser>();
             builder.Services.AddTransient<ISecretsListValidator, SecretValidator>();

--- a/src/IdentityServer/Endpoints/DeviceAuthorizationEndpoint.cs
+++ b/src/IdentityServer/Endpoints/DeviceAuthorizationEndpoint.cs
@@ -84,12 +84,9 @@ namespace Duende.IdentityServer.Endpoints
                 return Error(requestResult.Error, requestResult.ErrorDescription);
             }
 
-            // TODO: why do we need EnsureTrailingSlash?
-            var baseUrl = _urls.BaseUrl.EnsureTrailingSlash();
-
             // create response
             _logger.LogTrace("Calling into device authorize response generator: {type}", _responseGenerator.GetType().FullName);
-            var response = await _responseGenerator.ProcessAsync(requestResult, baseUrl);
+            var response = await _responseGenerator.ProcessAsync(requestResult, _urls.BaseUrl);
 
             await _events.RaiseAsync(new DeviceAuthorizationSuccessEvent(response, requestResult));
 

--- a/src/IdentityServer/Endpoints/DeviceAuthorizationEndpoint.cs
+++ b/src/IdentityServer/Endpoints/DeviceAuthorizationEndpoint.cs
@@ -27,6 +27,7 @@ namespace Duende.IdentityServer.Endpoints
         private readonly IDeviceAuthorizationRequestValidator _requestValidator;
         private readonly IDeviceAuthorizationResponseGenerator _responseGenerator;
         private readonly IEventService _events;
+        private readonly IServerUrls _urls;
         private readonly ILogger<DeviceAuthorizationEndpoint> _logger;
 
         public DeviceAuthorizationEndpoint(
@@ -34,12 +35,14 @@ namespace Duende.IdentityServer.Endpoints
             IDeviceAuthorizationRequestValidator requestValidator,
             IDeviceAuthorizationResponseGenerator responseGenerator,
             IEventService events,
+            IServerUrls urls,
             ILogger<DeviceAuthorizationEndpoint> logger)
         {
             _clientValidator = clientValidator;
             _requestValidator = requestValidator;
             _responseGenerator = responseGenerator;
             _events = events;
+            _urls = urls;
             _logger = logger;
         }
 
@@ -81,7 +84,8 @@ namespace Duende.IdentityServer.Endpoints
                 return Error(requestResult.Error, requestResult.ErrorDescription);
             }
 
-            var baseUrl = context.GetIdentityServerBaseUrl().EnsureTrailingSlash();
+            // TODO: why do we need EnsureTrailingSlash?
+            var baseUrl = _urls.BaseUrl.EnsureTrailingSlash();
 
             // create response
             _logger.LogTrace("Calling into device authorize response generator: {type}", _responseGenerator.GetType().FullName);

--- a/src/IdentityServer/Endpoints/DiscoveryEndpoint.cs
+++ b/src/IdentityServer/Endpoints/DiscoveryEndpoint.cs
@@ -7,7 +7,6 @@ using Duende.IdentityServer.Configuration;
 using Duende.IdentityServer.Endpoints.Results;
 using Duende.IdentityServer.Hosting;
 using Duende.IdentityServer.ResponseHandling;
-using Duende.IdentityServer.Extensions;
 using Duende.IdentityServer.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
@@ -20,17 +19,20 @@ namespace Duende.IdentityServer.Endpoints
 
         private readonly IdentityServerOptions _options;
         private readonly IIssuerNameService _issuerNameService;
+        private readonly IServerUrls _urls;
         private readonly IDiscoveryResponseGenerator _responseGenerator;
 
         public DiscoveryEndpoint(
             IdentityServerOptions options,
             IIssuerNameService issuerNameService,
             IDiscoveryResponseGenerator responseGenerator,
+            IServerUrls urls,
             ILogger<DiscoveryEndpoint> logger)
         {
             _logger = logger;
             _options = options;
             _issuerNameService = issuerNameService;
+            _urls = urls;
             _responseGenerator = responseGenerator;
         }
 
@@ -53,7 +55,7 @@ namespace Duende.IdentityServer.Endpoints
                 return new StatusCodeResult(HttpStatusCode.NotFound);
             }
 
-            var baseUrl = context.GetIdentityServerBaseUrl().EnsureTrailingSlash();
+            var baseUrl = _urls.BaseUrl;
             var issuerUri = await _issuerNameService.GetCurrentAsync();
 
             // generate response

--- a/src/IdentityServer/Endpoints/Results/AuthorizeResult.cs
+++ b/src/IdentityServer/Endpoints/Results/AuthorizeResult.cs
@@ -33,18 +33,21 @@ namespace Duende.IdentityServer.Endpoints.Results
             IdentityServerOptions options,
             IUserSession userSession,
             IMessageStore<ErrorMessage> errorMessageStore,
+            IServerUrls urls,
             ISystemClock clock)
             : this(response)
         {
             _options = options;
             _userSession = userSession;
             _errorMessageStore = errorMessageStore;
+            _urls = urls;
             _clock = clock;
         }
 
         private IdentityServerOptions _options;
         private IUserSession _userSession;
         private IMessageStore<ErrorMessage> _errorMessageStore;
+        private IServerUrls _urls;
         private ISystemClock _clock;
 
         private void Init(HttpContext context)
@@ -52,6 +55,7 @@ namespace Duende.IdentityServer.Endpoints.Results
             _options ??= context.RequestServices.GetRequiredService<IdentityServerOptions>();
             _userSession ??= context.RequestServices.GetRequiredService<IUserSession>();
             _errorMessageStore ??= context.RequestServices.GetRequiredService<IMessageStore<ErrorMessage>>();
+            _urls = _urls ?? context.RequestServices.GetRequiredService<IServerUrls>();
             _clock ??= context.RequestServices.GetRequiredService<ISystemClock>();
         }
 
@@ -199,7 +203,7 @@ namespace Duende.IdentityServer.Endpoints.Results
             var errorUrl = _options.UserInteraction.ErrorUrl;
 
             var url = errorUrl.AddQueryString(_options.UserInteraction.ErrorIdParameter, id);
-            context.Response.RedirectToAbsoluteUrl(url);
+            context.Response.Redirect(_urls.GetAbsoluteUrl(url));
         }
     }
 }

--- a/src/IdentityServer/Endpoints/Results/ConsentPageResult.cs
+++ b/src/IdentityServer/Endpoints/Results/ConsentPageResult.cs
@@ -13,6 +13,7 @@ using Duende.IdentityServer.Validation;
 using Microsoft.AspNetCore.Http;
 using Duende.IdentityServer.Extensions;
 using Microsoft.Extensions.DependencyInjection;
+using Duende.IdentityServer.Services;
 
 namespace Duende.IdentityServer.Endpoints.Results
 {
@@ -37,19 +38,23 @@ namespace Duende.IdentityServer.Endpoints.Results
         internal ConsentPageResult(
             ValidatedAuthorizeRequest request,
             IdentityServerOptions options,
+            IServerUrls urls,
             IAuthorizationParametersMessageStore authorizationParametersMessageStore = null) 
             : this(request)
         {
             _options = options;
+            _urls = urls;
             _authorizationParametersMessageStore = authorizationParametersMessageStore;
         }
 
         private IdentityServerOptions _options;
+        private IServerUrls _urls;
         private IAuthorizationParametersMessageStore _authorizationParametersMessageStore;
 
         private void Init(HttpContext context)
         {
             _options = _options ?? context.RequestServices.GetRequiredService<IdentityServerOptions>();
+            _urls = _urls ?? context.RequestServices.GetRequiredService<IServerUrls>();
             _authorizationParametersMessageStore = _authorizationParametersMessageStore ?? context.RequestServices.GetService<IAuthorizationParametersMessageStore>();
         }
 
@@ -62,7 +67,7 @@ namespace Duende.IdentityServer.Endpoints.Results
         {
             Init(context);
 
-            var returnUrl = context.GetIdentityServerBasePath().EnsureTrailingSlash() + Constants.ProtocolRoutePaths.AuthorizeCallback;
+            var returnUrl = _urls.BasePath.EnsureTrailingSlash() + Constants.ProtocolRoutePaths.AuthorizeCallback;
             if (_authorizationParametersMessageStore != null)
             {
                 var msg = new Message<IDictionary<string, string[]>>(_request.ToOptimizedFullDictionary());
@@ -79,11 +84,11 @@ namespace Duende.IdentityServer.Endpoints.Results
             {
                 // this converts the relative redirect path to an absolute one if we're 
                 // redirecting to a different server
-                returnUrl = context.GetIdentityServerHost().EnsureTrailingSlash() + returnUrl.RemoveLeadingSlash();
+                returnUrl = _urls.Origin + returnUrl;
             }
 
             var url = consentUrl.AddQueryString(_options.UserInteraction.ConsentReturnUrlParameter, returnUrl);
-            context.Response.RedirectToAbsoluteUrl(url);
+            context.Response.Redirect(_urls.GetAbsoluteUrl(url));
         }
     }
 }

--- a/src/IdentityServer/Endpoints/Results/EndSessionResult.cs
+++ b/src/IdentityServer/Endpoints/Results/EndSessionResult.cs
@@ -13,6 +13,7 @@ using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Stores;
 using Duende.IdentityServer.Validation;
 using Microsoft.AspNetCore.Authentication;
+using Duende.IdentityServer.Services;
 
 namespace Duende.IdentityServer.Endpoints.Results
 {
@@ -38,22 +39,26 @@ namespace Duende.IdentityServer.Endpoints.Results
             EndSessionValidationResult result,
             IdentityServerOptions options,
             ISystemClock clock,
+            IServerUrls urls,
             IMessageStore<LogoutMessage> logoutMessageStore)
             : this(result)
         {
             _options = options;
             _clock = clock;
+            _urls = urls;
             _logoutMessageStore = logoutMessageStore;
         }
 
         private IdentityServerOptions _options;
         private ISystemClock _clock;
+        private IServerUrls _urls;
         private IMessageStore<LogoutMessage> _logoutMessageStore;
 
         private void Init(HttpContext context)
         {
             _options = _options ?? context.RequestServices.GetRequiredService<IdentityServerOptions>();
             _clock = _clock ?? context.RequestServices.GetRequiredService<ISystemClock>();
+            _urls = _urls ?? context.RequestServices.GetRequiredService<IServerUrls>();
             _logoutMessageStore = _logoutMessageStore ?? context.RequestServices.GetRequiredService<IMessageStore<LogoutMessage>>();
         }
 
@@ -84,7 +89,7 @@ namespace Duende.IdentityServer.Endpoints.Results
 
             if (redirect.IsLocalUrl())
             {
-                redirect = context.GetIdentityServerRelativeUrl(redirect);
+                redirect = _urls.GetIdentityServerRelativeUrl(redirect);
             }
 
             if (id != null)

--- a/src/IdentityServer/Extensions/HttpContextAuthenticationExtensions.cs
+++ b/src/IdentityServer/Extensions/HttpContextAuthenticationExtensions.cs
@@ -39,11 +39,6 @@ namespace Microsoft.AspNetCore.Http
             await context.SignInAsync(await context.GetCookieAuthenticationSchemeAsync(), user.CreatePrincipal(), properties);
         }
 
-        internal static ISystemClock GetClock(this HttpContext context)
-        {
-            return context.RequestServices.GetRequiredService<ISystemClock>();
-        }
-
         internal static async Task<string> GetCookieAuthenticationSchemeAsync(this HttpContext context)
         {
             var options = context.RequestServices.GetRequiredService<IdentityServerOptions>();

--- a/src/IdentityServer/Extensions/HttpContextExtensions.cs
+++ b/src/IdentityServer/Extensions/HttpContextExtensions.cs
@@ -19,6 +19,7 @@ namespace Duende.IdentityServer.Extensions
 {
     public static class HttpContextExtensions
     {
+        [Obsolete("For a replacement, see here: xxx")]
         public static async Task<bool> GetSchemeSupportsSignOutAsync(this HttpContext context, string scheme)
         {
             var provider = context.RequestServices.GetRequiredService<IAuthenticationHandlerProvider>();
@@ -26,25 +27,22 @@ namespace Duende.IdentityServer.Extensions
             return (handler is IAuthenticationSignOutHandler);
         }
 
+        [Obsolete("Use IServerUrls.Origin instead.")]
         public static void SetIdentityServerOrigin(this HttpContext context, string value)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
-            if (value == null) throw new ArgumentNullException(nameof(value));
-
-            var split = value.Split(new[] { "://" }, StringSplitOptions.RemoveEmptyEntries);
-
-            var request = context.Request;
-            request.Scheme = split.First();
-            request.Host = new HostString(split.Last());
+            context.RequestServices.GetRequiredService<IServerUrls>().Origin = value;
         }
 
+        [Obsolete("Use IServerUrls.BasePath instead.")]
         public static void SetIdentityServerBasePath(this HttpContext context, string value)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
-
-            context.Items[Constants.EnvironmentKeys.IdentityServerBasePath] = value;
+            context.RequestServices.GetRequiredService<IServerUrls>().BasePath = value;
         }
 
+        [Obsolete("Use IIssuerNameService instead.")]
+        // TODO: unused now, remove in v7
         public static string GetIdentityServerOrigin(this HttpContext context)
         {
             var options = context.RequestServices.GetRequiredService<IdentityServerOptions>();
@@ -82,10 +80,10 @@ namespace Duende.IdentityServer.Extensions
         /// </summary>
         /// <param name="context">The context.</param>
         /// <returns></returns>
+        [Obsolete("Use IServerUrls.Origin instead.")]
         public static string GetIdentityServerHost(this HttpContext context)
         {
-            var request = context.Request;
-            return request.Scheme + "://" + request.Host.ToUriComponent();
+            return context.RequestServices.GetRequiredService<IServerUrls>().Origin;
         }
 
         /// <summary>
@@ -93,9 +91,10 @@ namespace Duende.IdentityServer.Extensions
         /// </summary>
         /// <param name="context">The context.</param>
         /// <returns></returns>
+        [Obsolete("Use IServerUrls.BasePath instead.")]
         public static string GetIdentityServerBasePath(this HttpContext context)
         {
-            return context.Items[Constants.EnvironmentKeys.IdentityServerBasePath] as string;
+            return context.RequestServices.GetRequiredService<IServerUrls>().BasePath;
         }
 
         /// <summary>
@@ -103,9 +102,10 @@ namespace Duende.IdentityServer.Extensions
         /// </summary>
         /// <param name="context">The context.</param>
         /// <returns></returns>
+        [Obsolete("Use IServerUrls.BaseUrl instead.")]
         public static string GetIdentityServerBaseUrl(this HttpContext context)
         {
-            return context.GetIdentityServerHost() + context.GetIdentityServerBasePath();
+            return context.RequestServices.GetRequiredService<IServerUrls>().BaseUrl;
         }
 
         /// <summary>
@@ -114,16 +114,10 @@ namespace Duende.IdentityServer.Extensions
         /// <param name="context">The context.</param>
         /// <param name="path">The path.</param>
         /// <returns></returns>
+        [Obsolete("Use IServerUrls.GetIdentityServerRelativeUrl instead.")]
         public static string GetIdentityServerRelativeUrl(this HttpContext context, string path)
         {
-            if (!path.IsLocalUrl())
-            {
-                return null;
-            }
-
-            if (path.StartsWith("~/")) path = path.Substring(1);
-            path = context.GetIdentityServerBaseUrl().EnsureTrailingSlash() + path.RemoveLeadingSlash();
-            return path;
+            return context.RequestServices.GetRequiredService<IServerUrls>().GetIdentityServerRelativeUrl(path);
         }
 
         /// <summary>
@@ -132,25 +126,12 @@ namespace Duende.IdentityServer.Extensions
         /// <param name="context">The context.</param>
         /// <returns></returns>
         /// <exception cref="System.ArgumentNullException">context</exception>
+        [Obsolete("Use the IIssuerNameService instead.")]
         public static string GetIdentityServerIssuerUri(this HttpContext context)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
-
-            // if they've explicitly configured a URI then use it,
-            // otherwise dynamically calculate it
-            var options = context.RequestServices.GetRequiredService<IdentityServerOptions>();
-            var uri = options.IssuerUri;
-            if (uri.IsMissing())
-            {
-                uri = context.GetIdentityServerOrigin() + context.GetIdentityServerBasePath();
-                if (uri.EndsWith("/")) uri = uri.Substring(0, uri.Length - 1);
-                if (options.LowerCaseIssuerUri)
-                {
-                    uri = uri.ToLowerInvariant();
-                }
-            }
-
-            return uri;
+            // TODO: why did we make the IIssuerNameService async????
+            return context.RequestServices.GetRequiredService<IIssuerNameService>().GetCurrentAsync().GetAwaiter().GetResult();
         }
 
         internal static async Task<string> GetIdentityServerSignoutFrameCallbackUrlAsync(this HttpContext context, LogoutMessage logoutMessage = null)
@@ -203,7 +184,8 @@ namespace Duende.IdentityServer.Extensions
                 var endSessionMessageStore = context.RequestServices.GetRequiredService<IMessageStore<LogoutNotificationContext>>();
                 var id = await endSessionMessageStore.WriteAsync(msg);
 
-                var signoutIframeUrl = context.GetIdentityServerBaseUrl().EnsureTrailingSlash() + Constants.ProtocolRoutePaths.EndSessionCallback;
+                var urls = context.RequestServices.GetRequiredService<IServerUrls>();
+                var signoutIframeUrl = urls.BaseUrl.EnsureTrailingSlash() + Constants.ProtocolRoutePaths.EndSessionCallback;
                 signoutIframeUrl = signoutIframeUrl.AddQueryString(Constants.UIConstants.DefaultRoutePathParams.EndSessionCallback, id);
 
                 return signoutIframeUrl;

--- a/src/IdentityServer/Extensions/HttpContextExtensions.cs
+++ b/src/IdentityServer/Extensions/HttpContextExtensions.cs
@@ -42,7 +42,6 @@ namespace Duende.IdentityServer.Extensions
         }
 
         [Obsolete("Use IIssuerNameService instead.")]
-        // TODO: unused now, remove in v7
         public static string GetIdentityServerOrigin(this HttpContext context)
         {
             var options = context.RequestServices.GetRequiredService<IdentityServerOptions>();
@@ -130,7 +129,6 @@ namespace Duende.IdentityServer.Extensions
         public static string GetIdentityServerIssuerUri(this HttpContext context)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
-            // TODO: why did we make the IIssuerNameService async????
             return context.RequestServices.GetRequiredService<IIssuerNameService>().GetCurrentAsync().GetAwaiter().GetResult();
         }
 

--- a/src/IdentityServer/Extensions/HttpResponseExtensions.cs
+++ b/src/IdentityServer/Extensions/HttpResponseExtensions.cs
@@ -8,6 +8,9 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Duende.IdentityServer.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Duende.IdentityServer.Services;
+using System;
 
 #pragma warning disable 1591
 
@@ -78,13 +81,10 @@ namespace Duende.IdentityServer.Extensions
             await response.Body.FlushAsync();
         }
 
+        [Obsolete("Use IServerUrls.GetAbsoluteUrl instead.")]
         public static void RedirectToAbsoluteUrl(this HttpResponse response, string url)
         {
-            if (url.IsLocalUrl())
-            {
-                if (url.StartsWith("~/")) url = url.Substring(1);
-                url = response.HttpContext.GetIdentityServerBaseUrl().EnsureTrailingSlash() + url.RemoveLeadingSlash();
-            }
+            url = response.HttpContext.RequestServices.GetRequiredService<IServerUrls>().GetAbsoluteUrl(url);
             response.Redirect(url);
         }
 

--- a/src/IdentityServer/Extensions/ServerUrlExtensions.cs
+++ b/src/IdentityServer/Extensions/ServerUrlExtensions.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+using Duende.IdentityServer.Services;
+using Microsoft.AspNetCore.Http;
+using System;
+using System.Linq;
+
+namespace Duende.IdentityServer.Extensions
+{
+    /// <summary>
+    /// Extension methods for IServerUrls
+    /// </summary>
+    public static class ServerUrlExtensions
+    {
+        /// <summary>
+        /// Returns the origin in unicode, and not in punycode (if we have a unicode hostname)
+        /// </summary>
+        public static string GetUnicodeOrigin(this IServerUrls urls)
+        {
+            var split = urls.Origin.Split(new[] { "://" }, StringSplitOptions.RemoveEmptyEntries);
+            var scheme = split.First();
+            var host = HostString.FromUriComponent(split.Last()).Value;
+            
+            return scheme + "://" + host;
+        }
+
+        /// <summary>
+        /// Returns an absolute URL for the URL or path.
+        /// </summary>
+        public static string GetAbsoluteUrl(this IServerUrls urls, string urlOrPath)
+        {
+            if (urlOrPath.IsLocalUrl())
+            {
+                if (urlOrPath.StartsWith("~/")) urlOrPath = urlOrPath.Substring(1);
+                urlOrPath = urls.BaseUrl + urlOrPath.EnsureLeadingSlash();
+            }
+            return urlOrPath;
+        }
+
+
+        /// <summary>
+        /// Returns the URL into the server based on the relative path. The path parameter can start with "~/" or "/".
+        /// </summary>
+        public static string GetIdentityServerRelativeUrl(this IServerUrls urls, string path)
+        {
+            if (!path.IsLocalUrl())
+            {
+                return null;
+            }
+
+            if (path.StartsWith("~/")) path = path.Substring(1);
+            path = urls.BaseUrl + path.EnsureLeadingSlash();
+            return path;
+        }
+    }
+}

--- a/src/IdentityServer/Extensions/StringsExtensions.cs
+++ b/src/IdentityServer/Extensions/StringsExtensions.cs
@@ -97,6 +97,7 @@ namespace Duende.IdentityServer.Extensions
             return url;
         }
 
+        // TODO: check usage and see if it's really needed
         [DebuggerStepThrough]
         public static string EnsureTrailingSlash(this string url)
         {

--- a/src/IdentityServer/Extensions/StringsExtensions.cs
+++ b/src/IdentityServer/Extensions/StringsExtensions.cs
@@ -97,7 +97,6 @@ namespace Duende.IdentityServer.Extensions
             return url;
         }
 
-        // TODO: check usage and see if it's really needed
         [DebuggerStepThrough]
         public static string EnsureTrailingSlash(this string url)
         {

--- a/src/IdentityServer/Hosting/BaseUrlMiddleware.cs
+++ b/src/IdentityServer/Hosting/BaseUrlMiddleware.cs
@@ -2,10 +2,10 @@
 // See LICENSE in the project root for license information.
 
 
-using Duende.IdentityServer.Extensions;
 using Microsoft.AspNetCore.Http;
 using System.Threading.Tasks;
-using Duende.IdentityServer.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Duende.IdentityServer.Services;
 
 #pragma warning disable 1591
 
@@ -14,19 +14,15 @@ namespace Duende.IdentityServer.Hosting
     public class BaseUrlMiddleware
     {
         private readonly RequestDelegate _next;
-        private readonly IdentityServerOptions _options;
 
-        public BaseUrlMiddleware(RequestDelegate next, IdentityServerOptions options)
+        public BaseUrlMiddleware(RequestDelegate next)
         {
             _next = next;
-            _options = options;
         }
 
         public async Task Invoke(HttpContext context)
         {
-            var request = context.Request;
-            
-            context.SetIdentityServerBasePath(request.PathBase.Value.RemoveTrailingSlash());
+            context.RequestServices.GetRequiredService<IServerUrls>().BasePath = context.Request.PathBase.Value;
 
             await _next(context);
         }

--- a/src/IdentityServer/Hosting/DynamicProviders/Configuration/ConfigureAuthenticationOptions.cs
+++ b/src/IdentityServer/Hosting/DynamicProviders/Configuration/ConfigureAuthenticationOptions.cs
@@ -33,6 +33,7 @@ namespace Duende.IdentityServer.Hosting.DynamicProviders
         /// <inheritdoc/>
         public void Configure(string name, TAuthenticationOptions options)
         {
+            // we have to resolve these here due to DI lifetime issues
             var providerOptions = _httpContextAccessor.HttpContext.RequestServices.GetRequiredService<DynamicProviderOptions>();
             var cache = _httpContextAccessor.HttpContext.RequestServices.GetRequiredService<DynamicAuthenticationSchemeCache>();
             

--- a/src/IdentityServer/Hosting/DynamicProviders/Oidc/OidcConfigureOptions.cs
+++ b/src/IdentityServer/Hosting/DynamicProviders/Oidc/OidcConfigureOptions.cs
@@ -5,7 +5,6 @@ using Duende.IdentityServer.Models;
 using IdentityModel;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Http;
-using System.IdentityModel.Tokens.Jwt;
 
 namespace Duende.IdentityServer.Hosting.DynamicProviders
 {

--- a/src/IdentityServer/Hosting/DynamicProviders/Store/CachingIdentityProviderStore.cs
+++ b/src/IdentityServer/Hosting/DynamicProviders/Store/CachingIdentityProviderStore.cs
@@ -88,6 +88,7 @@ namespace Duende.IdentityServer.Hosting.DynamicProviders
             if (provider != null)
             {
                 var optionsMonitorType = typeof(IOptionsMonitorCache<>).MakeGenericType(provider.OptionsType);
+                // need to resolve the provide type dynamically, thus the need for the http context accessor
                 var optionsCache = _httpContextAccessor.HttpContext.RequestServices.GetService(optionsMonitorType);
                 if (optionsCache != null)
                 {

--- a/src/IdentityServer/Infrastructure/MessageCookie.cs
+++ b/src/IdentityServer/Infrastructure/MessageCookie.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Security.Cryptography;
 using Duende.IdentityServer.Configuration;
 using Duende.IdentityServer.Models;
+using Duende.IdentityServer.Services;
 
 namespace Duende.IdentityServer
 {
@@ -20,17 +21,20 @@ namespace Duende.IdentityServer
         private readonly ILogger _logger;
         private readonly IdentityServerOptions _options;
         private readonly IHttpContextAccessor _context;
+        private readonly IServerUrls _urls;
         private readonly IDataProtector _protector;
 
         public MessageCookie(
             ILogger<MessageCookie<TModel>> logger, 
             IdentityServerOptions options,
             IHttpContextAccessor context, 
+            IServerUrls urls,
             IDataProtectionProvider provider)
         {
             _logger = logger;
             _options = options;
             _context = context;
+            _urls = urls;
             _protector = provider.CreateProtector(MessageType);
         }
 
@@ -58,7 +62,9 @@ namespace Duende.IdentityServer
             return CookiePrefix + id;
         }
 
-        private string CookiePath => _context.HttpContext.GetIdentityServerBasePath().CleanUrlPath();
+        // TODO: Request feature for IdentityServer paths?
+        // odd mixing IServerUrls and http request usage
+        private string CookiePath => _urls.BasePath.CleanUrlPath();
 
         private IEnumerable<string> GetCookieNames()
         {

--- a/src/IdentityServer/Infrastructure/MessageCookie.cs
+++ b/src/IdentityServer/Infrastructure/MessageCookie.cs
@@ -62,8 +62,6 @@ namespace Duende.IdentityServer
             return CookiePrefix + id;
         }
 
-        // TODO: Request feature for IdentityServer paths?
-        // odd mixing IServerUrls and http request usage
         private string CookiePath => _urls.BasePath.CleanUrlPath();
 
         private IEnumerable<string> GetCookieNames()

--- a/src/IdentityServer/ResponseHandling/Default/DiscoveryResponseGenerator.cs
+++ b/src/IdentityServer/ResponseHandling/Default/DiscoveryResponseGenerator.cs
@@ -94,6 +94,8 @@ namespace Duende.IdentityServer.ResponseHandling
         /// <param name="issuerUri">The issuer URI.</param>
         public virtual async Task<Dictionary<string, object>> CreateDiscoveryDocumentAsync(string baseUrl, string issuerUri)
         {
+            baseUrl = baseUrl.EnsureTrailingSlash();
+
             var entries = new Dictionary<string, object>
             {
                 { OidcConstants.Discovery.Issuer, issuerUri }

--- a/src/IdentityServer/Services/Default/DefaultIssuerNameService.cs
+++ b/src/IdentityServer/Services/Default/DefaultIssuerNameService.cs
@@ -2,7 +2,9 @@
 // See LICENSE in the project root for license information.
 
 
+using System;
 using System.Threading.Tasks;
+using Duende.IdentityServer.Configuration;
 using Duende.IdentityServer.Extensions;
 using Microsoft.AspNetCore.Http;
 
@@ -13,21 +15,65 @@ namespace Duende.IdentityServer.Services
     /// </summary>
     public class DefaultIssuerNameService : IIssuerNameService
     {
+        private readonly IdentityServerOptions _options;
+        private readonly IServerUrls _urls;
         private readonly IHttpContextAccessor _httpContextAccessor;
 
         /// <summary>
         /// ctor
         /// </summary>
+        /// <param name="options"></param>
+        /// <param name="urls"></param>
         /// <param name="httpContextAccessor">The HTTP context accessor</param>
-        public DefaultIssuerNameService(IHttpContextAccessor httpContextAccessor)
+        public DefaultIssuerNameService(IdentityServerOptions options, IServerUrls urls, IHttpContextAccessor httpContextAccessor)
         {
+            _options = options;
+            _urls = urls;
             _httpContextAccessor = httpContextAccessor;
         }
         
         /// <inheritdoc />
         public Task<string> GetCurrentAsync()
         {
-            return Task.FromResult(_httpContextAccessor.HttpContext.GetIdentityServerIssuerUri());
+            // if they've explicitly configured a URI then use it,
+            // otherwise dynamically calculate it
+            var issuer = _options.IssuerUri;
+            if (issuer.IsMissing())
+            {
+                string origin = null;
+
+                if (_options.MutualTls.Enabled && _options.MutualTls.DomainName.IsPresent())
+                {
+                    if (!_options.MutualTls.DomainName.Contains("."))
+                    {
+                        var request = _httpContextAccessor.HttpContext.Request;
+                        if (request.Host.Value.StartsWith(_options.MutualTls.DomainName, StringComparison.OrdinalIgnoreCase))
+                        {
+                            // if MTLS is configured with domain like "foo", then the request will be for "foo.acme.com", 
+                            // so the issuer we use is from the parent domain (e.g. "acme.com")
+                            // 
+                            // Host.Value is used to get unicode hostname, instread of ToUriComponent (aka punycode)
+                            origin = request.Scheme + "://" + request.Host.Value.Substring(_options.MutualTls.DomainName.Length + 1);
+                        }
+                    }
+                }
+
+                if (origin == null)
+                {
+                    // no MTLS, so use the current origin for the issuer
+                    // this also means we emit the issuer value in unicode
+                    origin = _urls.GetUnicodeOrigin();
+                }
+
+                issuer = origin + _urls.BasePath;
+
+                if (_options.LowerCaseIssuerUri)
+                {
+                    issuer = issuer.ToLowerInvariant();
+                }
+            }
+
+            return Task.FromResult(issuer);
         }
     }
 }

--- a/src/IdentityServer/Services/Default/DefaultJwtRequestUriHttpClient.cs
+++ b/src/IdentityServer/Services/Default/DefaultJwtRequestUriHttpClient.cs
@@ -3,7 +3,6 @@
 
 
 using System;
-using System.Collections.Generic;
 using Duende.IdentityServer.Models;
 using Microsoft.Extensions.Logging;
 using System.Net.Http;

--- a/src/IdentityServer/Services/Default/DefaultServerUrls.cs
+++ b/src/IdentityServer/Services/Default/DefaultServerUrls.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+using Duende.IdentityServer.Extensions;
+using Microsoft.AspNetCore.Http;
+using System;
+using System.Linq;
+
+namespace Duende.IdentityServer.Services
+{
+    /// <summary>
+    /// Implements IServerUrls
+    /// </summary>
+    public class DefaultServerUrls : IServerUrls
+    {
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        /// <summary>
+        /// ctor
+        /// </summary>
+        public DefaultServerUrls(IHttpContextAccessor httpContextAccessor)
+        {
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        /// <inheritdoc/>
+        public string Origin
+        {
+            get
+            {
+                var request = _httpContextAccessor.HttpContext.Request;
+                return request.Scheme + "://" + request.Host.ToUriComponent();
+            }
+            set
+            {
+                var split = value.Split(new[] { "://" }, StringSplitOptions.RemoveEmptyEntries);
+
+                var request = _httpContextAccessor.HttpContext.Request;
+                request.Scheme = split.First();
+                request.Host = new HostString(split.Last());
+            }
+        }
+
+        /// <inheritdoc/>
+        public string BasePath
+        {
+            get
+            {
+                return _httpContextAccessor.HttpContext.Items[Constants.EnvironmentKeys.IdentityServerBasePath] as string;
+            }
+            set
+            {
+                _httpContextAccessor.HttpContext.Items[Constants.EnvironmentKeys.IdentityServerBasePath] = value.RemoveTrailingSlash();
+            }
+        }
+    }
+}

--- a/src/IdentityServer/Services/Default/DefaultTokenService.cs
+++ b/src/IdentityServer/Services/Default/DefaultTokenService.cs
@@ -227,7 +227,6 @@ namespace Duende.IdentityServer.Services
             {
                 if (Options.MutualTls.AlwaysEmitConfirmationClaim)
                 {
-                    // TODO: Request feature for client certs?
                     var clientCertificate = await ContextAccessor.HttpContext.Connection.GetClientCertificateAsync();
                     if (clientCertificate != null)
                     {

--- a/src/IdentityServer/Services/Default/DefaultTokenService.cs
+++ b/src/IdentityServer/Services/Default/DefaultTokenService.cs
@@ -227,6 +227,7 @@ namespace Duende.IdentityServer.Services
             {
                 if (Options.MutualTls.AlwaysEmitConfirmationClaim)
                 {
+                    // TODO: Request feature for client certs?
                     var clientCertificate = await ContextAccessor.HttpContext.Connection.GetClientCertificateAsync();
                     if (clientCertificate != null)
                     {

--- a/src/IdentityServer/Services/Default/DefaultUserSession.cs
+++ b/src/IdentityServer/Services/Default/DefaultUserSession.cs
@@ -39,6 +39,11 @@ namespace Duende.IdentityServer.Services
         protected readonly ISystemClock Clock;
 
         /// <summary>
+        /// The server URL service.
+        /// </summary>
+        protected readonly IServerUrls Urls;
+
+        /// <summary>
         /// The logger
         /// </summary>
         protected readonly ILogger Logger;
@@ -92,18 +97,21 @@ namespace Duende.IdentityServer.Services
         /// <param name="handlers">The handlers.</param>
         /// <param name="options">The options.</param>
         /// <param name="clock">The clock.</param>
+        /// <param name="urls"></param>
         /// <param name="logger">The logger.</param>
         public DefaultUserSession(
             IHttpContextAccessor httpContextAccessor,
             IAuthenticationHandlerProvider handlers,
             IdentityServerOptions options,
             ISystemClock clock,
+            IServerUrls urls,
             ILogger<IUserSession> logger)
         {
             HttpContextAccessor = httpContextAccessor;
             Handlers = handlers;
             Options = options;
             Clock = clock;
+            Urls = urls;
             Logger = logger;
         }
 
@@ -250,7 +258,7 @@ namespace Duende.IdentityServer.Services
         public virtual CookieOptions CreateSessionIdCookieOptions()
         {
             var secure = HttpContext.Request.IsHttps;
-            var path = HttpContext.GetIdentityServerBasePath().CleanUrlPath();
+            var path = Urls.BasePath.CleanUrlPath();
 
             var options = new CookieOptions
             {

--- a/src/IdentityServer/Services/Default/OidcReturnUrlParser.cs
+++ b/src/IdentityServer/Services/Default/OidcReturnUrlParser.cs
@@ -10,7 +10,6 @@ using System.Collections.Specialized;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Stores;
 using Duende.IdentityServer.Validation;
-using Microsoft.AspNetCore.Http;
 using Duende.IdentityServer.Configuration;
 
 namespace Duende.IdentityServer.Services
@@ -20,7 +19,7 @@ namespace Duende.IdentityServer.Services
         private readonly IdentityServerOptions _options;
         private readonly IAuthorizeRequestValidator _validator;
         private readonly IUserSession _userSession;
-        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly IServerUrls _urls;
         private readonly ILogger _logger;
         private readonly IAuthorizationParametersMessageStore _authorizationParametersMessageStore;
 
@@ -28,14 +27,14 @@ namespace Duende.IdentityServer.Services
             IdentityServerOptions options,
             IAuthorizeRequestValidator validator,
             IUserSession userSession,
-            IHttpContextAccessor httpContextAccessor,
+            IServerUrls urls,
             ILogger<OidcReturnUrlParser> logger,
             IAuthorizationParametersMessageStore authorizationParametersMessageStore = null)
         {
             _options = options;
             _validator = validator;
             _userSession = userSession;
-            _httpContextAccessor = httpContextAccessor;
+            _urls = urls;
             _logger = logger;
             _authorizationParametersMessageStore = authorizationParametersMessageStore;
         }
@@ -75,7 +74,7 @@ namespace Duende.IdentityServer.Services
                     return false;
                 }
 
-                var host = _httpContextAccessor.HttpContext.GetIdentityServerHost();
+                var host = _urls.Origin;
                 if (returnUrl.StartsWith(host, StringComparison.OrdinalIgnoreCase) == true)
                 {
                     returnUrl = returnUrl.Substring(host.Length);

--- a/src/IdentityServer/Services/IIssuerNameService.cs
+++ b/src/IdentityServer/Services/IIssuerNameService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/src/IdentityServer/Services/IServerUrls.cs
+++ b/src/IdentityServer/Services/IServerUrls.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+namespace Duende.IdentityServer.Services
+{
+    /// <summary>
+    /// Configures the per-request URLs and paths into the current server
+    /// </summary>
+    public interface IServerUrls
+    {
+        /// <summary>
+        /// Gets or sets the origin for IdentityServer. For example, "https://server.acme.com:5001".
+        /// </summary>
+        string Origin { get; set; }
+
+        /// <summary>
+        /// Gets or sets the base path of IdentityServer.
+        /// </summary>
+        string BasePath { get; set; }
+        
+        /// <summary>
+        /// Gets the base URL for IdentityServer.
+        /// </summary>
+        string BaseUrl { get => Origin + BasePath; }
+    }
+}

--- a/src/IdentityServer/Validation/Default/EndSessionRequestValidator.cs
+++ b/src/IdentityServer/Validation/Default/EndSessionRequestValidator.cs
@@ -171,8 +171,7 @@ namespace Duende.IdentityServer.Validation
                 validatedRequest.ClientIds = await UserSession.GetClientListAsync();
             }
 
-            // todo: need OidcConstants.EndSession.UiLocales
-            var uilocales = parameters.Get(OidcConstants.AuthorizeRequest.UiLocales);
+            var uilocales = parameters.Get(OidcConstants.EndSessionRequest.UiLocales);
             if (uilocales.IsPresent())
             {
                 if (uilocales.Length > Options.InputLengthRestrictions.UiLocale)

--- a/src/IdentityServer/Validation/Default/EndSessionRequestValidator.cs
+++ b/src/IdentityServer/Validation/Default/EndSessionRequestValidator.cs
@@ -86,7 +86,9 @@ namespace Duende.IdentityServer.Validation
             IMessageStore<LogoutNotificationContext> endSessionMessageStore,
             ILogger<EndSessionRequestValidator> logger)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             Context = context;
+#pragma warning restore CS0618 // Type or member is obsolete
             Options = options;
             TokenValidator = tokenValidator;
             UriValidator = uriValidator;

--- a/src/IdentityServer/Validation/Default/EndSessionRequestValidator.cs
+++ b/src/IdentityServer/Validation/Default/EndSessionRequestValidator.cs
@@ -63,6 +63,7 @@ namespace Duende.IdentityServer.Validation
         /// The HTTP context accessor.
         /// </summary>
         protected readonly IHttpContextAccessor Context;
+        // TODO: remove?
 
         /// <summary>
         /// Creates a new instance of the EndSessionRequestValidator.

--- a/src/IdentityServer/Validation/Default/EndSessionRequestValidator.cs
+++ b/src/IdentityServer/Validation/Default/EndSessionRequestValidator.cs
@@ -62,8 +62,8 @@ namespace Duende.IdentityServer.Validation
         /// <summary>
         /// The HTTP context accessor.
         /// </summary>
+        [Obsolete("Unused. Will remove in a future release.")]
         protected readonly IHttpContextAccessor Context;
-        // TODO: remove?
 
         /// <summary>
         /// Creates a new instance of the EndSessionRequestValidator.

--- a/src/IdentityServer/Validation/Default/PrivateKeyJwtSecretValidator.cs
+++ b/src/IdentityServer/Validation/Default/PrivateKeyJwtSecretValidator.cs
@@ -25,6 +25,7 @@ namespace Duende.IdentityServer.Validation
         private readonly IHttpContextAccessor _contextAccessor; 
         private readonly IIssuerNameService _issuerNameService;
         private readonly IReplayCache _replayCache;
+        private readonly IServerUrls _urls;
         private readonly IdentityServerOptions _options;
         private readonly ILogger _logger;
 
@@ -37,12 +38,14 @@ namespace Duende.IdentityServer.Validation
             IHttpContextAccessor contextAccessor,
             IIssuerNameService issuerNameService, 
             IReplayCache replayCache,
+            IServerUrls urls,
             IdentityServerOptions options,
             ILogger<PrivateKeyJwtSecretValidator> logger)
         {
             _contextAccessor = contextAccessor;
             _issuerNameService = issuerNameService;
             _replayCache = replayCache;
+            _urls = urls;
             _options = options;
             _logger = logger;
         }
@@ -92,12 +95,10 @@ namespace Duende.IdentityServer.Validation
             var validAudiences = new[]
             {
                 // token endpoint URL
-                string.Concat(_contextAccessor.HttpContext.GetIdentityServerBaseUrl().EnsureTrailingSlash(),
-                    Constants.ProtocolRoutePaths.Token),
+                string.Concat(_urls.BaseUrl.EnsureTrailingSlash(), Constants.ProtocolRoutePaths.Token),
                 // TODO: remove the issuer URL in a future major release?
                 // issuer URL
-                string.Concat((await _issuerNameService.GetCurrentAsync()).EnsureTrailingSlash(),
-                    Constants.ProtocolRoutePaths.Token)
+                string.Concat((await _issuerNameService.GetCurrentAsync()).EnsureTrailingSlash(), Constants.ProtocolRoutePaths.Token)
             }.Distinct();
 
             var tokenValidationParameters = new TokenValidationParameters

--- a/src/IdentityServer/Validation/Default/PrivateKeyJwtSecretValidator.cs
+++ b/src/IdentityServer/Validation/Default/PrivateKeyJwtSecretValidator.cs
@@ -22,7 +22,6 @@ namespace Duende.IdentityServer.Validation
     /// </summary>
     public class PrivateKeyJwtSecretValidator : ISecretValidator
     {
-        private readonly IHttpContextAccessor _contextAccessor; 
         private readonly IIssuerNameService _issuerNameService;
         private readonly IReplayCache _replayCache;
         private readonly IServerUrls _urls;
@@ -35,14 +34,12 @@ namespace Duende.IdentityServer.Validation
         /// Instantiates an instance of private_key_jwt secret validator
         /// </summary>
         public PrivateKeyJwtSecretValidator(
-            IHttpContextAccessor contextAccessor,
             IIssuerNameService issuerNameService, 
             IReplayCache replayCache,
             IServerUrls urls,
             IdentityServerOptions options,
             ILogger<PrivateKeyJwtSecretValidator> logger)
         {
-            _contextAccessor = contextAccessor;
             _issuerNameService = issuerNameService;
             _replayCache = replayCache;
             _urls = urls;

--- a/src/Storage/Stores/IIdentityProviderStore.cs
+++ b/src/Storage/Stores/IIdentityProviderStore.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 using Duende.IdentityServer.Models;
-using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 

--- a/test/IdentityServer.UnitTests/Common/MockHttpContextAccessor.cs
+++ b/test/IdentityServer.UnitTests/Common/MockHttpContextAccessor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 
@@ -22,7 +22,8 @@ namespace UnitTests.Common
         public MockHttpContextAccessor(
             IdentityServerOptions options = null,
             IUserSession userSession = null,
-            IMessageStore<LogoutNotificationContext> endSessionStore = null)
+            IMessageStore<LogoutNotificationContext> endSessionStore = null,
+            IServerUrls urls = null)
         {
             options = options ?? TestIdentityServerOptions.Create();
 
@@ -53,6 +54,11 @@ namespace UnitTests.Common
             else
             {
                 services.AddSingleton(endSessionStore);
+            }
+
+            if (urls != null)
+            {
+                services.AddSingleton<IServerUrls>(urls);
             }
 
             _context.RequestServices = services.BuildServiceProvider();

--- a/test/IdentityServer.UnitTests/Common/MockServerUrls.cs
+++ b/test/IdentityServer.UnitTests/Common/MockServerUrls.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+
+using Duende.IdentityServer.Services;
+
+namespace UnitTests.Common
+{
+    public class MockServerUrls : IServerUrls
+    {
+        public string Origin { get; set; }
+        public string BasePath { get; set; }
+    }
+}

--- a/test/IdentityServer.UnitTests/Common/TestExtensions.cs
+++ b/test/IdentityServer.UnitTests/Common/TestExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/test/IdentityServer.UnitTests/Endpoints/Results/AuthorizeResultTests.cs
+++ b/test/IdentityServer.UnitTests/Endpoints/Results/AuthorizeResultTests.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Duende.IdentityServer.Configuration;
 using Duende.IdentityServer.Endpoints.Results;
-using Duende.IdentityServer.Extensions;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.ResponseHandling;
 using Duende.IdentityServer.Validation;
@@ -18,6 +17,7 @@ using UnitTests.Common;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.WebUtilities;
 using Xunit;
+using Duende.IdentityServer.Services;
 
 namespace UnitTests.Endpoints.Results
 {
@@ -29,19 +29,22 @@ namespace UnitTests.Endpoints.Results
         private IdentityServerOptions _options = new IdentityServerOptions();
         private MockUserSession _mockUserSession = new MockUserSession();
         private MockMessageStore<Duende.IdentityServer.Models.ErrorMessage> _mockErrorMessageStore = new MockMessageStore<Duende.IdentityServer.Models.ErrorMessage>();
-
+        
+        private DefaultServerUrls _urls;
         private DefaultHttpContext _context = new DefaultHttpContext();
 
         public AuthorizeResultTests()
         {
-            _context.SetIdentityServerOrigin("https://server");
-            _context.SetIdentityServerBasePath("/");
+            _urls = new DefaultServerUrls(new HttpContextAccessor { HttpContext = _context });
+
+            _context.Request.Scheme = "https";
+            _context.Request.Host = new HostString("server");
             _context.Response.Body = new MemoryStream();
 
             _options.UserInteraction.ErrorUrl = "~/error";
             _options.UserInteraction.ErrorIdParameter = "errorId";
 
-            _subject = new AuthorizeResult(_response, _options, _mockUserSession, _mockErrorMessageStore, new StubClock());
+            _subject = new AuthorizeResult(_response, _options, _mockUserSession, _mockErrorMessageStore, _urls, new StubClock());
         }
 
         [Fact]

--- a/test/IdentityServer.UnitTests/Endpoints/Results/CheckSessionResultTests.cs
+++ b/test/IdentityServer.UnitTests/Endpoints/Results/CheckSessionResultTests.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Duende.IdentityServer.Configuration;
 using Duende.IdentityServer.Endpoints.Results;
-using Duende.IdentityServer.Extensions;
 using Duende.IdentityServer.Models;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
@@ -25,8 +24,8 @@ namespace UnitTests.Endpoints.Results
 
         public CheckSessionResultTests()
         {
-            _context.SetIdentityServerOrigin("https://server");
-            _context.SetIdentityServerBasePath("/");
+            _context.Request.Scheme = "https";
+            _context.Request.Host = new HostString("server");
             _context.Response.Body = new MemoryStream();
 
             _options.Authentication.CheckSessionCookieName = "foobar";

--- a/test/IdentityServer.UnitTests/Endpoints/Results/EndSessionCallbackResultTests.cs
+++ b/test/IdentityServer.UnitTests/Endpoints/Results/EndSessionCallbackResultTests.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Duende.IdentityServer.Configuration;
 using Duende.IdentityServer.Endpoints.Results;
-using Duende.IdentityServer.Extensions;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Validation;
 using FluentAssertions;
@@ -28,8 +27,8 @@ namespace UnitTests.Endpoints.Results
 
         public EndSessionCallbackResultTests()
         {
-            _context.SetIdentityServerOrigin("https://server");
-            _context.SetIdentityServerBasePath("/");
+            _context.Request.Scheme = "https";
+            _context.Request.Host = new HostString("server");
             _context.Response.Body = new MemoryStream();
 
             _subject = new EndSessionCallbackResult(_result, _options);

--- a/test/IdentityServer.UnitTests/Endpoints/Results/EndSessionResultTests.cs
+++ b/test/IdentityServer.UnitTests/Endpoints/Results/EndSessionResultTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Duende.IdentityServer.Configuration;
 using Duende.IdentityServer.Endpoints.Results;
-using Duende.IdentityServer.Extensions;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Validation;
 using FluentAssertions;
@@ -15,6 +14,7 @@ using UnitTests.Common;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.WebUtilities;
 using Xunit;
+using Duende.IdentityServer.Services;
 
 namespace UnitTests.Endpoints.Results
 {
@@ -26,17 +26,20 @@ namespace UnitTests.Endpoints.Results
         private IdentityServerOptions _options = new IdentityServerOptions();
         private MockMessageStore<LogoutMessage> _mockLogoutMessageStore = new MockMessageStore<LogoutMessage>();
 
+        private DefaultServerUrls _urls;
+
         private DefaultHttpContext _context = new DefaultHttpContext();
 
         public EndSessionResultTests()
         {
-            _context.SetIdentityServerOrigin("https://server");
-            _context.SetIdentityServerBasePath("/");
+            _urls = new DefaultServerUrls(new HttpContextAccessor { HttpContext = _context });
+
+            _urls.Origin = "https://server";
 
             _options.UserInteraction.LogoutUrl = "~/logout";
             _options.UserInteraction.LogoutIdParameter = "logoutId";
 
-            _subject = new EndSessionResult(_result, _options, new StubClock(), _mockLogoutMessageStore);
+            _subject = new EndSessionResult(_result, _options, new StubClock(), _urls, _mockLogoutMessageStore);
         }
 
         [Fact]

--- a/test/IdentityServer.UnitTests/Services/Default/DefaultIdentityServerInteractionServiceTests.cs
+++ b/test/IdentityServer.UnitTests/Services/Default/DefaultIdentityServerInteractionServiceTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 
@@ -29,12 +29,13 @@ namespace UnitTests.Services.Default
         private MockPersistedGrantService _mockPersistedGrantService = new MockPersistedGrantService();
         private MockUserSession _mockUserSession = new MockUserSession();
         private MockReturnUrlParser _mockReturnUrlParser = new MockReturnUrlParser();
+        private MockServerUrls _mockServerUrls = new MockServerUrls();
 
         private ResourceValidationResult _resourceValidationResult;
 
         public DefaultIdentityServerInteractionServiceTests()
         {
-            _mockMockHttpContextAccessor = new MockHttpContextAccessor(_options, _mockUserSession, _mockEndSessionStore);
+            _mockMockHttpContextAccessor = new MockHttpContextAccessor(_options, _mockUserSession, _mockEndSessionStore, _mockServerUrls);
 
             _subject = new DefaultIdentityServerInteractionService(new StubClock(), 
                 _mockMockHttpContextAccessor,

--- a/test/IdentityServer.UnitTests/Services/Default/DefaultUserSessionTests.cs
+++ b/test/IdentityServer.UnitTests/Services/Default/DefaultUserSessionTests.cs
@@ -39,6 +39,7 @@ namespace UnitTests.Services.Default
                 _mockAuthenticationHandlerProvider,
                 _options,
                 new StubClock(), 
+                new MockServerUrls { Origin = "https://server" },
                 TestLogger.Create<DefaultUserSession>());
         }
 

--- a/test/IdentityServer.UnitTests/Validation/Secrets/PrivateKeyJwtSecretValidation.cs
+++ b/test/IdentityServer.UnitTests/Validation/Secrets/PrivateKeyJwtSecretValidation.cs
@@ -40,6 +40,7 @@ namespace UnitTests.Validation.Secrets
                  new HttpContextAccessor { HttpContext = ctx },
                  new TestIssuerNameService("https://idsrv3.com"),
                  new DefaultReplayCache(new TestCache()), 
+                 new MockServerUrls() { Origin = "https://idsrv3.com" },
                  new IdentityServerOptions(),
                  new LoggerFactory().CreateLogger<PrivateKeyJwtSecretValidator>());
             

--- a/test/IdentityServer.UnitTests/Validation/Secrets/PrivateKeyJwtSecretValidation.cs
+++ b/test/IdentityServer.UnitTests/Validation/Secrets/PrivateKeyJwtSecretValidation.cs
@@ -32,12 +32,7 @@ namespace UnitTests.Validation.Secrets
 
         public PrivateKeyJwtSecretValidation()
         {
-            var ctx = new DefaultHttpContext();
-            ctx.Request.Scheme = "https";
-            ctx.Request.Host = new HostString("idsrv3.com");
-
             _validator = new PrivateKeyJwtSecretValidator(
-                 new HttpContextAccessor { HttpContext = ctx },
                  new TestIssuerNameService("https://idsrv3.com"),
                  new DefaultReplayCache(new TestCache()), 
                  new MockServerUrls() { Origin = "https://idsrv3.com" },


### PR DESCRIPTION
This PR contains a new service that provides a replacement for many of the HttpContext extension methods (Set/GetIdentityServerBasePath, GetIdentityServerOrigin, GetIdentityServerIssuer). These extension methods have been marked with [Obsolete] and will eventually be removed.

Closes: https://github.com/DuendeSoftware/IdentityServer/issues/56