### PR TITLE
Add IdentityProvider validator

### DIFF
--- a/hosts/main/Startup.cs
+++ b/hosts/main/Startup.cs
@@ -18,6 +18,7 @@ using Duende.IdentityServer;
 using IdentityServerHost.Extensions;
 using Serilog.Events;
 using Microsoft.AspNetCore.Hosting;
+using Duende.IdentityServer.Hosting.DynamicProviders;
 
 namespace IdentityServerHost
 {
@@ -67,7 +68,18 @@ namespace IdentityServerHost
                 .AddProfileService<HostProfileService>()
                 .AddCustomTokenRequestValidator<ParameterizedScopeTokenRequestValidator>()
                 .AddScopeParser<ParameterizedScopeParser>()
-                .AddMutualTlsSecretValidators();
+                .AddMutualTlsSecretValidators()
+                .AddInMemoryOidcProviders(new[] { 
+                    new Duende.IdentityServer.Models.OidcProvider
+                    {
+                        Scheme = "dynamicprovider-idsvr",
+                        DisplayName = "IdentityServer (via Dynamic Providers)",
+                        Authority = "https://demo.duendesoftware.com",
+                        ClientId = "login",
+                        ResponseType = "id_token",
+                        Scope = "openid profile"
+                    }
+                });
 
             services.AddExternalIdentityProviders();
 

--- a/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Additional.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Additional.cs
@@ -279,7 +279,9 @@ namespace Microsoft.Extensions.DependencyInjection
             where T : IIdentityProviderStore
         {
             builder.Services.TryAddTransient(typeof(T));
-            builder.Services.AddTransient<IIdentityProviderStore, CachingIdentityProviderStore<T>>();
+            builder.Services.AddTransient<ValidatingIdentityProviderStore<T>>();
+            builder.Services.AddTransient<IIdentityProviderStore, CachingIdentityProviderStore<ValidatingIdentityProviderStore<T>>>();
+
             return builder;
         }
         
@@ -351,6 +353,21 @@ namespace Microsoft.Extensions.DependencyInjection
             where T : class, IClientConfigurationValidator
         {
             builder.Services.AddTransient<IClientConfigurationValidator, T>();
+
+            return builder;
+        }
+
+
+        /// <summary>
+        /// Adds an IdentityProvider configuration validator.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="builder">The builder.</param>
+        /// <returns></returns>
+        public static IIdentityServerBuilder AddIdentityProviderConfigurationValidator<T>(this IIdentityServerBuilder builder)
+            where T : class, IIdentityProviderConfigurationValidator
+        {
+            builder.Services.AddTransient<IIdentityProviderConfigurationValidator, T>();
 
             return builder;
         }
@@ -497,7 +514,8 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IIdentityServerBuilder AddIdentityProviderStore<T>(this IIdentityServerBuilder builder)
            where T : class, IIdentityProviderStore
         {
-            builder.Services.AddTransient<IIdentityProviderStore, T>();
+            builder.Services.TryAddTransient(typeof(T));
+            builder.Services.AddTransient<IIdentityProviderStore, ValidatingIdentityProviderStore<T>>();
 
             return builder;
         }

--- a/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -253,6 +253,7 @@ namespace Microsoft.Extensions.DependencyInjection
             builder.Services.TryAddTransient<ICustomTokenRequestValidator, DefaultCustomTokenRequestValidator>();
             builder.Services.TryAddTransient<IUserInfoRequestValidator, UserInfoRequestValidator>();
             builder.Services.TryAddTransient<IClientConfigurationValidator, DefaultClientConfigurationValidator>();
+            builder.Services.TryAddTransient<IIdentityProviderConfigurationValidator, DefaultIdentityProviderConfigurationValidator>();
             builder.Services.TryAddTransient<IDeviceAuthorizationRequestValidator, DeviceAuthorizationRequestValidator>();
             builder.Services.TryAddTransient<IDeviceCodeValidator, DeviceCodeValidator>();
 

--- a/src/IdentityServer/Events/Infrastructure/EventIds.cs
+++ b/src/IdentityServer/Events/Infrastructure/EventIds.cs
@@ -42,6 +42,7 @@ namespace Duende.IdentityServer.Events
 
         public const int UnhandledException = ErrorEventsStart + 0;
         public const int InvalidClientConfiguration = ErrorEventsStart + 1;
+        public const int InvalidIdentityProviderConfiguration = ErrorEventsStart + 2;
 
         //////////////////////////////////////////////////////
         /// Grants related events

--- a/src/IdentityServer/Events/InvalidClientConfiguration.cs
+++ b/src/IdentityServer/Events/InvalidClientConfiguration.cs
@@ -13,7 +13,7 @@ namespace Duende.IdentityServer.Events
     public class InvalidClientConfigurationEvent : Event
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="UnhandledExceptionEvent" /> class.
+        /// Initializes a new instance of the <see cref="InvalidClientConfigurationEvent" /> class.
         /// </summary>
         /// <param name="client">The client.</param>
         /// <param name="errorMessage">The error message.</param>

--- a/src/IdentityServer/Events/InvalidIdentityProviderConfiguration.cs
+++ b/src/IdentityServer/Events/InvalidIdentityProviderConfiguration.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+using Duende.IdentityServer.Models;
+
+namespace Duende.IdentityServer.Events
+{
+    /// <summary>
+    /// Event for unhandled exceptions
+    /// </summary>
+    /// <seealso cref="Event" />
+    public class InvalidIdentityProviderConfiguration : Event
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InvalidIdentityProviderConfiguration" /> class.
+        /// </summary>
+        public InvalidIdentityProviderConfiguration(IdentityProvider idp, string errorMessage)
+            : base(EventCategories.Error,
+                  "Invalid IdentityProvider Configuration",
+                  EventTypes.Error, 
+                  EventIds.InvalidIdentityProviderConfiguration,
+                  errorMessage)
+        {
+            Scheme = idp.Scheme;
+            DisplayName = idp.DisplayName ?? "unknown name";
+            Type = idp.Type ?? "unknown type";
+        }
+
+        /// <summary>
+        /// Gets or sets the scheme.
+        /// </summary>
+        public string Scheme { get; set; }
+
+        /// <summary>
+        /// Gets or sets the display name of the identity provider.
+        /// </summary>
+        public string DisplayName { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the type of the identity provider.
+        /// </summary>
+        public string Type { get; set; }
+    }
+}

--- a/src/IdentityServer/Hosting/DynamicProviders/Oidc/IdentityServerBuilderOidcExtensions.cs
+++ b/src/IdentityServer/Hosting/DynamicProviders/Oidc/IdentityServerBuilderOidcExtensions.cs
@@ -43,15 +43,13 @@ namespace Microsoft.Extensions.DependencyInjection
 
         /// <summary>
         /// Adds the in memory OIDC provider store.
-        /// This API is for testing only.
         /// </summary>
         /// <param name="builder">The builder.</param>
         /// <param name="providers"></param>
         /// <returns></returns>
-        internal static IIdentityServerBuilder AddInMemoryOidcProviders(this IIdentityServerBuilder builder, IEnumerable<OidcProvider> providers)
+        public static IIdentityServerBuilder AddInMemoryOidcProviders(this IIdentityServerBuilder builder, IEnumerable<OidcProvider> providers)
         {
             builder.Services.AddSingleton(providers);
-            //builder.Services.AddTransient<InMemoryOidcProviderStore>();
             builder.AddIdentityProviderStore<InMemoryOidcProviderStore>();
             return builder;
         }

--- a/src/IdentityServer/Hosting/DynamicProviders/Store/ValidatingIdentityProviderStore.cs
+++ b/src/IdentityServer/Hosting/DynamicProviders/Store/ValidatingIdentityProviderStore.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using Duende.IdentityServer.Events;
+using Duende.IdentityServer.Models;
+using Duende.IdentityServer.Services;
+using Duende.IdentityServer.Stores;
+using Duende.IdentityServer.Validation;
+using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Duende.IdentityServer.Hosting.DynamicProviders
+{
+    /// <summary>
+    /// Validating decorator for IIdentityProviderStore
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public class ValidatingIdentityProviderStore<T> : IIdentityProviderStore
+            where T : IIdentityProviderStore
+    {
+        private readonly IIdentityProviderStore _inner;
+        private readonly IIdentityProviderConfigurationValidator _validator;
+        private readonly IEventService _events;
+        private readonly ILogger<ValidatingIdentityProviderStore<T>> _logger;
+        private readonly string _validatorType;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValidatingIdentityProviderStore{T}" /> class.
+        /// </summary>
+        public ValidatingIdentityProviderStore(T inner, IIdentityProviderConfigurationValidator validator, IEventService events, ILogger<ValidatingIdentityProviderStore<T>> logger)
+        {
+            _inner = inner;
+            _validator = validator;
+            _events = events;
+            _logger = logger;
+
+            _validatorType = validator.GetType().FullName;
+        }
+
+        /// <inheritdoc/>
+        public Task<IEnumerable<IdentityProviderName>> GetAllSchemeNamesAsync()
+        {
+            return _inner.GetAllSchemeNamesAsync();
+        }
+
+        /// <inheritdoc/>
+        public async Task<IdentityProvider> GetBySchemeAsync(string scheme)
+        {
+            var idp = await _inner.GetBySchemeAsync(scheme);
+
+            if (idp != null)
+            {
+                _logger.LogTrace("Calling into identity provider configuration validator: {validatorType}", _validatorType);
+
+                var context = new IdentityProviderConfigurationValidationContext(idp);
+                await _validator.ValidateAsync(context);
+
+                if (context.IsValid)
+                {
+                    _logger.LogDebug("IdentityProvider validation for scheme {scheme} succeeded.", scheme);
+                    return idp;
+                }
+
+                _logger.LogError("Invalid IdentityProvider configuration for scheme {scheme}: {errorMessage}", scheme, context.ErrorMessage);
+                await _events.RaiseAsync(new InvalidIdentityProviderConfiguration(idp, context.ErrorMessage));
+
+                return null;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/IdentityServer/Validation/Contexts/IdentityProviderConfigurationValidationContext.cs
+++ b/src/IdentityServer/Validation/Contexts/IdentityProviderConfigurationValidationContext.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+using Duende.IdentityServer.Models;
+
+namespace Duende.IdentityServer.Validation
+{
+    /// <summary>
+    /// Context for identity provider configuration validation.
+    /// </summary>
+    public class IdentityProviderConfigurationValidationContext : IdentityProviderConfigurationValidationContext<IdentityProvider>
+    {
+        /// <summary>
+        /// Initializes a new instance of the IdentityProviderConfigurationValidationContext class.
+        /// </summary>
+        public IdentityProviderConfigurationValidationContext(IdentityProvider idp) : base(idp)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Context for identity provider configuration validation.
+    /// </summary>
+    public class IdentityProviderConfigurationValidationContext<T>
+        where T : IdentityProvider
+    {
+        /// <summary>
+        /// Gets or sets the identity provider.
+        /// </summary>
+        public T IdentityProvider { get; }
+
+        /// <summary>
+        /// Returns true if the configuration is valid.
+        /// </summary>
+        public bool IsValid { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets the error message.
+        /// </summary>
+        public string ErrorMessage { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the IdentityProviderConfigurationValidationContext class.
+        /// </summary>
+        public IdentityProviderConfigurationValidationContext(T idp)
+        {
+            IdentityProvider = idp;
+        }
+
+        /// <summary>
+        /// Sets a validation error.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        public void SetError(string message)
+        {
+            IsValid = false;
+            ErrorMessage = message;
+        }
+    }
+}

--- a/src/IdentityServer/Validation/Default/DefaultIdentityProviderConfigurationValidator.cs
+++ b/src/IdentityServer/Validation/Default/DefaultIdentityProviderConfigurationValidator.cs
@@ -1,0 +1,96 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Duende.IdentityServer.Configuration;
+using Duende.IdentityServer.Models;
+
+namespace Duende.IdentityServer.Validation
+{
+    /// <summary>
+    /// Default identity provider configuration validator
+    /// </summary>
+    /// <seealso cref="IIdentityProviderConfigurationValidator" />
+    public class DefaultIdentityProviderConfigurationValidator : IIdentityProviderConfigurationValidator
+    {
+        private readonly IdentityServerOptions _options;
+
+        /// <summary>
+        /// Constructor for DefaultIdentityProviderConfigurationValidator
+        /// </summary>
+        public DefaultIdentityProviderConfigurationValidator(IdentityServerOptions options)
+        {
+            _options = options;
+        }
+
+        /// <inheritdoc/>
+        public virtual async Task ValidateAsync(IdentityProviderConfigurationValidationContext context)
+        {
+            var type = _options.DynamicProviders.FindProviderType(context.IdentityProvider.Type);
+            if (type == null)
+            {
+                context.SetError("IdentityProvider Type has not been registered with AddProviderType on the DynamicProviderOptions.");
+                return;
+            }
+
+            if (String.IsNullOrWhiteSpace(context.IdentityProvider.Scheme))
+            {
+                context.SetError("Scheme is missing.");
+                return;
+            }
+
+            if (context.IdentityProvider is OidcProvider oidc)
+            {
+                var oidcContext = new IdentityProviderConfigurationValidationContext<OidcProvider>(oidc);
+                await ValidateOidcProviderAsync(oidcContext);
+                
+                if (!oidcContext.IsValid)
+                {
+                    context.SetError(oidcContext.ErrorMessage);
+                }
+
+                return;
+            }
+        }
+
+        /// <summary>
+        /// Validates the OIDC identity provider.
+        /// </summary>
+        /// <returns>A string that represents the error. Null if there is no error.</returns>
+        protected virtual Task ValidateOidcProviderAsync(IdentityProviderConfigurationValidationContext<OidcProvider> context)
+        {
+            if (String.IsNullOrWhiteSpace(context.IdentityProvider.Authority))
+            {
+                context.SetError("Authority is missing.");
+            }
+            
+            if (String.IsNullOrWhiteSpace(context.IdentityProvider.ClientId))
+            {
+                context.SetError("ClientId is missing.");
+            }
+
+            if (String.IsNullOrWhiteSpace(context.IdentityProvider.ResponseType))
+            {
+                context.SetError("ResponseType is missing.");
+            }
+            else
+            {
+                var parts = context.IdentityProvider.ResponseType.Split(' ', StringSplitOptions.RemoveEmptyEntries).Distinct();
+                if (parts.Contains(IdentityModel.OidcConstants.ResponseTypes.Code) && String.IsNullOrWhiteSpace(context.IdentityProvider.ClientSecret))
+                {
+                    context.SetError("ClientSecret is missing.");
+                }
+            }
+
+            if (String.IsNullOrWhiteSpace(context.IdentityProvider.Scope))
+            {
+                context.SetError("Scope is missing.");
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/IdentityServer/Validation/IIdentityProviderConfigurationValidator.cs
+++ b/src/IdentityServer/Validation/IIdentityProviderConfigurationValidator.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+using System.Threading.Tasks;
+
+namespace Duende.IdentityServer.Validation
+{
+    /// <summary>
+    /// Validator for handling identity provider configuration
+    /// </summary>
+    public interface IIdentityProviderConfigurationValidator
+    {
+        /// <summary>
+        /// Determines whether the configuration of an identity provider is valid.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <returns></returns>
+        Task ValidateAsync(IdentityProviderConfigurationValidationContext context);
+    }
+}

--- a/test/IdentityServer.UnitTests/Validation/IdentityProviderConfigurationValidation.cs
+++ b/test/IdentityServer.UnitTests/Validation/IdentityProviderConfigurationValidation.cs
@@ -1,0 +1,229 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+using System;
+using System.Threading.Tasks;
+using Duende.IdentityServer.Configuration;
+using Duende.IdentityServer.Models;
+using Duende.IdentityServer.Validation;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Xunit;
+
+namespace UnitTests.Validation
+{
+    public class IdentityProviderConfigurationValidation
+    {
+        private const string Category = "IdentityProvider Configuration Validation Tests";
+        private IIdentityProviderConfigurationValidator _validator;
+        IdentityServerOptions _options;
+
+        public IdentityProviderConfigurationValidation()
+        {
+            _options = new IdentityServerOptions();
+            _options.DynamicProviders.AddProviderType<OpenIdConnectHandler, OpenIdConnectOptions, OidcProvider>("oidc");
+
+            _validator = new DefaultIdentityProviderConfigurationValidator(_options);
+        }
+
+        [Fact]
+        [Trait("Category", Category)]
+        public async Task correctly_populated_idp_should_succeed()
+        {
+            var idp = new OidcProvider
+            {
+                Scheme = "scheme",
+                ClientId = "client",
+                ClientSecret = "secret",
+                Authority = "authority",
+                ResponseType = "code",
+                Scope = "openid scope",
+            };
+
+            var ctx = new IdentityProviderConfigurationValidationContext(idp);
+            await _validator.ValidateAsync(ctx);
+
+            ctx.IsValid.Should().BeTrue();
+        }
+
+        [Fact]
+        [Trait("Category", Category)]
+        public async Task missing_type_registration_should_fail()
+        {
+            var idp = new IdentityProvider("type")
+            {
+                Scheme = "scheme",
+            };
+
+            var ctx = new IdentityProviderConfigurationValidationContext(idp);
+            await _validator.ValidateAsync(ctx);
+
+            ctx.IsValid.Should().BeFalse();
+            ctx.ErrorMessage.Should().Contain("registered");
+        }
+
+        [Fact]
+        [Trait("Category", Category)]
+        public async Task custom_type_registration_should_succeed()
+        {
+            _options.DynamicProviders.AddProviderType<OpenIdConnectHandler, OpenIdConnectOptions, OidcProvider>("type");
+
+            var idp = new IdentityProvider("type")
+            {
+                Scheme = "scheme"
+            };
+
+            var ctx = new IdentityProviderConfigurationValidationContext(idp);
+            await _validator.ValidateAsync(ctx);
+
+            ctx.IsValid.Should().BeTrue();
+        }
+
+        [Fact]
+        [Trait("Category", Category)]
+        public async Task missing_scheme_should_fail()
+        {
+            var idp = new OidcProvider
+            {
+                ClientId = "client",
+                ClientSecret = "secret",
+                Authority = "authority",
+                ResponseType = "code",
+                Scope = "openid scope",
+            };
+            idp.Scheme = "";
+
+            var ctx = new IdentityProviderConfigurationValidationContext(idp);
+            await _validator.ValidateAsync(ctx);
+
+            ctx.IsValid.Should().BeFalse();
+            ctx.ErrorMessage.ToLowerInvariant().Should().Contain("scheme");
+        }
+
+        [Fact]
+        [Trait("Category", Category)]
+        public async Task missing_clientid_should_fail()
+        {
+            var idp = new OidcProvider
+            {
+                Scheme = "scheme",
+                ClientId = "",
+                ClientSecret = "secret",
+                Authority = "authority",
+                ResponseType = "code",
+                Scope = "openid scope",
+            };
+
+            var ctx = new IdentityProviderConfigurationValidationContext(idp);
+            await _validator.ValidateAsync(ctx);
+
+            ctx.IsValid.Should().BeFalse();
+            ctx.ErrorMessage.ToLowerInvariant().Should().Contain("clientid");
+        }
+
+        [Fact]
+        [Trait("Category", Category)]
+        public async Task missing_secret_should_fail()
+        {
+            var idp = new OidcProvider
+            {
+                Scheme = "scheme",
+                ClientId = "client",
+                ClientSecret = "",
+                Authority = "authority",
+                ResponseType = "code",
+                Scope = "openid scope",
+            };
+
+            var ctx = new IdentityProviderConfigurationValidationContext(idp);
+            await _validator.ValidateAsync(ctx);
+
+            ctx.IsValid.Should().BeFalse();
+            ctx.ErrorMessage.ToLowerInvariant().Should().Contain("clientsecret");
+        }
+
+        [Fact]
+        [Trait("Category", Category)]
+        public async Task missing_authority_should_fail()
+        {
+            var idp = new OidcProvider
+            {
+                Scheme = "scheme",
+                ClientId = "client",
+                ClientSecret = "secret",
+                Authority = "",
+                ResponseType = "code",
+                Scope = "openid scope",
+            };
+
+            var ctx = new IdentityProviderConfigurationValidationContext(idp);
+            await _validator.ValidateAsync(ctx);
+
+            ctx.IsValid.Should().BeFalse();
+            ctx.ErrorMessage.ToLowerInvariant().Should().Contain("authority");
+        }
+
+        [Fact]
+        [Trait("Category", Category)]
+        public async Task missing_responsetype_should_fail()
+        {
+            var idp = new OidcProvider
+            {
+                Scheme = "scheme",
+                ClientId = "client",
+                ClientSecret = "secret",
+                Authority = "authority",
+                ResponseType = "",
+                Scope = "openid scope",
+            };
+
+            var ctx = new IdentityProviderConfigurationValidationContext(idp);
+            await _validator.ValidateAsync(ctx);
+
+            ctx.IsValid.Should().BeFalse();
+            ctx.ErrorMessage.ToLowerInvariant().Should().Contain("responsetype");
+        }
+
+        [Fact]
+        [Trait("Category", Category)]
+        public async Task missing_scope_should_fail()
+        {
+            var idp = new OidcProvider
+            {
+                Scheme = "scheme",
+                ClientId = "client",
+                ClientSecret = "secret",
+                Authority = "authority",
+                ResponseType = "code",
+                Scope = "",
+            };
+
+            var ctx = new IdentityProviderConfigurationValidationContext(idp);
+            await _validator.ValidateAsync(ctx);
+
+            ctx.IsValid.Should().BeFalse();
+            ctx.ErrorMessage.ToLowerInvariant().Should().Contain("scope");
+        }
+
+        [Fact]
+        [Trait("Category", Category)]
+        public async Task when_implicit_flow_missing_clientid_should_succeed()
+        {
+            var idp = new OidcProvider
+            {
+                Scheme = "scheme",
+                ClientId = "client",
+                ClientSecret = "",
+                Authority = "authority",
+                ResponseType = "id_token",
+                Scope = "openid scope",
+            };
+
+            var ctx = new IdentityProviderConfigurationValidationContext(idp);
+            await _validator.ValidateAsync(ctx);
+
+            ctx.IsValid.Should().BeTrue();
+        }
+    }
+}


### PR DESCRIPTION
This PR adds infrastructure to validate OidcProvider models that are being loaded from the database when using the [dynamic providers](https://docs.duendesoftware.com/identityserver/v5/ui/login/dynamicproviders/) feature. This ensures that the configuration necessary to support the identity provider has been set properly and provides errors for the missing or invalid configuration.

Fixes: #275