### PR TITLE
Fix bug when storing session id in refresh token

### DIFF
--- a/src/IdentityServer/Services/Default/DefaultRefreshTokenService.cs
+++ b/src/IdentityServer/Services/Default/DefaultRefreshTokenService.cs
@@ -193,6 +193,7 @@ namespace Duende.IdentityServer.Services
             var refreshToken = new RefreshToken
             {
                 Subject = request.Subject,
+                SessionId = request.AccessToken.SessionId,
                 ClientId = request.Client.ClientId,
                 Description = request.Description,
                 AuthorizedScopes = request.AuthorizedScopes,

--- a/src/Storage/Models/RefreshToken.cs
+++ b/src/Storage/Models/RefreshToken.cs
@@ -115,7 +115,7 @@ namespace Duende.IdentityServer.Models
         /// <value>
         /// The session identifier.
         /// </value>
-        public string SessionId => Subject?.FindFirst(JwtClaimTypes.SessionId)?.Value;
+        public string SessionId { get; set; }
 
         /// <summary>
         /// Gets the description the user assigned to the device being authorized.

--- a/test/IdentityServer.UnitTests/Services/Default/DefaultPersistedGrantServiceTests.cs
+++ b/test/IdentityServer.UnitTests/Services/Default/DefaultPersistedGrantServiceTests.cs
@@ -338,7 +338,8 @@ namespace UnitTests.Services.Default
                 var handle1 = await _refreshTokens.StoreRefreshTokenAsync(new RefreshToken()
                 {
                     ClientId = "client1",
-                    Subject = new IdentityServerUser("123") { AdditionalClaims = new[] { new Claim("sid", "session1") } }.CreatePrincipal(),
+                    Subject = new IdentityServerUser("123").CreatePrincipal(),
+                    SessionId = "session1",
                     AuthorizedScopes = new[] { "baz" },
                     CreationTime = DateTime.UtcNow,
                     Lifetime = 10,
@@ -346,7 +347,8 @@ namespace UnitTests.Services.Default
                 var handle2 = await _refreshTokens.StoreRefreshTokenAsync(new RefreshToken()
                 {
                     ClientId = "client2",
-                    Subject = new IdentityServerUser("123") { AdditionalClaims = new[] { new Claim("sid", "session1") } }.CreatePrincipal(),
+                    Subject = new IdentityServerUser("123").CreatePrincipal(),
+                    SessionId = "session1",
                     AuthorizedScopes = new[] { "baz" },
                     CreationTime = DateTime.UtcNow,
                     Lifetime = 10,
@@ -354,7 +356,8 @@ namespace UnitTests.Services.Default
                 var handle3 = await _refreshTokens.StoreRefreshTokenAsync(new RefreshToken()
                 {
                     ClientId = "client3",
-                    Subject = new IdentityServerUser("123") { AdditionalClaims = new[] { new Claim("sid", "session3") } }.CreatePrincipal(),
+                    Subject = new IdentityServerUser("123").CreatePrincipal(),
+                    SessionId = "session3",
                     AuthorizedScopes = new[] { "baz" },
                     CreationTime = DateTime.UtcNow,
                     Lifetime = 10,
@@ -373,7 +376,8 @@ namespace UnitTests.Services.Default
                 var handle1 = await _refreshTokens.StoreRefreshTokenAsync(new RefreshToken()
                 {
                     ClientId = "client1",
-                    Subject = new IdentityServerUser("123") { AdditionalClaims = new[] { new Claim("sid", "session1") } }.CreatePrincipal(),
+                    Subject = new IdentityServerUser("123").CreatePrincipal(),
+                    SessionId = "session1",
                     AuthorizedScopes = new[] { "baz" },
                     CreationTime = DateTime.UtcNow,
                     Lifetime = 10,
@@ -381,7 +385,8 @@ namespace UnitTests.Services.Default
                 var handle2 = await _refreshTokens.StoreRefreshTokenAsync(new RefreshToken()
                 {
                     ClientId = "client2",
-                    Subject = new IdentityServerUser("123") { AdditionalClaims = new[] { new Claim("sid", "session1") } }.CreatePrincipal(),
+                    Subject = new IdentityServerUser("123").CreatePrincipal(),
+                    SessionId = "session1",
                     AuthorizedScopes = new[] { "baz" },
                     CreationTime = DateTime.UtcNow,
                     Lifetime = 10,
@@ -389,7 +394,8 @@ namespace UnitTests.Services.Default
                 var handle3 = await _refreshTokens.StoreRefreshTokenAsync(new RefreshToken()
                 {
                     ClientId = "client3",
-                    Subject = new IdentityServerUser("123") { AdditionalClaims = new[] { new Claim("sid", "session3") } }.CreatePrincipal(),
+                    Subject = new IdentityServerUser("123").CreatePrincipal(),
+                    SessionId = "session3",
                     AuthorizedScopes = new[] { "baz" },
                     CreationTime = DateTime.UtcNow,
                     Lifetime = 10,
@@ -408,7 +414,8 @@ namespace UnitTests.Services.Default
                 var handle1 = await _refreshTokens.StoreRefreshTokenAsync(new RefreshToken()
                 {
                     ClientId = "client1",
-                    Subject = new IdentityServerUser("123") { AdditionalClaims = new[] { new Claim("sid", "session1") } }.CreatePrincipal(),
+                    Subject = new IdentityServerUser("123").CreatePrincipal(),
+                    SessionId = "session1",
                     AuthorizedScopes = new[] { "baz" },
                     CreationTime = DateTime.UtcNow,
                     Lifetime = 10,
@@ -416,7 +423,8 @@ namespace UnitTests.Services.Default
                 var handle2 = await _refreshTokens.StoreRefreshTokenAsync(new RefreshToken()
                 {
                     ClientId = "client2",
-                    Subject = new IdentityServerUser("123") { AdditionalClaims = new[] { new Claim("sid", "session1") } }.CreatePrincipal(),
+                    Subject = new IdentityServerUser("123").CreatePrincipal(),
+                    SessionId = "session1",
                     AuthorizedScopes = new[] { "baz" },
                     CreationTime = DateTime.UtcNow,
                     Lifetime = 10,
@@ -424,7 +432,8 @@ namespace UnitTests.Services.Default
                 var handle3 = await _refreshTokens.StoreRefreshTokenAsync(new RefreshToken()
                 {
                     ClientId = "client3",
-                    Subject = new IdentityServerUser("123") { AdditionalClaims = new[] { new Claim("sid", "session1") } }.CreatePrincipal(),
+                    Subject = new IdentityServerUser("123").CreatePrincipal(),
+                    SessionId = "session1",
                     AuthorizedScopes = new[] { "baz" },
                     CreationTime = DateTime.UtcNow,
                     Lifetime = 10,
@@ -432,7 +441,8 @@ namespace UnitTests.Services.Default
                 var handle4 = await _refreshTokens.StoreRefreshTokenAsync(new RefreshToken()
                 {
                     ClientId = "client1",
-                    Subject = new IdentityServerUser("123") { AdditionalClaims = new[] { new Claim("sid", "session2") } }.CreatePrincipal(),
+                    Subject = new IdentityServerUser("123").CreatePrincipal(),
+                    SessionId = "session2",
                     AuthorizedScopes = new[] { "baz" },
                     CreationTime = DateTime.UtcNow,
                     Lifetime = 10,
@@ -452,7 +462,8 @@ namespace UnitTests.Services.Default
                 var handle1 = await _refreshTokens.StoreRefreshTokenAsync(new RefreshToken()
                 {
                     ClientId = "client1",
-                    Subject = new IdentityServerUser("123") { AdditionalClaims = new[] { new Claim("sid", "session1") } }.CreatePrincipal(),
+                    Subject = new IdentityServerUser("123").CreatePrincipal(),
+                    SessionId = "session1",
                     AuthorizedScopes = new[] { "baz" },
                     CreationTime = DateTime.UtcNow,
                     Lifetime = 10,
@@ -460,7 +471,8 @@ namespace UnitTests.Services.Default
                 var handle2 = await _refreshTokens.StoreRefreshTokenAsync(new RefreshToken()
                 {
                     ClientId = "client2",
-                    Subject = new IdentityServerUser("123") { AdditionalClaims = new[] { new Claim("sid", "session1") } }.CreatePrincipal(),
+                    Subject = new IdentityServerUser("123").CreatePrincipal(),
+                    SessionId = "session1",
                     AuthorizedScopes = new[] { "baz" },
                     CreationTime = DateTime.UtcNow,
                     Lifetime = 10,
@@ -468,7 +480,8 @@ namespace UnitTests.Services.Default
                 var handle3 = await _refreshTokens.StoreRefreshTokenAsync(new RefreshToken()
                 {
                     ClientId = "client3",
-                    Subject = new IdentityServerUser("123") { AdditionalClaims = new[] { new Claim("sid", "session1") } }.CreatePrincipal(),
+                    Subject = new IdentityServerUser("123").CreatePrincipal(),
+                    SessionId = "session1",
                     AuthorizedScopes = new[] { "baz" },
                     CreationTime = DateTime.UtcNow,
                     Lifetime = 10,
@@ -476,7 +489,8 @@ namespace UnitTests.Services.Default
                 var handle4 = await _refreshTokens.StoreRefreshTokenAsync(new RefreshToken()
                 {
                     ClientId = "client1",
-                    Subject = new IdentityServerUser("123") { AdditionalClaims = new[] { new Claim("sid", "session2") } }.CreatePrincipal(),
+                    Subject = new IdentityServerUser("123").CreatePrincipal(),
+                    SessionId = "session2",
                     AuthorizedScopes = new[] { "baz" },
                     CreationTime = DateTime.UtcNow,
                     Lifetime = 10,

--- a/test/IdentityServer.UnitTests/Stores/Default/DefaultPersistedGrantStoreTests.cs
+++ b/test/IdentityServer.UnitTests/Stores/Default/DefaultPersistedGrantStoreTests.cs
@@ -106,6 +106,7 @@ namespace UnitTests.Stores.Default
             {
                 CreationTime = DateTime.UtcNow,
                 Lifetime = 10,
+                SessionId = "sessionid",
                 AccessToken = new Token
                 {
                     ClientId = "client",
@@ -119,7 +120,7 @@ namespace UnitTests.Stores.Default
                         new Claim("sid", "sessionid"),
                         new Claim("scope", "s1"),
                         new Claim("scope", "s2"),
-                    }
+                    },
                 },
                 Version = 4
             };


### PR DESCRIPTION
When a refresh token was being created in the grant store, the session id value was being sourced from the wrong place. This most commonly meant that the SessionId column in the persisted grants table was null for refresh tokens.