### PR TITLE
Remove custom serialization handling for AuthenticationProperties

### DIFF
--- a/src/IdentityServer/Infrastructure/DistributedCacheStateDataFormatter.cs
+++ b/src/IdentityServer/Infrastructure/DistributedCacheStateDataFormatter.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.DependencyInjection;
 using System;
-using System.Collections.Generic;
 
 namespace Duende.IdentityServer.Infrastructure
 {
@@ -55,7 +54,7 @@ namespace Duende.IdentityServer.Infrastructure
         {
             var key = Guid.NewGuid().ToString();
             var cacheKey = $"{CacheKeyPrefix}-{_name}-{purpose}-{key}";
-            var json = ObjectSerializer.ToString(data.Items);
+            var json = ObjectSerializer.ToString(data);
 
             var options = new DistributedCacheEntryOptions();
             if (data.ExpiresUtc.HasValue)
@@ -107,8 +106,7 @@ namespace Duende.IdentityServer.Infrastructure
                 return null;
             }
 
-            var items = ObjectSerializer.FromString<Dictionary<string, string>>(json);
-            var props = new AuthenticationProperties(items);
+            var props = ObjectSerializer.FromString<AuthenticationProperties>(json);
             return props;
         }
     }


### PR DESCRIPTION
.NET 5 broke JSON serialization for the AuthenticationProperties class (when used in AddOidcStateDataFormatterCache), so we had custom handling for it. .NET 6 fixed the JSON serialization, so this PR removes our workaround for that prior .NET bug.

Fixes: #168