### PR TITLE
Fix bug in cache removal for DistributedCacheAuthorizationParametersMessageStore

### DIFF
--- a/src/IdentityServer/Stores/Default/DistributedCacheAuthorizationParametersMessageStore.cs
+++ b/src/IdentityServer/Stores/Default/DistributedCacheAuthorizationParametersMessageStore.cs
@@ -71,7 +71,8 @@ namespace Duende.IdentityServer.Stores.Default
         /// <inheritdoc/>
         public virtual Task DeleteAsync(string id)
         {
-            return _distributedCache.RemoveAsync(id);
+            var cacheKey = $"{CacheKeyPrefix}-{id}";
+            return _distributedCache.RemoveAsync(cacheKey);
         }
     }
 }

--- a/test/IdentityServer.UnitTests/Common/MockDistributedCache.cs
+++ b/test/IdentityServer.UnitTests/Common/MockDistributedCache.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Distributed;
+
+namespace UnitTests.Common
+{
+    public class MockDistributedCache : IDistributedCache
+    {
+        public Dictionary<string, (byte[] Bytes, DistributedCacheEntryOptions Options)> Items { get; set; } = new Dictionary<string, (byte[] Bytes, DistributedCacheEntryOptions Options)>();
+
+        public byte[] Get(string key)
+        {
+            if (Items.TryGetValue(key, out var item))
+            {
+                return item.Bytes;
+            }
+            return null;
+        }
+
+        public Task<byte[]> GetAsync(string key, CancellationToken token = default)
+        {
+            return Task.FromResult(Get(key));
+        }
+
+        public void Refresh(string key)
+        {
+        }
+
+        public Task RefreshAsync(string key, CancellationToken token = default)
+        {
+            return Task.CompletedTask;
+        }
+
+        public void Remove(string key)
+        {
+            Items.Remove(key);
+        }
+
+        public Task RemoveAsync(string key, CancellationToken token = default)
+        {
+            Remove(key);
+            return Task.CompletedTask;
+        }
+
+        public void Set(string key, byte[] value, DistributedCacheEntryOptions options)
+        {
+            Items[key] = (value, options);
+        }
+
+        public Task SetAsync(string key, byte[] value, DistributedCacheEntryOptions options, CancellationToken token = default)
+        {
+            Set(key, value, options);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/test/IdentityServer.UnitTests/Stores/Default/DistributedCacheAuthorizationParametersMessageStoreTests.cs
+++ b/test/IdentityServer.UnitTests/Stores/Default/DistributedCacheAuthorizationParametersMessageStoreTests.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Duende.IdentityServer;
+using Duende.IdentityServer.Extensions;
+using Duende.IdentityServer.Models;
+using Duende.IdentityServer.Services;
+using Duende.IdentityServer.Stores;
+using Duende.IdentityServer.Stores.Default;
+using Duende.IdentityServer.Stores.Serialization;
+using FluentAssertions;
+using UnitTests.Common;
+using Xunit;
+
+namespace UnitTests.Stores.Default
+{
+    public class DistributedCacheAuthorizationParametersMessageStoreTests
+    {
+        MockDistributedCache _mockCache = new MockDistributedCache();
+        DistributedCacheAuthorizationParametersMessageStore _subject;
+        public DistributedCacheAuthorizationParametersMessageStoreTests()
+        {
+            _subject = new DistributedCacheAuthorizationParametersMessageStore(_mockCache, new DefaultHandleGenerationService());
+        }
+
+        [Fact]
+        public async Task DeleteAsync_should_remove_item()
+        {
+            _mockCache.Items.Count.Should().Be(0);
+
+            var msg = new Message<IDictionary<string, string[]>>(new Dictionary<string, string[]>());
+            var id = await _subject.WriteAsync(msg);
+
+            _mockCache.Items.Count.Should().Be(1);
+
+            await _subject.DeleteAsync(id);
+
+            _mockCache.Items.Count.Should().Be(0);
+        }
+    }
+}


### PR DESCRIPTION
The wrong key was being used.