### PR TITLE
Add finer grained IdentityServerBuilderExtensions for registering cookie authentication services

### DIFF
--- a/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
-        /// Adds the default cookie handlers and corresponding configuration
+        /// Adds the default infrastructure for cookie authentication in IdentityServer.
         /// </summary>
         /// <param name="builder">The builder.</param>
         /// <returns></returns>

--- a/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -62,6 +62,18 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns></returns>
         public static IIdentityServerBuilder AddCookieAuthentication(this IIdentityServerBuilder builder)
         {
+            return builder
+                .AddDefaultCookieHandlers()
+                .AddCookieAuthenticationExtensions();
+        }
+
+        /// <summary>
+        /// Adds the default cookie handlers and corresponding configuration
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <returns></returns>
+        public static IIdentityServerBuilder AddDefaultCookieHandlers(this IIdentityServerBuilder builder)
+        {
             builder.Services.AddAuthentication(IdentityServerConstants.DefaultCookieAuthenticationScheme)
                 .AddCookie(IdentityServerConstants.DefaultCookieAuthenticationScheme)
                 .AddCookie(IdentityServerConstants.ExternalCookieAuthenticationScheme);
@@ -69,7 +81,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             return builder;
         }
-        
+
         /// <summary>
         /// Adds the necessary decorators for cookie authentication required by IdentityServer
         /// </summary>

--- a/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -65,8 +65,18 @@ namespace Microsoft.Extensions.DependencyInjection
             builder.Services.AddAuthentication(IdentityServerConstants.DefaultCookieAuthenticationScheme)
                 .AddCookie(IdentityServerConstants.DefaultCookieAuthenticationScheme)
                 .AddCookie(IdentityServerConstants.ExternalCookieAuthenticationScheme);
-
             builder.Services.AddSingleton<IConfigureOptions<CookieAuthenticationOptions>, ConfigureInternalCookieOptions>();
+
+            return builder;
+        }
+        
+        /// <summary>
+        /// Adds the necessary decorators for cookie authentication required by IdentityServer
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <returns></returns>
+        public static IIdentityServerBuilder AddCookieAuthenticationExtensions(this IIdentityServerBuilder builder)
+        {
             builder.Services.AddSingleton<IPostConfigureOptions<CookieAuthenticationOptions>, PostConfigureInternalCookieOptions>();
             builder.Services.AddTransientDecorator<IAuthenticationService, IdentityServerAuthenticationService>();
             builder.Services.AddTransientDecorator<IAuthenticationHandlerProvider, FederatedSignoutAuthenticationHandlerProvider>();

--- a/src/IdentityServer/Configuration/DependencyInjection/IdentityServerServiceCollectionExtensions.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/IdentityServerServiceCollectionExtensions.cs
@@ -37,7 +37,6 @@ namespace Microsoft.Extensions.DependencyInjection
             builder
                 .AddRequiredPlatformServices()
                 .AddCookieAuthentication()
-                .AddCookieAuthenticationExtensions()
                 .AddCoreServices()
                 .AddDefaultEndpoints()
                 .AddPluggableServices()

--- a/src/IdentityServer/Configuration/DependencyInjection/IdentityServerServiceCollectionExtensions.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/IdentityServerServiceCollectionExtensions.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Extensions.DependencyInjection
             builder
                 .AddRequiredPlatformServices()
                 .AddCookieAuthentication()
+                .AddCookieAuthenticationExtensions()
                 .AddCoreServices()
                 .AddDefaultEndpoints()
                 .AddPluggableServices()

--- a/src/IdentityServer/Hosting/IdentityServerAuthenticationService.cs
+++ b/src/IdentityServer/Hosting/IdentityServerAuthenticationService.cs
@@ -30,8 +30,6 @@ namespace Duende.IdentityServer.Hosting
         private readonly IAuthenticationSchemeProvider _schemes;
         private readonly ISystemClock _clock;
         private readonly IUserSession _session;
-        private readonly IBackChannelLogoutService _backChannelLogoutService;
-        private readonly IdentityServerOptions _options;
         private readonly ILogger<IdentityServerAuthenticationService> _logger;
 
         public IdentityServerAuthenticationService(
@@ -39,8 +37,6 @@ namespace Duende.IdentityServer.Hosting
             IAuthenticationSchemeProvider schemes,
             ISystemClock clock,
             IUserSession session,
-            IBackChannelLogoutService backChannelLogoutService,
-            IdentityServerOptions options,
             ILogger<IdentityServerAuthenticationService> logger)
         {
             _inner = decorator.Instance;
@@ -48,8 +44,6 @@ namespace Duende.IdentityServer.Hosting
             _schemes = schemes;
             _clock = clock;
             _session = session;
-            _backChannelLogoutService = backChannelLogoutService;
-            _options = options;
             _logger = logger;
         }
 

--- a/src/IdentityServer/Hosting/IdentityServerAuthenticationService.cs
+++ b/src/IdentityServer/Hosting/IdentityServerAuthenticationService.cs
@@ -11,7 +11,6 @@ using Duende.IdentityServer.Extensions;
 using System;
 using IdentityModel;
 using System.Linq;
-using Duende.IdentityServer.Configuration;
 using Duende.IdentityServer.Configuration.DependencyInjection;
 using Duende.IdentityServer.Services;
 


### PR DESCRIPTION
When registering IdentityServer in the DI system, we have a `AddCookieAuthentication` API to add the default services needed by IdentityServer. If you want more fine grained control over the cookie authentication handler, a custom one can be registered, but with the above `AddCookieAuthentication` our default is still added but unused. 

This PR introduces new APIs to allow finer grained control over how much of our default cookie authentication services are added to the host. A `AddDefaultCookieHandlers` API will register our default cookie handlers and `AddCookieAuthenticationExtensions` API will add our mandatory decorators (and other services) that IdentityServer needs for session management.

The existing `AddCookieAuthentication` remains the same and now internally just invokes the two new APIs.

This PR addresses the first part of: https://github.com/DuendeSoftware/IdentityServer/issues/344