### PR TITLE
Change cache design for resource store cache

### DIFF
--- a/src/IdentityServer/Hosting/DynamicProviders/Store/CachingIdentityProviderStore.cs
+++ b/src/IdentityServer/Hosting/DynamicProviders/Store/CachingIdentityProviderStore.cs
@@ -84,15 +84,10 @@ namespace Duende.IdentityServer.Hosting.DynamicProviders
                     var optionsCache = _httpContextAccessor.HttpContext.RequestServices.GetService(optionsMonitorType);
                     if (optionsCache != null)
                     {
-                        var optionsMonitorType = typeof(IOptionsMonitorCache<>).MakeGenericType(provider.OptionsType);
-                        var optionsCache = _httpContextAccessor.HttpContext.RequestServices.GetService(optionsMonitorType);
-                        if (optionsCache != null)
+                        var mi = optionsMonitorType.GetMethod("TryRemove");
+                        if (mi != null)
                         {
-                            var mi = optionsMonitorType.GetMethod("TryRemove");
-                            if (mi != null)
-                            {
-                                mi.Invoke(optionsCache, new[] { idp.Scheme });
-                            }
+                            mi.Invoke(optionsCache, new[] { idp.Scheme });
                         }
                     }
                 }

--- a/src/IdentityServer/Stores/Caching/CachingResourceStore.cs
+++ b/src/IdentityServer/Stores/Caching/CachingResourceStore.cs
@@ -36,10 +36,10 @@ namespace Duende.IdentityServer.Stores
         /// </summary>
         /// <param name="options">The options.</param>
         /// <param name="inner">The inner.</param>
-        /// <param name="identityCache">The identity cache.</param>
-        /// <param name="apisCache">The API cache.</param>
-        /// <param name="scopeCache"></param>
-        /// <param name="allCache">All cache.</param>
+        /// <param name="identityCache">The IdentityResource cache.</param>
+        /// <param name="apisCache">The ApiResource cache.</param>
+        /// <param name="scopeCache">The ApiScope cache.</param>
+        /// <param name="allCache">All Resources cache.</param>
         public CachingResourceStore(IdentityServerOptions options, T inner, 
             ICache<IdentityResource> identityCache, 
             ICache<ApiResource> apisCache,
@@ -133,9 +133,9 @@ namespace Duende.IdentityServer.Stores
 
                 // create a key based on the names we're about to lookup
                 var itemsKey = keyPrefix + GetKey(uncachedNames);
-                // expire this use 10% as this should expire much faster than the normal items
+                // expire this entry much faster than the normal items
                 var itemsDuration = _options.Caching.ResourceStoreExpiration / 20;
-                // do the cache lookup
+                // do the cache/DB lookup
                 var resources = await _allCache.GetOrAddAsync(itemsKey, itemsDuration, async () => await getResourcesFunc(uncachedNames));
                 
                 // get the specific items from the Resources object

--- a/test/IdentityServer.UnitTests/Common/MockCache.cs
+++ b/test/IdentityServer.UnitTests/Common/MockCache.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Duende.IdentityServer.Services;
+
+namespace UnitTests.Common
+{
+    public class MockCache<T> : ICache<T>
+        where T : class
+    {
+        public Dictionary<string, T> Items { get; set; } = new Dictionary<string, T>();
+         
+
+        public Task<T> GetAsync(string key)
+        {
+            Items.TryGetValue(key, out var item);
+            return Task.FromResult(item);
+        }
+
+        public async Task<T> GetOrAddAsync(string key, TimeSpan duration, Func<Task<T>> get)
+        {
+            var item = await GetAsync(key);
+            if (item == null)
+            {
+                item = await get();
+                await SetAsync(key, item, duration);
+            }
+            return item;
+        }
+
+        public Task RemoveAsync(string key)
+        {
+            Items.Remove(key);
+            return Task.CompletedTask;
+        }
+
+        public Task SetAsync(string key, T item, TimeSpan expiration)
+        {
+            Items[key] = item;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/test/IdentityServer.UnitTests/Stores/Default/CachingResourceStoreTests.cs
+++ b/test/IdentityServer.UnitTests/Stores/Default/CachingResourceStoreTests.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Duende.IdentityServer;
+using Duende.IdentityServer.Configuration;
+using Duende.IdentityServer.Extensions;
+using Duende.IdentityServer.Models;
+using Duende.IdentityServer.Stores;
+using Duende.IdentityServer.Stores.Serialization;
+using FluentAssertions;
+using UnitTests.Common;
+using Xunit;
+
+namespace UnitTests.Stores.Default
+{
+    public class CachingResourceStoreTests
+    {
+        List<IdentityResource> _identityResources = new List<IdentityResource>();
+        List<ApiResource> _apiResources = new List<ApiResource>();
+        List<ApiScope> _apiScopes = new List<ApiScope>();
+        InMemoryResourcesStore _store;
+        IdentityServerOptions _options = new IdentityServerOptions();
+
+        MockCache<ApiScope> _scopeCache = new MockCache<ApiScope>();
+
+        CachingResourceStore<InMemoryResourcesStore> _subject;
+
+        public CachingResourceStoreTests()
+        {
+            _apiScopes.Add(new ApiScope("scope1"));
+            _apiScopes.Add(new ApiScope("scope2"));
+            _apiScopes.Add(new ApiScope("scope3"));
+
+            _store = new InMemoryResourcesStore(_identityResources, _apiResources, _apiScopes);
+            _subject = new CachingResourceStore<InMemoryResourcesStore>(_options, _store,
+                new MockCache<IEnumerable<IdentityResource>>(),
+                new MockCache<IEnumerable<ApiResource>>(),
+                new MockCache<IEnumerable<ApiResource>>(),
+                _scopeCache,
+                new MockCache<Resources>());
+        }
+
+        [Fact]
+        public async Task FindApiScopesByNameAsync_should_populate_cache()
+        {
+            _scopeCache.Items.Count.Should().Be(0);
+
+            var items = await _subject.FindApiScopesByNameAsync(new[] { "scope3", "scope1", "scope2", "invalid" });
+            items.Count().Should().Be(3);
+
+            _scopeCache.Items.Count.Should().Be(3);
+        }
+        
+        [Fact]
+        public async Task FindApiScopesByNameAsync_should_populate_missing_cache_items()
+        {
+            var items = await _subject.FindApiScopesByNameAsync(new[] { "scope1" });
+            items.Count().Should().Be(1);
+            _scopeCache.Items.Count.Should().Be(1);
+
+            _apiScopes.Remove(_apiScopes.Single(x => x.Name == "scope1"));
+            items = await _subject.FindApiScopesByNameAsync(new[] { "scope1", "scope2" });
+            items.Count().Should().Be(2);
+            _scopeCache.Items.Count.Should().Be(2);
+
+            _apiScopes.Remove(_apiScopes.Single(x => x.Name == "scope2"));
+            items = await _subject.FindApiScopesByNameAsync(new[] { "scope3", "scope2" });
+            items.Count().Should().Be(2);
+            _scopeCache.Items.Count.Should().Be(3);
+
+            _apiScopes.Remove(_apiScopes.Single(x => x.Name == "scope3"));
+            items = await _subject.FindApiScopesByNameAsync(new[] { "scope3", "scope1", "scope2" });
+            items.Count().Should().Be(3);
+            _scopeCache.Items.Count.Should().Be(3);
+        }
+    }
+}

--- a/test/IdentityServer.UnitTests/Stores/Default/CachingResourceStoreTests.cs
+++ b/test/IdentityServer.UnitTests/Stores/Default/CachingResourceStoreTests.cs
@@ -2,17 +2,12 @@
 // See LICENSE in the project root for license information.
 
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Security.Claims;
 using System.Threading.Tasks;
-using Duende.IdentityServer;
 using Duende.IdentityServer.Configuration;
-using Duende.IdentityServer.Extensions;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Stores;
-using Duende.IdentityServer.Stores.Serialization;
 using FluentAssertions;
 using UnitTests.Common;
 using Xunit;
@@ -28,6 +23,7 @@ namespace UnitTests.Stores.Default
         IdentityServerOptions _options = new IdentityServerOptions();
 
         MockCache<ApiScope> _scopeCache = new MockCache<ApiScope>();
+        MockCache<Resources> _resourceCache = new MockCache<Resources>();
 
         CachingResourceStore<InMemoryResourcesStore> _subject;
 
@@ -36,14 +32,16 @@ namespace UnitTests.Stores.Default
             _apiScopes.Add(new ApiScope("scope1"));
             _apiScopes.Add(new ApiScope("scope2"));
             _apiScopes.Add(new ApiScope("scope3"));
+            _apiScopes.Add(new ApiScope("scope4"));
 
             _store = new InMemoryResourcesStore(_identityResources, _apiResources, _apiScopes);
-            _subject = new CachingResourceStore<InMemoryResourcesStore>(_options, _store,
-                new MockCache<IEnumerable<IdentityResource>>(),
-                new MockCache<IEnumerable<ApiResource>>(),
-                new MockCache<IEnumerable<ApiResource>>(),
+            _subject = new CachingResourceStore<InMemoryResourcesStore>(
+                _options, 
+                _store,
+                new MockCache<IdentityResource>(),
+                new MockCache<ApiResource>(),
                 _scopeCache,
-                new MockCache<Resources>());
+                _resourceCache);
         }
 
         [Fact]
@@ -60,6 +58,8 @@ namespace UnitTests.Stores.Default
         [Fact]
         public async Task FindApiScopesByNameAsync_should_populate_missing_cache_items()
         {
+            _scopeCache.Items.Count.Should().Be(0);
+
             var items = await _subject.FindApiScopesByNameAsync(new[] { "scope1" });
             items.Count().Should().Be(1);
             _scopeCache.Items.Count.Should().Be(1);
@@ -70,14 +70,15 @@ namespace UnitTests.Stores.Default
             _scopeCache.Items.Count.Should().Be(2);
 
             _apiScopes.Remove(_apiScopes.Single(x => x.Name == "scope2"));
-            items = await _subject.FindApiScopesByNameAsync(new[] { "scope3", "scope2" });
-            items.Count().Should().Be(2);
-            _scopeCache.Items.Count.Should().Be(3);
+            items = await _subject.FindApiScopesByNameAsync(new[] { "scope3", "scope2", "scope4" });
+            items.Count().Should().Be(3);
+            _scopeCache.Items.Count.Should().Be(4);
 
+            // this shows we will find it in the cache, even if removed from the DB
             _apiScopes.Remove(_apiScopes.Single(x => x.Name == "scope3"));
             items = await _subject.FindApiScopesByNameAsync(new[] { "scope3", "scope1", "scope2" });
             items.Count().Should().Be(3);
-            _scopeCache.Items.Count.Should().Be(3);
+            _scopeCache.Items.Count.Should().Be(4);
         }
     }
 }


### PR DESCRIPTION
The resource store cache caches items based on the collection of requested items (e.g. scopes), rather then caching individual items. It was done that way given the expectation that client apps will make all of their requests with the same set of scopes, so instead of breaking down the cache into individual items, we used the entire set of scopes requested as the key and the entire set of matching resources is what's cached.

This PR changes that and stores items individually by name in the appropriate cache. This now requires items to be looked up first in the cache one by one, and then any remaining items requested not found in the cache to be looked up in the store, and then those results cached one by one.