### PR TITLE
Dependency cleanup to allow for runtime provided System.Text.Json

### DIFF
--- a/src/IdentityServer/Duende.IdentityServer.csproj
+++ b/src/IdentityServer/Duende.IdentityServer.csproj
@@ -15,9 +15,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="IdentityModel" />
-      
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" />
   </ItemGroup>
 

--- a/src/Storage/Duende.IdentityServer.Storage.csproj
+++ b/src/Storage/Duende.IdentityServer.Storage.csproj
@@ -10,7 +10,6 @@
 
     <ItemGroup>
         <PackageReference Include="IdentityModel" />
-        <PackageReference Include="System.Text.Json" />
         <PackageReference Include="Microsoft.AspNetCore.DataProtection.Abstractions" />
     </ItemGroup>
 


### PR DESCRIPTION
@leastprivilege this is the continuation of [PR 415 on IdentityModel](https://github.com/IdentityModel/IdentityModel/pull/415)

Rationale:
Microsoft.AspNetCore.Authentication.OpenIdConnect provides Microsoft.IdentityModel.Protocols.OpenIdConnect to Duende.IdentityServer
Duende.IdentityServer.Storage provides IdentityModel to Duende.IdentityServer
IdentityModel provides System.Text.Json to Duende.IdentityServer.Storage and by proxy Duende.IdentityServer

Once you release the version of IdentityModel with PR#415 the next release of IdentityServer with these changes will use the runtime provided STJ assemblies.