### PR TITLE
add SaveChangesAsync for backwards compat with prior version

### DIFF
--- a/src/EntityFramework.Storage/DbContexts/PersistedGrantDbContext.cs
+++ b/src/EntityFramework.Storage/DbContexts/PersistedGrantDbContext.cs
@@ -3,6 +3,7 @@
 
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Duende.IdentityServer.EntityFramework.Entities;
 using Duende.IdentityServer.EntityFramework.Extensions;
@@ -49,51 +50,16 @@ namespace Duende.IdentityServer.EntityFramework.DbContexts
         {
         }
 
-        /// <summary>
-        /// Gets or sets the persisted grants.
-        /// </summary>
-        /// <value>
-        /// The persisted grants.
-        /// </value>
+        /// <inheritdoc/>
         public DbSet<PersistedGrant> PersistedGrants { get; set; }
 
-        /// <summary>
-        /// Gets or sets the device codes.
-        /// </summary>
-        /// <value>
-        /// The device codes.
-        /// </value>
+        /// <inheritdoc/>
         public DbSet<DeviceFlowCodes> DeviceFlowCodes { get; set; }
 
-        /// <summary>
-        /// Gets or sets the keys.
-        /// </summary>
-        /// <value>
-        /// The keys.
-        /// </value>
+        /// <inheritdoc/>
         public DbSet<Key> Keys { get; set; }
 
-        /// <summary>
-        /// Saves the changes.
-        /// </summary>
-        /// <returns></returns>
-        public virtual Task<int> SaveChangesAsync()
-        {
-            return base.SaveChangesAsync();
-        }
-
-        /// <summary>
-        /// Override this method to further configure the model that was discovered by convention from the entity types
-        /// exposed in <see cref="T:Microsoft.EntityFrameworkCore.DbSet`1" /> properties on your derived context. The resulting model may be cached
-        /// and re-used for subsequent instances of your derived context.
-        /// </summary>
-        /// <param name="modelBuilder">The builder being used to construct the model for this context. Databases (and other extensions) typically
-        /// define extension methods on this object that allow you to configure aspects of the model that are specific
-        /// to a given database.</param>
-        /// <remarks>
-        /// If a model is explicitly set on the options for this context (via <see cref="M:Microsoft.EntityFrameworkCore.DbContextOptionsBuilder.UseModel(Microsoft.EntityFrameworkCore.Metadata.IModel)" />)
-        /// then this method will not be run.
-        /// </remarks>
+        /// <inheritdoc/>
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             var storeOptions = this.GetService<OperationalStoreOptions>();

--- a/src/EntityFramework.Storage/Interfaces/IPersistedGrantDbContext.cs
+++ b/src/EntityFramework.Storage/Interfaces/IPersistedGrantDbContext.cs
@@ -32,7 +32,6 @@ namespace Duende.IdentityServer.EntityFramework.Interfaces
         /// </value>
         DbSet<DeviceFlowCodes> DeviceFlowCodes { get; set; }
 
-
         /// <summary>
         /// Gets or sets the keys.
         /// </summary>
@@ -46,6 +45,15 @@ namespace Duende.IdentityServer.EntityFramework.Interfaces
         /// Saves the changes.
         /// </summary>
         /// <returns></returns>
-        Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
+        Task<int> SaveChangesAsync(CancellationToken cancellationToken);
+
+        // this is here only because of this: https://github.com/DuendeSoftware/IdentityServer/issues/472
+        // and because Microsoft implements the old API explicitly: https://github.com/dotnet/aspnetcore/blob/v6.0.0-rc.2.21480.10/src/Identity/ApiAuthorization.IdentityServer/src/Data/ApiAuthorizationDbContext.cs
+
+        /// <summary>
+        /// Saves the changes.
+        /// </summary>
+        /// <returns></returns>
+        Task<int> SaveChangesAsync() => SaveChangesAsync(CancellationToken.None);
     }
 }


### PR DESCRIPTION
In v6 we changed the signature of the `SaveChangesAsync` on `IPersistedGrantDbContext`. There are existing implementations that implement the older signature, so this PR adds back the old signature and so both can be supported.

Fixes: https://github.com/DuendeSoftware/IdentityServer/issues/472