### PR TITLE
fix Bullseye and SimpleExec refs

### DIFF
--- a/build/build.csproj
+++ b/build/build.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bullseye" Version="3.5.0" />
-    <PackageReference Include="SimpleExec" Version="6.3.0" />
+    <PackageReference Include="Bullseye" />
+    <PackageReference Include="SimpleExec" />
   </ItemGroup>
   
 </Project>


### PR DESCRIPTION
**What issue does this PR address?**

The versions in the csproj are not used. They are controlled by the top level `Directory.Build.targets`.

This totally threw me when I was trying to run the build for https://github.com/DuendeSoftware/IdentityServer/pull/501
