### PR TITLE
Improvement to OidcProvider

### DIFF
--- a/src/IdentityServer/Hosting/DynamicProviders/Oidc/OidcConfigureOptions.cs
+++ b/src/IdentityServer/Hosting/DynamicProviders/Oidc/OidcConfigureOptions.cs
@@ -28,6 +28,7 @@ namespace Duende.IdentityServer.Hosting.DynamicProviders
             context.AuthenticationOptions.ResponseType = context.IdentityProvider.ResponseType;
             context.AuthenticationOptions.ResponseMode =
                 context.IdentityProvider.ResponseType.Contains("id_token") ? "form_post" : "query";
+            context.AuthenticationOptions.UsePkce = context.IdentityProvider.UsePkce;
 
             context.AuthenticationOptions.Scope.Clear();
             foreach (var scope in context.IdentityProvider.Scopes)
@@ -36,7 +37,7 @@ namespace Duende.IdentityServer.Hosting.DynamicProviders
             }
 
             context.AuthenticationOptions.SaveTokens = true;
-            context.AuthenticationOptions.GetClaimsFromUserInfoEndpoint = true;
+            context.AuthenticationOptions.GetClaimsFromUserInfoEndpoint = context.IdentityProvider.GetClaimsFromUserInfoEndpoint;
             context.AuthenticationOptions.DisableTelemetry = true;
 #if NET5_0_OR_GREATER
             context.AuthenticationOptions.MapInboundClaims = false;

--- a/src/Storage/Models/OidcProvider.cs
+++ b/src/Storage/Models/OidcProvider.cs
@@ -66,6 +66,22 @@ namespace Duende.IdentityServer.Models
             get => this["Scope"] ?? "openid";
             set => this["Scope"] = value;
         }
+        /// <summary>
+        /// Indicates if userinfo endpoint is to be contacted. Defaults to true.
+        /// </summary>
+        public bool GetClaimsFromUserInfoEndpoint
+        {
+            get => this["GetClaimsFromUserInfoEndpoint"] == null || "true".Equals(this["GetClaimsFromUserInfoEndpoint"]);
+            set => this["GetClaimsFromUserInfoEndpoint"] = value ? "true" : "false";
+        }
+        /// <summary>
+        /// Indicates if PKCE should be used. Defaults to true.
+        /// </summary>
+        public bool UsePkce
+        {
+            get => this["UsePkce"] == null || "true".Equals(this["UsePkce"]);
+            set => this["UsePkce"] = value ? "true" : "false";
+        }
 
         /// <summary>
         /// Parses the scope into a collection.
@@ -75,10 +91,6 @@ namespace Duende.IdentityServer.Models
             get
             {
                 var scopes = Scope?.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries).ToList() ?? new List<string>();
-                if (!scopes.Contains("openid"))
-                {
-                    scopes.Add("openid");
-                }
                 return scopes;
             }
         }


### PR DESCRIPTION
This PR adds two new properties to the `OidcProvider` class to control the OIDC configuration:
* UsePkce (bool)
* GetClaimsFromUserInfoEndpoint (bool)

Both default to `true`. These two values were previously hard coded, so they can now be disabled (if needed).

Also, the calculated `Scopes` collection (based on the `Scope` property) no longer automatically adds `openid` to the returned collection. This is technically a breaking change, but would only manifest if the `Scope` is set and `openid` was omitted from the list of values.

Fixes: https://github.com/DuendeSoftware/IdentityServer/issues/484
Fixes: https://github.com/DuendeSoftware/IdentityServer/issues/493
