### PR TITLE
Handle TaskCanceledException

### DIFF
--- a/src/IdentityServer/Hosting/IdentityServerMiddleware.cs
+++ b/src/IdentityServer/Hosting/IdentityServerMiddleware.cs
@@ -92,6 +92,10 @@ namespace Duende.IdentityServer.Hosting
                     return;
                 }
             }
+            catch (TaskCanceledException ex)
+            {
+                _logger.LogDebug(ex, "Handled TaskCanceledException. Call stack for informational purposes.");
+            }
             catch (Exception ex)
             {
                 await events.RaiseAsync(new UnhandledExceptionEvent(ex));


### PR DESCRIPTION
Now that we're using the CancellationToken from the HttpContext, we might occasionally experience a non-error TaskCanceledException. This PR handles it so as to prevent the host's unhandled exception filter from running.

// @damianh