### PR TITLE
Add support to set subject for ciba login request outside of browser session

### DIFF
--- a/clients/src/ConsoleCibaClient/Program.cs
+++ b/clients/src/ConsoleCibaClient/Program.cs
@@ -47,8 +47,8 @@ namespace ConsoleCibaClient
                 ClientId = "ciba",
                 ClientSecret = "secret",
                 Scope = "openid profile email resource1.scope1 offline_access",
-                //LoginHint = username,
-                IdTokenHint = "eyJhbGciOiJSUzI1NiIsImtpZCI6IjkxODA1RkM0RjhBRDFBQkJEMjE0OTJFOUFBQ0Q3Njk2IiwidHlwIjoiSldUIn0.eyJpc3MiOiJodHRwczovL2xvY2FsaG9zdDo1MDAxIiwibmJmIjoxNjM4MzY4MjQ5LCJpYXQiOjE2MzgzNjgyNDksImV4cCI6MTYzODM2ODU0OSwiYXVkIjoiY2liYSIsImFtciI6WyJwd2QiXSwiYXRfaGFzaCI6IkpoU2N3eTJQNFhWOFA2WFphNGNIcmciLCJzaWQiOiI1NzAyRjUyMzNGRDU3NjBERkY5ODVFQjg3Q0E5MEUyNiIsInN1YiI6IjgxODcyNyIsImF1dGhfdGltZSI6MTYzODM2ODI0MiwiaWRwIjoibG9jYWwifQ.dfcdEQxy3GAYcVgciOp_3YD7Qlb3EA0WIWYiNZFGmGC6kQYyvlPSBow8R4UyL29gH3HDq-gOzBSfCp0zZKXXHQqNlpRIuiOEfhz0KfOaq7HpYCOXh58FrzacNxxlcJTrRXUykUROMBkO2mLSKrtILHyOivlBtW5gO2kUty5Z602WnD1n-WpLntqITYTCQboVr0GaANbtPtffw2381ayPeiV9U6S4ZPjVxCtqCt58kMNS4cXclZeVd7NL5AAbs6YrlUuJEwDTckbX9Bi6apKtc6-PuLh4YlntoI2yO3mACmlQW_E2fACsFW0cN7UyXTCkH2IpP2W35KGL7YQf76VU1A",
+                LoginHint = username,
+                //IdTokenHint = "eyJhbGciOiJSUzI1NiIsImtpZCI6IkYyNjZCQzA3NTFBNjIyNDkzMzFDMzI4QUQ1RkIwMkJGIiwidHlwIjoiSldUIn0.eyJpc3MiOiJodHRwczovL2xvY2FsaG9zdDo1MDAxIiwibmJmIjoxNjM4NDc3MDE2LCJpYXQiOjE2Mzg0NzcwMTYsImV4cCI6MTYzODQ3NzMxNiwiYXVkIjoiY2liYSIsImFtciI6WyJwd2QiXSwiYXRfaGFzaCI6ImE1angwelVQZ2twczBVS1J5VjBUWmciLCJzaWQiOiIzQTJDQTJDNjdBNTAwQ0I2REY1QzEyRUZDMzlCQTI2MiIsInN1YiI6IjgxODcyNyIsImF1dGhfdGltZSI6MTYzODQ3NzAwOCwiaWRwIjoibG9jYWwifQ.GAIHXYgEtXw5NasR0zPMW3jSKBuWujzwwnXJnfHdulKX-I3r47N0iqHm5v5V0xfLYdrmntjLgmdm0DSvdXswtZ1dh96DqS1zVm6yQ2V0zsA2u8uOt1RG8qtjd5z4Gb_wTvks4rbUiwi008FOZfRuqbMJJDSscy_YdEJqyQahdzkcUnWZwdbY8L2RUTxlAAWQxktpIbaFnxfr8PFQpyTcyQyw0b7xmYd9ogR7JyOff7IJIHPDur0wbRdpI1FDE_VVCgoze8GVAbVxXPtj4CtWHAv07MJxa9SdA_N-lBcrZ3PHTKQ5t1gFXwdQvp3togUJl33mJSru3lqfK36pn8y8ow",
                 BindingMessage = bindingMessage,
                 RequestedExpiry = 200
             };

--- a/hosts/AspNetIdentity/Pages/Ciba/Consent.cshtml.cs
+++ b/hosts/AspNetIdentity/Pages/Ciba/Consent.cshtml.cs
@@ -56,7 +56,7 @@ namespace IdentityServerHost.Pages.Ciba
         public async Task<IActionResult> OnPost()
         {
             // validate return url is still valid
-            var request = await _interaction.GetLoginRequestByIdAsync(Input.Id);
+            var request = await _interaction.GetLoginRequestByInternalIdAsync(Input.Id);
             if (request == null || request.Subject.GetSubjectId() != User.GetSubjectId())
             {
                 _logger.LogError("Invalid id {id}", Input.Id);
@@ -119,7 +119,7 @@ namespace IdentityServerHost.Pages.Ciba
 
         private async Task<ViewModel> BuildViewModelAsync(string id, InputModel model = null)
         {
-            var request = await _interaction.GetLoginRequestByIdAsync(id);
+            var request = await _interaction.GetLoginRequestByInternalIdAsync(id);
             if (request != null && request.Subject.GetSubjectId() == User.GetSubjectId())
             {
                 return CreateConsentViewModel(model, id, request);

--- a/hosts/AspNetIdentity/Pages/Ciba/Consent.cshtml.cs
+++ b/hosts/AspNetIdentity/Pages/Ciba/Consent.cshtml.cs
@@ -7,7 +7,6 @@ using Duende.IdentityServer.Extensions;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services;
 using Duende.IdentityServer.Validation;
-using IdentityModel;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -34,7 +33,7 @@ namespace IdentityServerHost.Pages.Ciba
         }
 
         public ViewModel View { get; set; }
-        
+
         [BindProperty]
         public InputModel Input { get; set; }
 
@@ -64,12 +63,12 @@ namespace IdentityServerHost.Pages.Ciba
                 return RedirectToPage("/Home/Error/Index");
             }
 
-            ConsentResponse grantedConsent = null;
+            CompleteBackchannelLoginRequest result = null;
 
             // user clicked 'no' - send back the standard 'access_denied' response
             if (Input?.Button == "no")
             {
-                grantedConsent = new ConsentResponse { Error = AuthorizationError.AccessDenied };
+                result = new CompleteBackchannelLoginRequest(Input.Id);
 
                 // emit event
                 await _events.RaiseAsync(new ConsentDeniedEvent(User.GetSubjectId(), request.Client.ClientId, request.ValidatedResources.RawScopeValues));
@@ -86,14 +85,14 @@ namespace IdentityServerHost.Pages.Ciba
                         scopes = scopes.Where(x => x != Duende.IdentityServer.IdentityServerConstants.StandardScopes.OfflineAccess);
                     }
 
-                    grantedConsent = new ConsentResponse
+                    result = new CompleteBackchannelLoginRequest(Input.Id)
                     {
                         ScopesValuesConsented = scopes.ToArray(),
                         Description = Input.Description
                     };
 
                     // emit event
-                    await _events.RaiseAsync(new ConsentGrantedEvent(User.GetSubjectId(), request.Client.ClientId, request.ValidatedResources.RawScopeValues, grantedConsent.ScopesValuesConsented, grantedConsent.RememberConsent));
+                    await _events.RaiseAsync(new ConsentGrantedEvent(User.GetSubjectId(), request.Client.ClientId, request.ValidatedResources.RawScopeValues, result.ScopesValuesConsented, false));
                 }
                 else
                 {
@@ -105,10 +104,10 @@ namespace IdentityServerHost.Pages.Ciba
                 ModelState.AddModelError("", ConsentOptions.InvalidSelectionErrorMessage);
             }
 
-            if (grantedConsent != null)
+            if (result != null)
             {
                 // communicate outcome of consent back to identityserver
-                await _interaction.CompleteRequestByIdAsync(Input.Id, grantedConsent);
+                await _interaction.CompleteLoginRequestAsync(result);
 
                 return RedirectToPage("/Ciba/All");
             }

--- a/hosts/AspNetIdentity/Pages/Ciba/Index.cshtml.cs
+++ b/hosts/AspNetIdentity/Pages/Ciba/Index.cshtml.cs
@@ -27,7 +27,7 @@ namespace IdentityServerHost.Pages.Ciba
 
         public async Task<IActionResult> OnGet(string id)
         {
-            LoginRequest = await _backchannelAuthenticationInteraction.GetLoginRequestByIdAsync(id);
+            LoginRequest = await _backchannelAuthenticationInteraction.GetLoginRequestByInternalIdAsync(id);
             if (LoginRequest == null)
             {
                 _logger.LogWarning("Invalid backchannel login id {id}", id);

--- a/hosts/EntityFramework/Pages/Ciba/Consent.cshtml.cs
+++ b/hosts/EntityFramework/Pages/Ciba/Consent.cshtml.cs
@@ -56,7 +56,7 @@ namespace IdentityServerHost.Pages.Ciba
         public async Task<IActionResult> OnPost()
         {
             // validate return url is still valid
-            var request = await _interaction.GetLoginRequestByIdAsync(Input.Id);
+            var request = await _interaction.GetLoginRequestByInternalIdAsync(Input.Id);
             if (request == null || request.Subject.GetSubjectId() != User.GetSubjectId())
             {
                 _logger.LogError("Invalid id {id}", Input.Id);
@@ -119,7 +119,7 @@ namespace IdentityServerHost.Pages.Ciba
 
         private async Task<ViewModel> BuildViewModelAsync(string id, InputModel model = null)
         {
-            var request = await _interaction.GetLoginRequestByIdAsync(id);
+            var request = await _interaction.GetLoginRequestByInternalIdAsync(id);
             if (request != null && request.Subject.GetSubjectId() == User.GetSubjectId())
             {
                 return CreateConsentViewModel(model, id, request);

--- a/hosts/EntityFramework/Pages/Ciba/Consent.cshtml.cs
+++ b/hosts/EntityFramework/Pages/Ciba/Consent.cshtml.cs
@@ -7,7 +7,6 @@ using Duende.IdentityServer.Extensions;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services;
 using Duende.IdentityServer.Validation;
-using IdentityModel;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -34,7 +33,7 @@ namespace IdentityServerHost.Pages.Ciba
         }
 
         public ViewModel View { get; set; }
-        
+
         [BindProperty]
         public InputModel Input { get; set; }
 
@@ -64,12 +63,12 @@ namespace IdentityServerHost.Pages.Ciba
                 return RedirectToPage("/Home/Error/Index");
             }
 
-            ConsentResponse grantedConsent = null;
+            CompleteBackchannelLoginRequest result = null;
 
             // user clicked 'no' - send back the standard 'access_denied' response
             if (Input?.Button == "no")
             {
-                grantedConsent = new ConsentResponse { Error = AuthorizationError.AccessDenied };
+                result = new CompleteBackchannelLoginRequest(Input.Id);
 
                 // emit event
                 await _events.RaiseAsync(new ConsentDeniedEvent(User.GetSubjectId(), request.Client.ClientId, request.ValidatedResources.RawScopeValues));
@@ -86,14 +85,14 @@ namespace IdentityServerHost.Pages.Ciba
                         scopes = scopes.Where(x => x != Duende.IdentityServer.IdentityServerConstants.StandardScopes.OfflineAccess);
                     }
 
-                    grantedConsent = new ConsentResponse
+                    result = new CompleteBackchannelLoginRequest(Input.Id)
                     {
                         ScopesValuesConsented = scopes.ToArray(),
                         Description = Input.Description
                     };
 
                     // emit event
-                    await _events.RaiseAsync(new ConsentGrantedEvent(User.GetSubjectId(), request.Client.ClientId, request.ValidatedResources.RawScopeValues, grantedConsent.ScopesValuesConsented, grantedConsent.RememberConsent));
+                    await _events.RaiseAsync(new ConsentGrantedEvent(User.GetSubjectId(), request.Client.ClientId, request.ValidatedResources.RawScopeValues, result.ScopesValuesConsented, false));
                 }
                 else
                 {
@@ -105,10 +104,10 @@ namespace IdentityServerHost.Pages.Ciba
                 ModelState.AddModelError("", ConsentOptions.InvalidSelectionErrorMessage);
             }
 
-            if (grantedConsent != null)
+            if (result != null)
             {
                 // communicate outcome of consent back to identityserver
-                await _interaction.CompleteRequestByIdAsync(Input.Id, grantedConsent);
+                await _interaction.CompleteLoginRequestAsync(result);
 
                 return RedirectToPage("/Ciba/All");
             }

--- a/hosts/EntityFramework/Pages/Ciba/Index.cshtml.cs
+++ b/hosts/EntityFramework/Pages/Ciba/Index.cshtml.cs
@@ -27,7 +27,7 @@ namespace IdentityServerHost.Pages.Ciba
 
         public async Task<IActionResult> OnGet(string id)
         {
-            LoginRequest = await _backchannelAuthenticationInteraction.GetLoginRequestByIdAsync(id);
+            LoginRequest = await _backchannelAuthenticationInteraction.GetLoginRequestByInternalIdAsync(id);
             if (LoginRequest == null)
             {
                 _logger.LogWarning("Invalid backchannel login id {id}", id);

--- a/hosts/main/Pages/Ciba/Consent.cshtml.cs
+++ b/hosts/main/Pages/Ciba/Consent.cshtml.cs
@@ -56,7 +56,7 @@ namespace IdentityServerHost.Pages.Ciba
         public async Task<IActionResult> OnPost()
         {
             // validate return url is still valid
-            var request = await _interaction.GetLoginRequestByIdAsync(Input.Id);
+            var request = await _interaction.GetLoginRequestByInternalIdAsync(Input.Id);
             if (request == null || request.Subject.GetSubjectId() != User.GetSubjectId())
             {
                 _logger.LogError("Invalid id {id}", Input.Id);
@@ -119,7 +119,7 @@ namespace IdentityServerHost.Pages.Ciba
 
         private async Task<ViewModel> BuildViewModelAsync(string id, InputModel model = null)
         {
-            var request = await _interaction.GetLoginRequestByIdAsync(id);
+            var request = await _interaction.GetLoginRequestByInternalIdAsync(id);
             if (request != null && request.Subject.GetSubjectId() == User.GetSubjectId())
             {
                 return CreateConsentViewModel(model, id, request);

--- a/hosts/main/Pages/Ciba/Consent.cshtml.cs
+++ b/hosts/main/Pages/Ciba/Consent.cshtml.cs
@@ -7,7 +7,6 @@ using Duende.IdentityServer.Extensions;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services;
 using Duende.IdentityServer.Validation;
-using IdentityModel;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -64,12 +63,12 @@ namespace IdentityServerHost.Pages.Ciba
                 return RedirectToPage("/Home/Error/Index");
             }
 
-            ConsentResponse grantedConsent = null;
+            CompleteBackchannelLoginRequest result = null;
 
             // user clicked 'no' - send back the standard 'access_denied' response
             if (Input?.Button == "no")
             {
-                grantedConsent = new ConsentResponse { Error = AuthorizationError.AccessDenied };
+                result = new CompleteBackchannelLoginRequest(Input.Id);
 
                 // emit event
                 await _events.RaiseAsync(new ConsentDeniedEvent(User.GetSubjectId(), request.Client.ClientId, request.ValidatedResources.RawScopeValues));
@@ -86,14 +85,14 @@ namespace IdentityServerHost.Pages.Ciba
                         scopes = scopes.Where(x => x != Duende.IdentityServer.IdentityServerConstants.StandardScopes.OfflineAccess);
                     }
 
-                    grantedConsent = new ConsentResponse
+                    result = new CompleteBackchannelLoginRequest(Input.Id)
                     {
                         ScopesValuesConsented = scopes.ToArray(),
                         Description = Input.Description
                     };
 
                     // emit event
-                    await _events.RaiseAsync(new ConsentGrantedEvent(User.GetSubjectId(), request.Client.ClientId, request.ValidatedResources.RawScopeValues, grantedConsent.ScopesValuesConsented, grantedConsent.RememberConsent));
+                    await _events.RaiseAsync(new ConsentGrantedEvent(User.GetSubjectId(), request.Client.ClientId, request.ValidatedResources.RawScopeValues, result.ScopesValuesConsented, false));
                 }
                 else
                 {
@@ -105,10 +104,10 @@ namespace IdentityServerHost.Pages.Ciba
                 ModelState.AddModelError("", ConsentOptions.InvalidSelectionErrorMessage);
             }
 
-            if (grantedConsent != null)
+            if (result != null)
             {
                 // communicate outcome of consent back to identityserver
-                await _interaction.CompleteRequestByIdAsync(Input.Id, grantedConsent);
+                await _interaction.CompleteLoginRequestAsync(result);
 
                 return RedirectToPage("/Ciba/All");
             }

--- a/hosts/main/Pages/Ciba/Index.cshtml.cs
+++ b/hosts/main/Pages/Ciba/Index.cshtml.cs
@@ -27,7 +27,7 @@ namespace IdentityServerHost.Pages.Ciba
 
         public async Task<IActionResult> OnGet(string id)
         {
-            LoginRequest = await _backchannelAuthenticationInteraction.GetLoginRequestByIdAsync(id);
+            LoginRequest = await _backchannelAuthenticationInteraction.GetLoginRequestByInternalIdAsync(id);
             if (LoginRequest == null)
             {
                 _logger.LogWarning("Invalid backchannel login id {id}", id);

--- a/src/IdentityServer/Services/Default/DefaultBackchannelAuthenticationInteractionService.cs
+++ b/src/IdentityServer/Services/Default/DefaultBackchannelAuthenticationInteractionService.cs
@@ -96,7 +96,7 @@ namespace Duende.IdentityServer.Services
                 var items = await _requestStore.GetLoginsForUserAsync(user.GetSubjectId());
                 foreach (var item in items)
                 {
-                    if (!item.IsAuthorized)
+                    if (!item.IsComplete)
                     {
                         var req = await CreateAsync(item);
                         if (req != null)
@@ -155,7 +155,7 @@ namespace Duende.IdentityServer.Services
                 }
             }
 
-            request.IsAuthorized = true;
+            request.IsComplete = true;
             request.Subject = subject;
             request.SessionId = sid;
             request.AuthorizedScopes = competionRequest.ScopesValuesConsented;

--- a/src/IdentityServer/Services/IBackchannelAuthenticationInteractionService.cs
+++ b/src/IdentityServer/Services/IBackchannelAuthenticationInteractionService.cs
@@ -23,7 +23,7 @@ namespace Duende.IdentityServer.Services
         /// <summary>
         /// Returns the login request for the id.
         /// </summary>
-        Task<BackchannelUserLoginRequest> GetLoginRequestByIdAsync(string id);
+        Task<BackchannelUserLoginRequest> GetLoginRequestByInternalIdAsync(string id);
 
         /// <summary>
         /// Completes the login request with the provided response for the current user or the subject passed.

--- a/src/IdentityServer/Services/IBackchannelAuthenticationInteractionService.cs
+++ b/src/IdentityServer/Services/IBackchannelAuthenticationInteractionService.cs
@@ -3,7 +3,9 @@
 
 
 using Duende.IdentityServer.Models;
+using System;
 using System.Collections.Generic;
+using System.Security.Claims;
 using System.Threading.Tasks;
 
 namespace Duende.IdentityServer.Services
@@ -24,8 +26,52 @@ namespace Duende.IdentityServer.Services
         Task<BackchannelUserLoginRequest> GetLoginRequestByIdAsync(string id);
 
         /// <summary>
-        /// Completes the login request with the provided response for the current user.
+        /// Completes the login request with the provided response for the current user or the subject passed.
         /// </summary>
-        Task CompleteRequestByIdAsync(string id, ConsentResponse consent);
+        Task CompleteLoginRequestAsync(CompleteBackchannelLoginRequest competionRequest);
+    }
+
+    /// <summary>
+    /// Models the data needed for a user to complete a backchannel authentication request.
+    /// </summary>
+    public class CompleteBackchannelLoginRequest
+    {
+        /// <summary>
+        /// Ctor
+        /// </summary>
+        public CompleteBackchannelLoginRequest(string internalId)
+        {
+            InternalId = internalId ?? throw new ArgumentNullException(nameof(internalId));
+        }
+
+        /// <summary>
+        /// The internal store id for the request.
+        /// </summary>
+        public string InternalId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the scope values consented to. 
+        /// Setting any scopes grants the login request.
+        /// Leaving the scopes null or empty denies the request.
+        /// </summary>
+        public IEnumerable<string> ScopesValuesConsented { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional description to associate with the consent.
+        /// </summary>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// The subject for which the completion is being made.
+        /// This allows more claims to be associated with the request that was identified on the backchannel authentication request.
+        /// If not provided, then the IUserSession service will be consulting to obtain the current subject.
+        /// </summary>
+        public ClaimsPrincipal Subject { get; set; }
+
+        /// <summary>
+        /// The session id to associate with the completion request if the Subject is provided.
+        /// If the Subject is not provided, then this property is ignored in favor of the session id provided by the IUserSession service.
+        /// </summary>
+        public string SessionId { get; set; }
     }
 }

--- a/src/IdentityServer/Stores/Default/DefaultBackChannelAuthenticationRequestStore.cs
+++ b/src/IdentityServer/Stores/Default/DefaultBackChannelAuthenticationRequestStore.cs
@@ -44,7 +44,7 @@ namespace Duende.IdentityServer.Stores
         }
 
         /// <inheritdoc/>
-        public Task<BackChannelAuthenticationRequest> GetByIdAsync(string id)
+        public Task<BackChannelAuthenticationRequest> GetByInternalIdAsync(string id)
         {
             return GetItemByHashedKeyAsync(id);
         }
@@ -56,7 +56,7 @@ namespace Duende.IdentityServer.Stores
         }
 
         /// <inheritdoc/>
-        public Task RemoveByIdAsync(string requestId)
+        public Task RemoveByInternalIdAsync(string requestId)
         {
             return RemoveItemByHashedKeyAsync(requestId);
         }
@@ -71,7 +71,7 @@ namespace Duende.IdentityServer.Stores
         }
 
         /// <inheritdoc/>
-        public Task UpdateByIdAsync(string id, BackChannelAuthenticationRequest request)
+        public Task UpdateByInternalIdAsync(string id, BackChannelAuthenticationRequest request)
         {
             return StoreItemByHashedKeyAsync(id, request, request.ClientId, request.Subject.GetSubjectId(), request.SessionId, request.Description, request.CreationTime, request.CreationTime.AddSeconds(request.Lifetime));
         }

--- a/src/IdentityServer/Validation/Default/BackchannelAuthenticationRequestIdValidator.cs
+++ b/src/IdentityServer/Validation/Default/BackchannelAuthenticationRequestIdValidator.cs
@@ -80,7 +80,7 @@ namespace Duende.IdentityServer.Validation
             {
                 _logger.LogError("No scopes authorized for backchannel authentication request. Access denied");
                 context.Result = new TokenRequestValidationResult(context.Request, OidcConstants.TokenErrors.AccessDenied);
-                await _backchannelAuthenticationStore.RemoveByIdAsync(request.InternalId);
+                await _backchannelAuthenticationStore.RemoveByInternalIdAsync(request.InternalId);
                 return;
             }
 
@@ -108,7 +108,7 @@ namespace Duende.IdentityServer.Validation
 
             context.Result = new TokenRequestValidationResult(context.Request);
 
-            await _backchannelAuthenticationStore.RemoveByIdAsync(request.InternalId);
+            await _backchannelAuthenticationStore.RemoveByInternalIdAsync(request.InternalId);
 
             _logger.LogDebug("Success validating backchannel authentication request id.");
         }

--- a/src/IdentityServer/Validation/Default/BackchannelAuthenticationRequestIdValidator.cs
+++ b/src/IdentityServer/Validation/Default/BackchannelAuthenticationRequestIdValidator.cs
@@ -75,7 +75,7 @@ namespace Duende.IdentityServer.Validation
             }
 
             // denied
-            if (request.IsAuthorized
+            if (request.IsComplete
                 && (request.AuthorizedScopes == null || request.AuthorizedScopes.Any() == false))
             {
                 _logger.LogError("No scopes authorized for backchannel authentication request. Access denied");
@@ -84,8 +84,8 @@ namespace Duende.IdentityServer.Validation
                 return;
             }
 
-            // make sure authentication request id is authorized
-            if (!request.IsAuthorized)
+            // make sure authentication request id is complete
+            if (!request.IsComplete)
             {
                 context.Result = new TokenRequestValidationResult(context.Request, OidcConstants.TokenErrors.AuthorizationPending);
                 return;

--- a/src/Storage/Models/BackChannelAuthenticationRequest.cs
+++ b/src/Storage/Models/BackChannelAuthenticationRequest.cs
@@ -70,9 +70,9 @@ namespace Duende.IdentityServer.Models
 
 
         /// <summary>
-        /// Gets or sets a value indicating whether this instance is authorized.
+        /// Gets or sets a value indicating whether this instance has been completed.
         /// </summary>
-        public bool IsAuthorized { get; set; }
+        public bool IsComplete { get; set; }
 
         /// <summary>
         /// Gets or sets the authorized scopes.

--- a/src/Storage/Stores/IBackChannelAuthenticationRequestStore.cs
+++ b/src/Storage/Stores/IBackChannelAuthenticationRequestStore.cs
@@ -31,16 +31,16 @@ namespace Duende.IdentityServer.Stores
         /// <summary>
         /// Gets the request.
         /// </summary>
-        Task<BackChannelAuthenticationRequest> GetByIdAsync(string id);
+        Task<BackChannelAuthenticationRequest> GetByInternalIdAsync(string id);
 
         /// <summary>
         /// Removes the request.
         /// </summary>
-        Task RemoveByIdAsync(string id);
+        Task RemoveByInternalIdAsync(string id);
 
         /// <summary>
         /// Updates the request.
         /// </summary>
-        Task UpdateByIdAsync(string id, BackChannelAuthenticationRequest request);
+        Task UpdateByInternalIdAsync(string id, BackChannelAuthenticationRequest request);
     }
 }

--- a/test/EntityFramework.Tests/EntityFramework.Tests.csproj
+++ b/test/EntityFramework.Tests/EntityFramework.Tests.csproj
@@ -2,8 +2,6 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-
-        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/IdentityServer.IntegrationTests/Endpoints/Token/CibaTokenEndpointTests.cs
+++ b/test/IdentityServer.IntegrationTests/Endpoints/Token/CibaTokenEndpointTests.cs
@@ -152,21 +152,20 @@ namespace IntegrationTests.Endpoints.Token
 
 
             // user auth/consent
-            var requestStore = _mockPipeline.Resolve<IBackChannelAuthenticationRequestStore>();
-            var request = await requestStore.GetByIdAsync(_mockCibaUserNotificationService.LoginRequest.InternalId);
-
-            request.Subject = 
-                new IdentityServerUser(_user.SubjectId) 
-                { 
+            var cibaService = _mockPipeline.Resolve<IBackchannelAuthenticationInteractionService>();
+            var request = await cibaService.GetLoginRequestByIdAsync(_mockCibaUserNotificationService.LoginRequest.InternalId);
+            await cibaService.CompleteLoginRequestAsync(new CompleteBackchannelLoginRequest(_mockCibaUserNotificationService.LoginRequest.InternalId) 
+            {
+                ScopesValuesConsented = request.ValidatedResources.RawScopeValues,
+                Subject = new IdentityServerUser(_user.SubjectId)
+                {
                     AuthenticationTime = DateTime.UtcNow,
                     IdentityProvider = IdentityServerConstants.LocalIdentityProvider,
                 }
-                .CreatePrincipal();
-            request.AuthorizedScopes = request.RequestedScopes;
-            request.IsAuthorized = true;
-            await requestStore.UpdateByIdAsync(_mockCibaUserNotificationService.LoginRequest.InternalId, request);
+                .CreatePrincipal()
+            });
 
-
+            
             // token request
             var values = JsonSerializer.Deserialize<Dictionary<string, object>>(await cibaResponse.Content.ReadAsStringAsync());
             var requestId = values["auth_req_id"].ToString();
@@ -260,19 +259,18 @@ namespace IntegrationTests.Endpoints.Token
 
 
             // user auth/consent
-            var requestStore = _mockPipeline.Resolve<IBackChannelAuthenticationRequestStore>();
-            var request = await requestStore.GetByIdAsync(_mockCibaUserNotificationService.LoginRequest.InternalId);
-
-            request.Subject =
-                new IdentityServerUser(_user.SubjectId)
+            var cibaService = _mockPipeline.Resolve<IBackchannelAuthenticationInteractionService>();
+            var request = await cibaService.GetLoginRequestByIdAsync(_mockCibaUserNotificationService.LoginRequest.InternalId);
+            await cibaService.CompleteLoginRequestAsync(new CompleteBackchannelLoginRequest(_mockCibaUserNotificationService.LoginRequest.InternalId)
+            {
+                ScopesValuesConsented = request.ValidatedResources.RawScopeValues,
+                Subject = new IdentityServerUser(_user.SubjectId)
                 {
                     AuthenticationTime = DateTime.UtcNow,
                     IdentityProvider = IdentityServerConstants.LocalIdentityProvider,
                 }
-                .CreatePrincipal();
-            request.AuthorizedScopes = request.RequestedScopes;
-            request.IsAuthorized = true;
-            await requestStore.UpdateByIdAsync(_mockCibaUserNotificationService.LoginRequest.InternalId, request);
+                .CreatePrincipal()
+            });
 
 
             // token request
@@ -324,19 +322,18 @@ namespace IntegrationTests.Endpoints.Token
 
 
             // user auth/consent
-            var requestStore = _mockPipeline.Resolve<IBackChannelAuthenticationRequestStore>();
-            var request = await requestStore.GetByIdAsync(_mockCibaUserNotificationService.LoginRequest.InternalId);
-
-            request.Subject =
-                new IdentityServerUser(_user.SubjectId)
+            var cibaService = _mockPipeline.Resolve<IBackchannelAuthenticationInteractionService>();
+            var request = await cibaService.GetLoginRequestByIdAsync(_mockCibaUserNotificationService.LoginRequest.InternalId);
+            await cibaService.CompleteLoginRequestAsync(new CompleteBackchannelLoginRequest(_mockCibaUserNotificationService.LoginRequest.InternalId)
+            {
+                ScopesValuesConsented = request.ValidatedResources.RawScopeValues,
+                Subject = new IdentityServerUser(_user.SubjectId)
                 {
                     AuthenticationTime = DateTime.UtcNow,
                     IdentityProvider = IdentityServerConstants.LocalIdentityProvider,
                 }
-                .CreatePrincipal();
-            request.AuthorizedScopes = request.RequestedScopes;
-            request.IsAuthorized = true;
-            await requestStore.UpdateByIdAsync(_mockCibaUserNotificationService.LoginRequest.InternalId, request);
+                .CreatePrincipal()
+            });
 
 
             // token request
@@ -388,18 +385,18 @@ namespace IntegrationTests.Endpoints.Token
 
 
             // user auth/consent
-            var requestStore = _mockPipeline.Resolve<IBackChannelAuthenticationRequestStore>();
-            var request = await requestStore.GetByIdAsync(_mockCibaUserNotificationService.LoginRequest.InternalId);
-
-            request.Subject =
-                new IdentityServerUser(_user.SubjectId)
+            var cibaService = _mockPipeline.Resolve<IBackchannelAuthenticationInteractionService>();
+            var request = await cibaService.GetLoginRequestByIdAsync(_mockCibaUserNotificationService.LoginRequest.InternalId);
+            await cibaService.CompleteLoginRequestAsync(new CompleteBackchannelLoginRequest(_mockCibaUserNotificationService.LoginRequest.InternalId)
+            {
+                //ScopesValuesConsented = request.ValidatedResources.RawScopeValues, // none to deny
+                Subject = new IdentityServerUser(_user.SubjectId)
                 {
                     AuthenticationTime = DateTime.UtcNow,
                     IdentityProvider = IdentityServerConstants.LocalIdentityProvider,
                 }
-                .CreatePrincipal();
-            request.IsAuthorized = true;
-            await requestStore.UpdateByIdAsync(_mockCibaUserNotificationService.LoginRequest.InternalId, request);
+                .CreatePrincipal()
+            });
 
 
             // token request
@@ -451,19 +448,18 @@ namespace IntegrationTests.Endpoints.Token
 
 
             // user auth/consent
-            var requestStore = _mockPipeline.Resolve<IBackChannelAuthenticationRequestStore>();
-            var request = await requestStore.GetByIdAsync(_mockCibaUserNotificationService.LoginRequest.InternalId);
-
-            request.Subject =
-                new IdentityServerUser(_user.SubjectId)
+            var cibaService = _mockPipeline.Resolve<IBackchannelAuthenticationInteractionService>();
+            var request = await cibaService.GetLoginRequestByIdAsync(_mockCibaUserNotificationService.LoginRequest.InternalId);
+            await cibaService.CompleteLoginRequestAsync(new CompleteBackchannelLoginRequest(_mockCibaUserNotificationService.LoginRequest.InternalId)
+            {
+                ScopesValuesConsented = request.ValidatedResources.RawScopeValues,
+                Subject = new IdentityServerUser(_user.SubjectId)
                 {
                     AuthenticationTime = DateTime.UtcNow,
                     IdentityProvider = IdentityServerConstants.LocalIdentityProvider,
                 }
-                .CreatePrincipal();
-            request.AuthorizedScopes = request.RequestedScopes;
-            request.IsAuthorized = true;
-            await requestStore.UpdateByIdAsync(_mockCibaUserNotificationService.LoginRequest.InternalId, request);
+                .CreatePrincipal()
+            });
 
 
             // token request
@@ -521,19 +517,18 @@ namespace IntegrationTests.Endpoints.Token
 
 
             // user auth/consent
-            var requestStore = _mockPipeline.Resolve<IBackChannelAuthenticationRequestStore>();
-            var request = await requestStore.GetByIdAsync(_mockCibaUserNotificationService.LoginRequest.InternalId);
-
-            request.Subject =
-                new IdentityServerUser(_user.SubjectId)
+            var cibaService = _mockPipeline.Resolve<IBackchannelAuthenticationInteractionService>();
+            var request = await cibaService.GetLoginRequestByIdAsync(_mockCibaUserNotificationService.LoginRequest.InternalId);
+            await cibaService.CompleteLoginRequestAsync(new CompleteBackchannelLoginRequest(_mockCibaUserNotificationService.LoginRequest.InternalId)
+            {
+                ScopesValuesConsented = request.ValidatedResources.RawScopeValues,
+                Subject = new IdentityServerUser(_user.SubjectId)
                 {
                     AuthenticationTime = DateTime.UtcNow,
                     IdentityProvider = IdentityServerConstants.LocalIdentityProvider,
                 }
-                .CreatePrincipal();
-            request.AuthorizedScopes = request.RequestedScopes;
-            request.IsAuthorized = true;
-            await requestStore.UpdateByIdAsync(_mockCibaUserNotificationService.LoginRequest.InternalId, request);
+                .CreatePrincipal()
+            });
 
 
             // token request

--- a/test/IdentityServer.IntegrationTests/Endpoints/Token/CibaTokenEndpointTests.cs
+++ b/test/IdentityServer.IntegrationTests/Endpoints/Token/CibaTokenEndpointTests.cs
@@ -153,7 +153,7 @@ namespace IntegrationTests.Endpoints.Token
 
             // user auth/consent
             var cibaService = _mockPipeline.Resolve<IBackchannelAuthenticationInteractionService>();
-            var request = await cibaService.GetLoginRequestByIdAsync(_mockCibaUserNotificationService.LoginRequest.InternalId);
+            var request = await cibaService.GetLoginRequestByInternalIdAsync(_mockCibaUserNotificationService.LoginRequest.InternalId);
             await cibaService.CompleteLoginRequestAsync(new CompleteBackchannelLoginRequest(_mockCibaUserNotificationService.LoginRequest.InternalId) 
             {
                 ScopesValuesConsented = request.ValidatedResources.RawScopeValues,
@@ -260,7 +260,7 @@ namespace IntegrationTests.Endpoints.Token
 
             // user auth/consent
             var cibaService = _mockPipeline.Resolve<IBackchannelAuthenticationInteractionService>();
-            var request = await cibaService.GetLoginRequestByIdAsync(_mockCibaUserNotificationService.LoginRequest.InternalId);
+            var request = await cibaService.GetLoginRequestByInternalIdAsync(_mockCibaUserNotificationService.LoginRequest.InternalId);
             await cibaService.CompleteLoginRequestAsync(new CompleteBackchannelLoginRequest(_mockCibaUserNotificationService.LoginRequest.InternalId)
             {
                 ScopesValuesConsented = request.ValidatedResources.RawScopeValues,
@@ -323,7 +323,7 @@ namespace IntegrationTests.Endpoints.Token
 
             // user auth/consent
             var cibaService = _mockPipeline.Resolve<IBackchannelAuthenticationInteractionService>();
-            var request = await cibaService.GetLoginRequestByIdAsync(_mockCibaUserNotificationService.LoginRequest.InternalId);
+            var request = await cibaService.GetLoginRequestByInternalIdAsync(_mockCibaUserNotificationService.LoginRequest.InternalId);
             await cibaService.CompleteLoginRequestAsync(new CompleteBackchannelLoginRequest(_mockCibaUserNotificationService.LoginRequest.InternalId)
             {
                 ScopesValuesConsented = request.ValidatedResources.RawScopeValues,
@@ -386,7 +386,7 @@ namespace IntegrationTests.Endpoints.Token
 
             // user auth/consent
             var cibaService = _mockPipeline.Resolve<IBackchannelAuthenticationInteractionService>();
-            var request = await cibaService.GetLoginRequestByIdAsync(_mockCibaUserNotificationService.LoginRequest.InternalId);
+            var request = await cibaService.GetLoginRequestByInternalIdAsync(_mockCibaUserNotificationService.LoginRequest.InternalId);
             await cibaService.CompleteLoginRequestAsync(new CompleteBackchannelLoginRequest(_mockCibaUserNotificationService.LoginRequest.InternalId)
             {
                 //ScopesValuesConsented = request.ValidatedResources.RawScopeValues, // none to deny
@@ -449,7 +449,7 @@ namespace IntegrationTests.Endpoints.Token
 
             // user auth/consent
             var cibaService = _mockPipeline.Resolve<IBackchannelAuthenticationInteractionService>();
-            var request = await cibaService.GetLoginRequestByIdAsync(_mockCibaUserNotificationService.LoginRequest.InternalId);
+            var request = await cibaService.GetLoginRequestByInternalIdAsync(_mockCibaUserNotificationService.LoginRequest.InternalId);
             await cibaService.CompleteLoginRequestAsync(new CompleteBackchannelLoginRequest(_mockCibaUserNotificationService.LoginRequest.InternalId)
             {
                 ScopesValuesConsented = request.ValidatedResources.RawScopeValues,
@@ -518,7 +518,7 @@ namespace IntegrationTests.Endpoints.Token
 
             // user auth/consent
             var cibaService = _mockPipeline.Resolve<IBackchannelAuthenticationInteractionService>();
-            var request = await cibaService.GetLoginRequestByIdAsync(_mockCibaUserNotificationService.LoginRequest.InternalId);
+            var request = await cibaService.GetLoginRequestByInternalIdAsync(_mockCibaUserNotificationService.LoginRequest.InternalId);
             await cibaService.CompleteLoginRequestAsync(new CompleteBackchannelLoginRequest(_mockCibaUserNotificationService.LoginRequest.InternalId)
             {
                 ScopesValuesConsented = request.ValidatedResources.RawScopeValues,

--- a/test/IdentityServer.UnitTests/Common/MockBackChannelAuthenticationRequestStore.cs
+++ b/test/IdentityServer.UnitTests/Common/MockBackChannelAuthenticationRequestStore.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Duende.IdentityServer.Extensions;
+using Duende.IdentityServer.Models;
+using Duende.IdentityServer.Stores;
+
+namespace UnitTests.Common
+{
+    public class MockBackChannelAuthenticationRequestStore : IBackChannelAuthenticationRequestStore
+    {
+        public Dictionary<string, BackChannelAuthenticationRequest> Items { get; set; } = new Dictionary<string, BackChannelAuthenticationRequest>();
+
+        public Task<string> CreateRequestAsync(BackChannelAuthenticationRequest request)
+        {
+            var key = Guid.NewGuid().ToString();
+            request.InternalId = key.Sha256();
+            Items.Add(key, request);
+            return Task.FromResult(key);
+        }
+
+        public Task<BackChannelAuthenticationRequest> GetByAuthenticationRequestIdAsync(string requestId)
+        {
+            return Task.FromResult(Items[requestId]);
+        }
+
+        public Task<BackChannelAuthenticationRequest> GetByInternalIdAsync(string id)
+        {
+            var item = Items.SingleOrDefault(x => x.Value.InternalId == id);
+            return Task.FromResult(item.Value);
+        }
+
+        public Task<IEnumerable<BackChannelAuthenticationRequest>> GetLoginsForUserAsync(string subjectId, string clientId = null)
+        {
+            var items = Items.Where(x => x.Value.Subject.GetSubjectId() == subjectId 
+                && (clientId == null || x.Value.ClientId == clientId)
+            );
+            return Task.FromResult(items.Select(x => x.Value).AsEnumerable());
+        }
+
+        public Task RemoveByInternalIdAsync(string id)
+        {
+            var item = Items.SingleOrDefault(x => x.Value.InternalId == id);
+            if (item.Key != null)
+            {
+                Items.Remove(item.Key);
+            }
+            return Task.CompletedTask;
+        }
+
+        public Task UpdateByInternalIdAsync(string id, BackChannelAuthenticationRequest request)
+        {
+            var item = Items.SingleOrDefault(x => x.Value.InternalId == id);
+            if (item.Key != null)
+            {
+                Items.Remove(item.Key);
+                Items.Add(item.Key, request);
+            }
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/test/IdentityServer.UnitTests/Common/MockSystemClock.cs
+++ b/test/IdentityServer.UnitTests/Common/MockSystemClock.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/test/IdentityServer.UnitTests/Services/Default/DefaultBackchannelAuthenticationInteractionServiceTests.cs
+++ b/test/IdentityServer.UnitTests/Services/Default/DefaultBackchannelAuthenticationInteractionServiceTests.cs
@@ -1,0 +1,336 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Duende.IdentityServer;
+using Duende.IdentityServer.Configuration;
+using Duende.IdentityServer.Models;
+using Duende.IdentityServer.Services;
+using Duende.IdentityServer.Stores;
+using Duende.IdentityServer.Validation;
+using FluentAssertions;
+using UnitTests.Common;
+using Xunit;
+
+namespace UnitTests.Services.Default
+{
+    public class DefaultBackchannelAuthenticationInteractionServiceTests
+    {
+        private Client _client;
+        private DefaultBackchannelAuthenticationInteractionService _subject;
+
+        private MockBackChannelAuthenticationRequestStore _mockStore = new MockBackChannelAuthenticationRequestStore();
+        private InMemoryClientStore _clientStore;
+        private List<Client> _clients = new List<Client>();
+        private MockUserSession _mockUserSession = new MockUserSession();
+        private MockSystemClock _mockSystemClock = new MockSystemClock() { Now = DateTimeOffset.UtcNow };
+        private MockResourceValidator _mockResourceValidator = new MockResourceValidator();
+
+        public DefaultBackchannelAuthenticationInteractionServiceTests()
+        {
+            _clients.Add(_client = new Client
+            {
+                ClientId = "client",
+            });
+
+            _clientStore = new InMemoryClientStore(_clients);
+            _subject = new DefaultBackchannelAuthenticationInteractionService(
+                _mockStore,
+                _clientStore,
+                _mockUserSession,
+                _mockResourceValidator,
+                _mockSystemClock,
+                TestLogger.Create<DefaultBackchannelAuthenticationInteractionService>());
+        }
+
+        [Fact]
+        public async Task GetPendingLoginRequestsForCurrentUserAsync_should_use_current_sub_to_filter_results()
+        {
+            _mockUserSession.User = new IdentityServerUser("123").CreatePrincipal();
+            var req = new BackChannelAuthenticationRequest
+            {
+                ClientId = _client.ClientId,
+                Subject = new IdentityServerUser("123").CreatePrincipal(),
+            };
+            await _mockStore.CreateRequestAsync(req);
+            await _mockStore.CreateRequestAsync(new BackChannelAuthenticationRequest
+            {
+                ClientId = _client.ClientId,
+                Subject = new IdentityServerUser("other").CreatePrincipal()
+            });
+
+            var results = await _subject.GetPendingLoginRequestsForCurrentUserAsync();
+            results.Count().Should().Be(1);
+            results.First().InternalId.Should().Be(req.InternalId);
+        }
+
+        [Fact]
+        public async Task GetLoginRequestByInternalIdAsync_should_return_correct_item()
+        {
+            _mockUserSession.User = new IdentityServerUser("123").CreatePrincipal();
+            var req = new BackChannelAuthenticationRequest
+            {
+                ClientId = _client.ClientId,
+                Subject = new IdentityServerUser("123").CreatePrincipal(),
+            };
+            var requestId = await _mockStore.CreateRequestAsync(req);
+            await _mockStore.CreateRequestAsync(new BackChannelAuthenticationRequest
+            {
+                ClientId = _client.ClientId,
+                Subject = new IdentityServerUser("other").CreatePrincipal()
+            });
+
+            var result = await _subject.GetLoginRequestByInternalIdAsync(req.InternalId);
+            result.InternalId.Should().Be(req.InternalId);
+        }
+        
+        [Fact]
+        public async Task CompleteLoginRequestAsync_for_valid_request_should_mark_login_request_complete()
+        {
+            _mockUserSession.User = new IdentityServerUser("123").CreatePrincipal();
+            var req = new BackChannelAuthenticationRequest
+            {
+                ClientId = _client.ClientId,
+                Subject = new IdentityServerUser("123").CreatePrincipal(),
+                RequestedScopes = new[] { "scope1", "scope2", "scope3" },
+            };
+            var requestId = await _mockStore.CreateRequestAsync(req);
+
+            await _subject.CompleteLoginRequestAsync(new CompleteBackchannelLoginRequest(req.InternalId)
+            {
+                Description = "desc",
+                ScopesValuesConsented = new string[] { "scope1", "scope2" },
+                SessionId = "sid",
+                Subject = new IdentityServerUser("123") 
+                {
+                    DisplayName = "name",
+                    AuthenticationTime = new DateTime(2000, 02, 03, 8, 15, 00, DateTimeKind.Utc),
+                    IdentityProvider = "idp",
+                    AdditionalClaims = { new Claim("foo", "bar") },
+                    AuthenticationMethods = { "phone", "pin" }
+                }.CreatePrincipal()
+            });
+
+            var item = _mockStore.Items[requestId];
+            item.IsComplete.Should().BeTrue();
+            item.Description.Should().Be("desc");
+            item.SessionId.Should().Be("sid");
+            item.AuthorizedScopes.Should().BeEquivalentTo(new[] { "scope2", "scope1" });
+
+            item.Subject.HasClaim("sub", "123").Should().BeTrue();
+            item.Subject.HasClaim("foo", "bar").Should().BeTrue();
+            item.Subject.HasClaim("amr", "phone").Should().BeTrue();
+            item.Subject.HasClaim("amr", "pin").Should().BeTrue();
+            item.Subject.HasClaim("idp", "idp").Should().BeTrue();
+            item.Subject.HasClaim("auth_time", new DateTimeOffset(new DateTime(2000, 02, 03, 8, 15, 00, DateTimeKind.Utc)).ToUnixTimeSeconds().ToString()).Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task CompleteLoginRequestAsync_should_require_request_object()
+        {
+            _mockUserSession.User = new IdentityServerUser("123").CreatePrincipal();
+            var req = new BackChannelAuthenticationRequest
+            {
+                ClientId = _client.ClientId,
+                Subject = new IdentityServerUser("123").CreatePrincipal(),
+                RequestedScopes = new[] { "scope1", "scope2", "scope3" },
+            };
+            var requestId = await _mockStore.CreateRequestAsync(req);
+
+            Func<Task> f = async () => await _subject.CompleteLoginRequestAsync(null);
+            f.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public async Task CompleteLoginRequestAsync_should_prevent_scopes_not_requested()
+        {
+            _mockUserSession.User = new IdentityServerUser("123").CreatePrincipal();
+            var req = new BackChannelAuthenticationRequest
+            {
+                ClientId = _client.ClientId,
+                Subject = new IdentityServerUser("123").CreatePrincipal(),
+                RequestedScopes = new[] { "scope1", "scope2", "scope3" },
+            };
+            var requestId = await _mockStore.CreateRequestAsync(req);
+
+            Func<Task> f = async () => await _subject.CompleteLoginRequestAsync(new CompleteBackchannelLoginRequest(req.InternalId)
+            {
+                Description = "desc",
+                ScopesValuesConsented = new string[] { "scope1", "invalid" },
+                SessionId = "sid",
+                Subject = new IdentityServerUser("123")
+                {
+                    DisplayName = "name",
+                    AuthenticationTime = new DateTime(2000, 02, 03, 8, 15, 00, DateTimeKind.Utc),
+                    IdentityProvider = "idp",
+                    AdditionalClaims = { new Claim("foo", "bar") },
+                    AuthenticationMethods = { "phone", "pin" }
+                }.CreatePrincipal()
+            });
+            f.Should().Throw<InvalidOperationException>().WithMessage("More scopes consented than originally requested.");
+        }
+
+        [Fact]
+        public async Task CompleteLoginRequestAsync_should_prevent_invalid_subject_id()
+        {
+            _mockUserSession.User = new IdentityServerUser("123").CreatePrincipal();
+            var req = new BackChannelAuthenticationRequest
+            {
+                ClientId = _client.ClientId,
+                Subject = new IdentityServerUser("123").CreatePrincipal(),
+                RequestedScopes = new[] { "scope1", "scope2", "scope3" },
+            };
+            var requestId = await _mockStore.CreateRequestAsync(req);
+
+            Func<Task> f = async () => await _subject.CompleteLoginRequestAsync(new CompleteBackchannelLoginRequest(req.InternalId)
+            {
+                Description = "desc",
+                ScopesValuesConsented = new string[] { "scope1", "invalid" },
+                SessionId = "sid",
+                Subject = new IdentityServerUser("invalid")
+                {
+                    DisplayName = "name",
+                    AuthenticationTime = new DateTime(2000, 02, 03, 8, 15, 00, DateTimeKind.Utc),
+                    IdentityProvider = "idp",
+                    AdditionalClaims = { new Claim("foo", "bar") },
+                    AuthenticationMethods = { "phone", "pin" }
+                }.CreatePrincipal()
+            });
+            f.Should().Throw<InvalidOperationException>().WithMessage("User's subject id: 'invalid' does not match subject id for backchannel authentication request: '123'.");
+        }
+
+        [Fact]
+        public async Task CompleteLoginRequestAsync_should_require_a_subject()
+        {
+            var req = new BackChannelAuthenticationRequest
+            {
+                ClientId = _client.ClientId,
+                Subject = new IdentityServerUser("123").CreatePrincipal(),
+                RequestedScopes = new[] { "scope1", "scope2", "scope3" },
+            };
+            var requestId = await _mockStore.CreateRequestAsync(req);
+
+            Func<Task> f = async () => await _subject.CompleteLoginRequestAsync(new CompleteBackchannelLoginRequest(req.InternalId)
+            {
+                Description = "desc",
+                ScopesValuesConsented = new string[] { "scope1", "invalid" },
+                SessionId = "sid",
+                //Subject = new IdentityServerUser("invalid")
+                //{
+                //    DisplayName = "name",
+                //    AuthenticationTime = new DateTime(2000, 02, 03, 8, 15, 00, DateTimeKind.Utc),
+                //    IdentityProvider = "idp",
+                //    AdditionalClaims = { new Claim("foo", "bar") },
+                //    AuthenticationMethods = { "phone", "pin" }
+                //}.CreatePrincipal()
+            });
+            f.Should().Throw<InvalidOperationException>().WithMessage("Invalid subject.");
+        }
+
+        [Fact]
+        public async Task CompleteLoginRequestAsync_should_require_a_valid_request_id()
+        {
+            var req = new BackChannelAuthenticationRequest
+            {
+                ClientId = _client.ClientId,
+                Subject = new IdentityServerUser("123").CreatePrincipal(),
+                RequestedScopes = new[] { "scope1", "scope2", "scope3" },
+            };
+            var requestId = await _mockStore.CreateRequestAsync(req);
+
+            Func<Task> f = async () => await _subject.CompleteLoginRequestAsync(new CompleteBackchannelLoginRequest("invalid")
+            {
+                Description = "desc",
+                ScopesValuesConsented = new string[] { "scope1", "invalid" },
+                SessionId = "sid",
+                Subject = new IdentityServerUser("123")
+                {
+                    DisplayName = "name",
+                    AuthenticationTime = new DateTime(2000, 02, 03, 8, 15, 00, DateTimeKind.Utc),
+                    IdentityProvider = "idp",
+                    AdditionalClaims = { new Claim("foo", "bar") },
+                    AuthenticationMethods = { "phone", "pin" }
+                }.CreatePrincipal()
+            });
+            f.Should().Throw<InvalidOperationException>().WithMessage("Invalid backchannel authentication request id.");
+        }
+
+        [Fact]
+        public async Task CompleteLoginRequestAsync_should_use_session_if_no_user_passed()
+        {
+            _mockUserSession.User = new IdentityServerUser("123").CreatePrincipal();
+            var req = new BackChannelAuthenticationRequest
+            {
+                ClientId = _client.ClientId,
+                Subject = new IdentityServerUser("123").CreatePrincipal(),
+                RequestedScopes = new[] { "scope1", "scope2", "scope3" },
+            };
+            var requestId = await _mockStore.CreateRequestAsync(req);
+
+            _mockUserSession.User = new IdentityServerUser("123")
+            {
+                DisplayName = "name",
+                AuthenticationTime = new DateTime(2000, 02, 03, 8, 15, 00, DateTimeKind.Utc),
+                IdentityProvider = "idp",
+                AdditionalClaims = { new Claim("foo", "bar") },
+                AuthenticationMethods = { "phone", "pin" }
+            }.CreatePrincipal();
+            _mockUserSession.SessionId = "session id";
+
+            await _subject.CompleteLoginRequestAsync(new CompleteBackchannelLoginRequest(req.InternalId)
+            {
+                Description = "desc",
+                ScopesValuesConsented = new string[] { "scope1", "scope2" },
+                SessionId = "ignored",
+                //Subject = 
+            });
+
+            var item = _mockStore.Items[requestId];
+            item.SessionId.Should().Be("session id");
+
+            item.Subject.HasClaim("sub", "123").Should().BeTrue();
+            item.Subject.HasClaim("foo", "bar").Should().BeTrue();
+            item.Subject.HasClaim("amr", "phone").Should().BeTrue();
+            item.Subject.HasClaim("amr", "pin").Should().BeTrue();
+            item.Subject.HasClaim("idp", "idp").Should().BeTrue();
+            item.Subject.HasClaim("auth_time", new DateTimeOffset(new DateTime(2000, 02, 03, 8, 15, 00, DateTimeKind.Utc)).ToUnixTimeSeconds().ToString()).Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task CompleteLoginRequestAsync_should_default_idp_and_authtime()
+        {
+            _mockUserSession.User = new IdentityServerUser("123").CreatePrincipal();
+            var req = new BackChannelAuthenticationRequest
+            {
+                ClientId = _client.ClientId,
+                Subject = new IdentityServerUser("123").CreatePrincipal(),
+                RequestedScopes = new[] { "scope1", "scope2", "scope3" },
+            };
+            var requestId = await _mockStore.CreateRequestAsync(req);
+
+            await _subject.CompleteLoginRequestAsync(new CompleteBackchannelLoginRequest(req.InternalId)
+            {
+                Description = "desc",
+                ScopesValuesConsented = new string[] { "scope1", "scope2" },
+                SessionId = "sid",
+                Subject = new IdentityServerUser("123")
+                {
+                    DisplayName = "name",
+                    //AuthenticationTime = _mockSystemClock.UtcNow.UtcDateTime,
+                    //IdentityProvider = "idp",
+                    AdditionalClaims = { new Claim("foo", "bar") },
+                    AuthenticationMethods = { "phone", "pin" }
+                }.CreatePrincipal()
+            });
+
+            var item = _mockStore.Items[requestId];
+            item.Subject.HasClaim("idp", "local").Should().BeTrue();
+            item.Subject.HasClaim("auth_time", _mockSystemClock.UtcNow.ToUnixTimeSeconds().ToString()).Should().BeTrue();
+        }
+    }
+}


### PR DESCRIPTION
This will allow scenarios where use can consent to login request via non-browser mechanisms (e.g. native app on phone).