### PR TITLE
Prevent ASP.NET Core from caching OIDC provider options

### DIFF
--- a/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Additional.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Additional.cs
@@ -515,7 +515,8 @@ namespace Microsoft.Extensions.DependencyInjection
            where T : class, IIdentityProviderStore
         {
             builder.Services.TryAddTransient(typeof(T));
-            builder.Services.AddTransient<IIdentityProviderStore, ValidatingIdentityProviderStore<T>>();
+            builder.Services.TryAddTransient(typeof(ValidatingIdentityProviderStore<T>));
+            builder.Services.AddTransientDecorator<IIdentityProviderStore, NonCachingIdentityProviderStore<ValidatingIdentityProviderStore<T>>>();
 
             return builder;
         }

--- a/src/IdentityServer/Hosting/DynamicProviders/Store/NonCachingIdentityProviderStore.cs
+++ b/src/IdentityServer/Hosting/DynamicProviders/Store/NonCachingIdentityProviderStore.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using Duende.IdentityServer.Configuration;
+using Duende.IdentityServer.Models;
+using Duende.IdentityServer.Stores;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Duende.IdentityServer.Hosting.DynamicProviders
+{
+    /// <summary>
+    /// Decorator for IIdentityProviderStore that will purge the IOptionsMonitor so that the options are not cached.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public class NonCachingIdentityProviderStore<T> : IIdentityProviderStore
+            where T : IIdentityProviderStore
+    {
+        private readonly IIdentityProviderStore _inner;
+        private readonly IdentityServerOptions _options;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        /// <summary>
+        /// Ctor
+        /// </summary>
+        public NonCachingIdentityProviderStore(T inner, 
+            IdentityServerOptions options,
+            IHttpContextAccessor httpContextAccessor)
+        {
+            _inner = inner;
+            _options = options;
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        /// <inheritdoc/>
+        public Task<IEnumerable<IdentityProviderName>> GetAllSchemeNamesAsync()
+        {
+            return _inner.GetAllSchemeNamesAsync();
+        }
+
+        /// <inheritdoc/>
+        public async Task<IdentityProvider> GetBySchemeAsync(string scheme)
+        {
+            var item = await _inner.GetBySchemeAsync(scheme);
+            RemoveCacheEntry(item);
+            return item;
+        }
+
+        // when we load these items, we remove the corresponding options from the 
+        // options monitor since those instances are cached my the authentication handler plumbing
+        // this keeps theirs in sync with ours when we re-load from the DB
+        void RemoveCacheEntry(IdentityProvider idp)
+        {
+            if (idp != null)
+            {
+                var provider = _options.DynamicProviders.FindProviderType(idp.Type);
+                if (provider != null)
+                {
+                    var optionsMonitorType = typeof(IOptionsMonitorCache<>).MakeGenericType(provider.OptionsType);
+                    // need to resolve the provide type dynamically, thus the need for the http context accessor
+                    var optionsCache = _httpContextAccessor.HttpContext.RequestServices.GetService(optionsMonitorType);
+                    if (optionsCache != null)
+                    {
+                        var mi = optionsMonitorType.GetMethod("TryRemove");
+                        if (mi != null)
+                        {
+                            mi.Invoke(optionsCache, new[] { idp.Scheme });
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
* adds a non-caching (cache purging) decorator for the IIdentityProviderStore as the default

 Fixes: https://github.com/DuendeSoftware/IdentityServer/issues/528