### PR TITLE
Fix PostLogout check in AppAuth redirect validator

### DIFF
--- a/src/IdentityServer/Validation/Default/StrictRedirectUriValidatorAppAuth.cs
+++ b/src/IdentityServer/Validation/Default/StrictRedirectUriValidatorAppAuth.cs
@@ -59,7 +59,7 @@ namespace Duende.IdentityServer.Validation
             if (isAllowed) return isAllowed;
 
             // since this is appauth specific, we can require pkce
-            if (client.RequirePkce && client.RedirectUris.Contains("http://127.0.0.1")) return IsLoopback(requestedUri);
+            if (client.RequirePkce && client.PostLogoutRedirectUris.Contains("http://127.0.0.1")) return IsLoopback(requestedUri);
 
             return false;
         }


### PR DESCRIPTION
The AppAuth redirect validator checked the redirect URI collection for logout. This is has been updated to use the post logout redirect URIs instead.