### PR TITLE
Adjust ASP.NET Identity integration to use EmailClaimType option

### DIFF
--- a/src/AspNetIdentity/IdentityServerBuilderExtensions.cs
+++ b/src/AspNetIdentity/IdentityServerBuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 
@@ -36,6 +36,7 @@ public static class IdentityServerBuilderExtensions
             options.ClaimsIdentity.UserIdClaimType = JwtClaimTypes.Subject;
             options.ClaimsIdentity.UserNameClaimType = JwtClaimTypes.Name;
             options.ClaimsIdentity.RoleClaimType = JwtClaimTypes.Role;
+            options.ClaimsIdentity.EmailClaimType = JwtClaimTypes.Email;
         });
 
         builder.Services.Configure<SecurityStampValidatorOptions>(opts =>

--- a/src/AspNetIdentity/UserClaimsFactory.cs
+++ b/src/AspNetIdentity/UserClaimsFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 
@@ -54,7 +54,6 @@ internal class UserClaimsFactory<TUser> : IUserClaimsPrincipalFactory<TUser>
             {
                 identity.AddClaims(new[]
                 {
-                    new Claim(JwtClaimTypes.Email, email),
                     new Claim(JwtClaimTypes.EmailVerified,
                         await _userManager.IsEmailConfirmedAsync(user) ? "true" : "false", ClaimValueTypes.Boolean)
                 });


### PR DESCRIPTION
ASP.NET Identity will [now] issue an email claim in its `UserClaimsFactory`. This means we no longer have to in our decorator. 