### PR TITLE
Fix OnConfiguring exception from EF when DbContext pooling is enabled

### DIFF
--- a/src/EntityFramework.Storage/DbContexts/ConfigurationDbContext.cs
+++ b/src/EntityFramework.Storage/DbContexts/ConfigurationDbContext.cs
@@ -131,6 +131,9 @@ public class ConfigurationDbContext<TContext> : DbContext, IConfigurationDbConte
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
         base.OnConfiguring(optionsBuilder);
-        optionsBuilder.ConfigureWarnings(w => w.Ignore(new EventId[] { RelationalEventId.MultipleCollectionIncludeWarning }));
+        if (!optionsBuilder.Options.IsFrozen)
+        {
+            optionsBuilder.ConfigureWarnings(w => w.Ignore(new EventId[] { RelationalEventId.MultipleCollectionIncludeWarning }));
+        }
     }
 }


### PR DESCRIPTION
When EF DbContext pooling is enabled for our ConfigurationDbContext, the EF options builder can't be modified more than one in OnConfiguring. This PR prevents us from trying to modify the options more than once.

Fixes:  #645