### PR TITLE
Allow empty secret when validating OIDC IDP config

### DIFF
--- a/src/IdentityServer/Validation/Default/DefaultIdentityProviderConfigurationValidator.cs
+++ b/src/IdentityServer/Validation/Default/DefaultIdentityProviderConfigurationValidator.cs
@@ -76,14 +76,6 @@ public class DefaultIdentityProviderConfigurationValidator : IIdentityProviderCo
         {
             context.SetError("ResponseType is missing.");
         }
-        else
-        {
-            var parts = context.IdentityProvider.ResponseType.Split(' ', StringSplitOptions.RemoveEmptyEntries).Distinct();
-            if (parts.Contains(IdentityModel.OidcConstants.ResponseTypes.Code) && String.IsNullOrWhiteSpace(context.IdentityProvider.ClientSecret))
-            {
-                context.SetError("ClientSecret is missing.");
-            }
-        }
 
         if (String.IsNullOrWhiteSpace(context.IdentityProvider.Scope))
         {

--- a/test/IdentityServer.UnitTests/Validation/IdentityProviderConfigurationValidation.cs
+++ b/test/IdentityServer.UnitTests/Validation/IdentityProviderConfigurationValidation.cs
@@ -124,8 +124,9 @@ public class IdentityProviderConfigurationValidation
 
     [Fact]
     [Trait("Category", Category)]
-    public async Task missing_secret_should_fail()
+    public async Task missing_secret_should_be_allowed()
     {
+        // we allow no secret because they might pull it from somewhere else
         var idp = new OidcProvider
         {
             Scheme = "scheme",
@@ -139,8 +140,7 @@ public class IdentityProviderConfigurationValidation
         var ctx = new IdentityProviderConfigurationValidationContext(idp);
         await _validator.ValidateAsync(ctx);
 
-        ctx.IsValid.Should().BeFalse();
-        ctx.ErrorMessage.ToLowerInvariant().Should().Contain("clientsecret");
+        ctx.IsValid.Should().BeTrue();
     }
 
     [Fact]


### PR DESCRIPTION
In 6.0 the concept of `IIdentityProviderConfigurationValidator` was introduced. This allows some minimal validation of the `OidcProvider` data stored when using the [dynamic provider feature](https://docs.duendesoftware.com/identityserver/v6/ui/login/dynamicproviders/). As part of this validation the client secret is checked, but given that the secret is a special value that might need to be stored elsewhere and configured after loading the IdP data from the database, it makes sense to not require in our store.

This PR removes the validation logic to require the client secret in the identity provider store.

Fixes: #647