### PR TITLE
Optimize logging

### DIFF
--- a/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -30,6 +30,7 @@ using Duende.IdentityServer.Services.KeyManagement;
 using Microsoft.Extensions.Logging;
 using Duende.IdentityServer.Hosting.DynamicProviders;
 using Duende.IdentityServer.Internal;
+using Duende.IdentityServer.Logging;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -168,7 +169,8 @@ public static class IdentityServerBuilderExtensionsCore
         builder.Services.TryAddTransient<IBackchannelAuthenticationUserValidator, NopBackchannelAuthenticationUserValidator>();
 
         builder.Services.TryAddTransient(typeof(IConcurrencyLock<>), typeof(DefaultConcurrencyLock<>));
-
+        builder.Services.AddTransient(typeof(IDevLogger<>), typeof(DevLogger<>));
+        
         return builder;
     }
 

--- a/src/IdentityServer/Hosting/EndpointRouter.cs
+++ b/src/IdentityServer/Hosting/EndpointRouter.cs
@@ -51,7 +51,7 @@ internal class EndpointRouter : IEndpointRouter
         {
             if (context.RequestServices.GetService(endpoint.Handler) is IEndpointHandler handler)
             {
-                _logger.DevLogDebug("Endpoint enabled: {endpoint}, successfully created handler: {endpointHandler}", endpoint.Name, endpoint.Handler.FullName);
+                _logger.LogDebug("Endpoint enabled: {endpoint}, successfully created handler: {endpointHandler}", endpoint.Name, endpoint.Handler.FullName);
                 return handler;
             }
 

--- a/src/IdentityServer/Hosting/EndpointRouter.cs
+++ b/src/IdentityServer/Hosting/EndpointRouter.cs
@@ -34,13 +34,13 @@ internal class EndpointRouter : IEndpointRouter
             if (context.Request.Path.Equals(path, StringComparison.OrdinalIgnoreCase))
             {
                 var endpointName = endpoint.Name;
-                _logger.LogDebug("Request path {path} matched to endpoint type {endpoint}", context.Request.Path, endpointName);
+                _logger.DevLogDebug("Request path {path} matched to endpoint type {endpoint}", context.Request.Path, endpointName);
 
                 return GetEndpointHandler(endpoint, context);
             }
         }
 
-        _logger.LogTrace("No endpoint entry found for request path: {path}", context.Request.Path);
+        _logger.DevLogTrace("No endpoint entry found for request path: {path}", context.Request.Path);
 
         return null;
     }
@@ -51,11 +51,11 @@ internal class EndpointRouter : IEndpointRouter
         {
             if (context.RequestServices.GetService(endpoint.Handler) is IEndpointHandler handler)
             {
-                _logger.LogDebug("Endpoint enabled: {endpoint}, successfully created handler: {endpointHandler}", endpoint.Name, endpoint.Handler.FullName);
+                _logger.DevLogDebug("Endpoint enabled: {endpoint}, successfully created handler: {endpointHandler}", endpoint.Name, endpoint.Handler.FullName);
                 return handler;
             }
 
-            _logger.LogDebug("Endpoint enabled: {endpoint}, failed to create handler: {endpointHandler}", endpoint.Name, endpoint.Handler.FullName);
+            _logger.DevLogDebug("Endpoint enabled: {endpoint}, failed to create handler: {endpointHandler}", endpoint.Name, endpoint.Handler.FullName);
         }
         else
         {

--- a/src/IdentityServer/Hosting/IdentityServerMiddleware.cs
+++ b/src/IdentityServer/Hosting/IdentityServerMiddleware.cs
@@ -99,7 +99,7 @@ public class IdentityServerMiddleware
         {
             // todo: better way to log exceptions?
             await events.RaiseAsync(new UnhandledExceptionEvent(ex));
-            _devLogger.UnhandledException(ex.Message);
+            _devLogger.UnhandledException(ex);
             //_logger.LogCritical(ex, "Unhandled exception: {exception}", ex.Message);
             throw;
         }

--- a/src/IdentityServer/Hosting/IdentityServerMiddleware.cs
+++ b/src/IdentityServer/Hosting/IdentityServerMiddleware.cs
@@ -20,19 +20,16 @@ namespace Duende.IdentityServer.Hosting;
 public class IdentityServerMiddleware
 {
     private readonly RequestDelegate _next;
-    private readonly ILogger _logger;
     private readonly IDevLogger<IdentityServerMiddleware> _devLogger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="IdentityServerMiddleware"/> class.
     /// </summary>
     /// <param name="next">The next.</param>
-    /// <param name="logger">The logger.</param>
     /// <param name="devLogger">The dev logger.</param>
-    public IdentityServerMiddleware(RequestDelegate next, ILogger<IdentityServerMiddleware> logger, IDevLogger<IdentityServerMiddleware> devLogger)
+    public IdentityServerMiddleware(RequestDelegate next, IDevLogger<IdentityServerMiddleware> devLogger)
     {
         _next = next;
-        _logger = logger;
         _devLogger = devLogger;
     }
 
@@ -85,7 +82,7 @@ public class IdentityServerMiddleware
 
                 // todo: does this need to be info?
                 //_logger.LogInformation("Invoking IdentityServer endpoint: {endpointType} for {url}", endpoint.GetType().FullName, context.Request.Path.ToString());
-                _logger.InvokeEndpoint(endpoint.GetType().FullName, context.Request.Path.ToString());
+                _devLogger.InvokeEndpoint(endpoint.GetType().FullName, context.Request.Path.ToString());
                 
                 var result = await endpoint.ProcessAsync(context);
 
@@ -102,7 +99,7 @@ public class IdentityServerMiddleware
         {
             // todo: better way to log exceptions?
             await events.RaiseAsync(new UnhandledExceptionEvent(ex));
-            _logger.UnhandledException(ex.Message);
+            _devLogger.UnhandledException(ex.Message);
             //_logger.LogCritical(ex, "Unhandled exception: {exception}", ex.Message);
             throw;
         }

--- a/src/IdentityServer/Logging/DevLogger.cs
+++ b/src/IdentityServer/Logging/DevLogger.cs
@@ -1,0 +1,99 @@
+using Microsoft.Extensions.Logging;
+
+namespace Duende.IdentityServer.Logging;
+
+#pragma warning disable 1591
+
+/// <summary>
+/// More efficient logging for debug/traces
+/// </summary>
+/// <typeparam name="T"></typeparam>
+public class DevLogger<T> : IDevLogger<T>
+{
+    private readonly ILogger<T> _logger;
+    
+    public DevLogger(ILogger<T> logger)
+    {
+        _logger = logger;
+    }
+    
+    public void DevLogDebug(string message)
+    {
+        if (_logger.IsEnabled(LogLevel.Debug))
+        {
+            _logger.LogDebug(message);
+        }
+    }
+
+    public void DevLogDebug<T0>(string message, T0 arg0)
+    {
+        if (_logger.IsEnabled(LogLevel.Debug))
+        {
+            _logger.LogDebug(message, arg0);
+        }
+    }
+
+    public void DevLogDebug<T0, T1>(string message, T0 arg0, T1 arg1)
+    {
+        if (_logger.IsEnabled(LogLevel.Debug))
+        {
+            _logger.LogDebug(message, arg0, arg1);
+        }
+    }
+
+    public void DevLogDebug<T0, T1, T2>(string message, T0 arg0, T1 arg1, T2 arg2)
+    {
+        if (_logger.IsEnabled(LogLevel.Debug))
+        {
+            _logger.LogDebug(message, arg0, arg1, arg2);
+        }
+    }
+
+    public void DevLogDebug<T0, T1, T2, T3>(string message, T0 arg0, T1 arg1, T2 arg2, T3 arg3)
+    {
+        if (_logger.IsEnabled(LogLevel.Debug))
+        {
+            _logger.LogDebug(message, arg0, arg1, arg2, arg3);
+        }
+    }
+    
+    public void DevLogTrace(string message)
+    {
+        if (_logger.IsEnabled(LogLevel.Trace))
+        {
+            _logger.LogTrace(message);
+        }
+    }
+
+    public void DevLogTrace<T0>(string message, T0 arg0)
+    {
+        if (_logger.IsEnabled(LogLevel.Trace))
+        {
+            _logger.LogTrace(message, arg0);
+        }
+    }
+
+    public void DevLogTrace<T0, T1>(string message, T0 arg0, T1 arg1)
+    {
+        if (_logger.IsEnabled(LogLevel.Trace))
+        {
+            _logger.LogTrace(message, arg0, arg1);
+        }
+    }
+
+    public void DevLogTrace<T0, T1, T2>(string message, T0 arg0, T1 arg1, T2 arg2)
+    {
+        if (_logger.IsEnabled(LogLevel.Trace))
+        {
+            _logger.LogTrace(message, arg0, arg1, arg2);
+        }
+    }
+
+    public void DevLogTrace<T0, T1, T2, T3>(string message, T0 arg0, T1 arg1, T2 arg2, T3 arg3)
+    {
+        if (_logger.IsEnabled(LogLevel.Trace))
+        {
+            _logger.LogTrace(message, arg0, arg1, arg2, arg3);
+        }
+    }
+}

--- a/src/IdentityServer/Logging/DevLogger.cs
+++ b/src/IdentityServer/Logging/DevLogger.cs
@@ -108,7 +108,7 @@ public class DevLogger<T> : IDevLogger<T>
         return _logger.IsEnabled(logLevel);
     }
 
-    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
     {
         _logger.Log(logLevel, eventId, state, exception, formatter);
     }

--- a/src/IdentityServer/Logging/DevLogger.cs
+++ b/src/IdentityServer/Logging/DevLogger.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.Extensions.Logging;
 
 namespace Duende.IdentityServer.Logging;
@@ -95,5 +96,20 @@ public class DevLogger<T> : IDevLogger<T>
         {
             _logger.LogTrace(message, arg0, arg1, arg2, arg3);
         }
+    }
+
+    public IDisposable BeginScope<TState>(TState state)
+    {
+        return _logger.BeginScope(state);
+    }
+
+    public bool IsEnabled(LogLevel logLevel)
+    {
+        return _logger.IsEnabled(logLevel);
+    }
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        _logger.Log(logLevel, eventId, state, exception, formatter);
     }
 }

--- a/src/IdentityServer/Logging/IDevLogger.cs
+++ b/src/IdentityServer/Logging/IDevLogger.cs
@@ -1,8 +1,15 @@
+using Microsoft.Extensions.Logging;
+
 namespace Duende.IdentityServer.Logging;
 
 #pragma warning disable 1591
 
-public interface IDevLogger<T>
+public interface IDevLogger<out T> : IDevLogger
+{
+    
+}
+
+public interface IDevLogger : ILogger
 {
     void DevLogDebug(string message);
     void DevLogDebug<T0>(string message, T0 arg0);

--- a/src/IdentityServer/Logging/IDevLogger.cs
+++ b/src/IdentityServer/Logging/IDevLogger.cs
@@ -1,0 +1,18 @@
+namespace Duende.IdentityServer.Logging;
+
+#pragma warning disable 1591
+
+public interface IDevLogger<T>
+{
+    void DevLogDebug(string message);
+    void DevLogDebug<T0>(string message, T0 arg0);
+    void DevLogDebug<T0, T1>(string message, T0 arg0, T1 arg1);
+    void DevLogDebug<T0, T1, T2>(string message, T0 arg0, T1 arg1, T2 arg2);
+    void DevLogDebug<T0, T1, T2, T3>(string message, T0 arg0, T1 arg1, T2 arg2, T3 arg3);
+    
+    void DevLogTrace(string message);
+    void DevLogTrace<T0>(string message, T0 arg0);
+    void DevLogTrace<T0, T1>(string message, T0 arg0, T1 arg1);
+    void DevLogTrace<T0, T1, T2>(string message, T0 arg0, T1 arg1, T2 arg2);
+    void DevLogTrace<T0, T1, T2, T3>(string message, T0 arg0, T1 arg1, T2 arg2, T3 arg3);
+}

--- a/src/IdentityServer/Logging/IDevLoggerExtensions.cs
+++ b/src/IdentityServer/Logging/IDevLoggerExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using Duende.IdentityServer.Logging.Models;
 using Microsoft.Extensions.Logging;
 
 namespace Duende.IdentityServer.Logging;
@@ -9,7 +10,13 @@ internal static partial class DevLoggerExtensions
         Message = "Unhandled exception")]
     internal static partial void UnhandledException(this IDevLogger logger, Exception exception);
     
+    
     [LoggerMessage(EventId = 1, EventName = "InvokeEndpoint", Level = LogLevel.Information,
         Message = "Invoking IdentityServer endpoint: {endpointType} for {url}")]
     internal static partial void InvokeEndpoint(this IDevLogger logger, string endpointType, string url);
+    
+    
+    [LoggerMessage(EventId = 2, EventName = "Test", Level = LogLevel.Information,
+        Message = "Log: {log}")]
+    internal static partial void Test(this IDevLogger logger, TokenRequestValidationLog log);
 }

--- a/src/IdentityServer/Logging/IDevLoggerExtensions.cs
+++ b/src/IdentityServer/Logging/IDevLoggerExtensions.cs
@@ -3,13 +3,13 @@ using Microsoft.Extensions.Logging;
 
 namespace Duende.IdentityServer.Logging;
 
-public static partial class IDevLoggerExtensions
+internal static partial class IDevLoggerExtensions
 {
     [LoggerMessage(EventId = 0, EventName = "UnhandledException", Level = LogLevel.Critical,
-        Message = "Unhandled exception: {message}")]
-    public static partial void UnhandledException(this IDevLogger logger, string message);
+        Message = "Unhandled exception")]
+    internal static partial void UnhandledException(this IDevLogger logger, Exception exception);
     
     [LoggerMessage(EventId = 1, EventName = "InvokeEndpoint", Level = LogLevel.Information,
         Message = "Invoking IdentityServer endpoint: {endpointType} for {url}")]
-    public static partial void InvokeEndpoint(this IDevLogger logger, string endpointType, string url);
+    internal static partial void InvokeEndpoint(this IDevLogger logger, string endpointType, string url);
 }

--- a/src/IdentityServer/Logging/IDevLoggerExtensions.cs
+++ b/src/IdentityServer/Logging/IDevLoggerExtensions.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Duende.IdentityServer.Logging;
 
-internal static partial class IDevLoggerExtensions
+internal static partial class DevLoggerExtensions
 {
     [LoggerMessage(EventId = 0, EventName = "UnhandledException", Level = LogLevel.Critical,
         Message = "Unhandled exception")]

--- a/src/IdentityServer/Logging/IDevLoggerExtensions.cs
+++ b/src/IdentityServer/Logging/IDevLoggerExtensions.cs
@@ -1,0 +1,15 @@
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Duende.IdentityServer.Logging;
+
+public static partial class IDevLoggerExtensions
+{
+    [LoggerMessage(EventId = 0, EventName = "UnhandledException", Level = LogLevel.Critical,
+        Message = "Unhandled exception: {message}")]
+    public static partial void UnhandledException(this ILogger logger, string message);
+    
+    [LoggerMessage(EventId = 1, EventName = "InvokeEndpoint", Level = LogLevel.Information,
+        Message = "Invoking IdentityServer endpoint: {endpointType} for {url}")]
+    public static partial void InvokeEndpoint(this ILogger logger, string endpointType, string url);
+}

--- a/src/IdentityServer/Logging/IDevLoggerExtensions.cs
+++ b/src/IdentityServer/Logging/IDevLoggerExtensions.cs
@@ -7,9 +7,9 @@ public static partial class IDevLoggerExtensions
 {
     [LoggerMessage(EventId = 0, EventName = "UnhandledException", Level = LogLevel.Critical,
         Message = "Unhandled exception: {message}")]
-    public static partial void UnhandledException(this ILogger logger, string message);
+    public static partial void UnhandledException(this IDevLogger logger, string message);
     
     [LoggerMessage(EventId = 1, EventName = "InvokeEndpoint", Level = LogLevel.Information,
         Message = "Invoking IdentityServer endpoint: {endpointType} for {url}")]
-    public static partial void InvokeEndpoint(this ILogger logger, string endpointType, string url);
+    public static partial void InvokeEndpoint(this IDevLogger logger, string endpointType, string url);
 }

--- a/src/IdentityServer/Logging/ILoggerDevExtensions.cs
+++ b/src/IdentityServer/Logging/ILoggerDevExtensions.cs
@@ -69,6 +69,7 @@ internal static class ILoggerDevExtensions
     }
     
     // todo: understand ordering of extension method visibility
+    // https://codeblog.jonskeet.uk/2010/11/03/using-extension-method-resolution-rules-to-decorate-awaiters/
     // public static void LogDebug<T0, T1>(this ILogger logger, string message, T0 arg0, T1 arg1)
     // {
     //     if (logger.IsEnabled(LogLevel.Debug))

--- a/src/IdentityServer/Logging/ILoggerDevExtensions.cs
+++ b/src/IdentityServer/Logging/ILoggerDevExtensions.cs
@@ -69,14 +69,14 @@ internal static class ILoggerDevExtensions
     }
     
     // todo: understand ordering of extension method visibility
-    // https://codeblog.jonskeet.uk/2010/11/03/using-extension-method-resolution-rules-to-decorate-awaiters/
-    // public static void LogDebug<T0, T1>(this ILogger logger, string message, T0 arg0, T1 arg1)
-    // {
-    //     if (logger.IsEnabled(LogLevel.Debug))
-    //     {
-    //         logger.LogDebug(message, arg0, arg1);
-    //     }
-    // }
+    //https://codeblog.jonskeet.uk/2010/11/03/using-extension-method-resolution-rules-to-decorate-awaiters/
+    public static void LogDebug<T0, T1>(this ILogger logger, string message, T0 arg0, T1 arg1)
+    {
+        if (logger.IsEnabled(LogLevel.Debug))
+        {
+            logger.LogDebug(message, arg0, arg1);
+        }
+    }
 
     public static void DevLogDebug<T0, T1, T2>(this ILogger logger, string message, T0 arg0, T1 arg1, T2 arg2)
     {

--- a/src/IdentityServer/Logging/ILoggerDevExtensions.cs
+++ b/src/IdentityServer/Logging/ILoggerDevExtensions.cs
@@ -1,0 +1,95 @@
+using Microsoft.Extensions.Logging;
+
+namespace Duende.IdentityServer;
+
+internal static class ILoggerDevExtensions
+{
+    public static void DevLogTrace(this ILogger _logger, string message)
+    {
+        if (_logger.IsEnabled(LogLevel.Trace))
+        {
+            _logger.LogTrace(message);
+        }
+    }
+
+    public static void DevLogTrace<T0>(this ILogger _logger, string message, T0 arg0)
+    {
+        if (_logger.IsEnabled(LogLevel.Trace))
+        {
+            _logger.LogTrace(message, arg0);
+        }
+    }
+
+    public static void DevLogTrace<T0, T1>(this ILogger _logger, string message, T0 arg0, T1 arg1)
+    {
+        if (_logger.IsEnabled(LogLevel.Trace))
+        {
+            _logger.LogTrace(message, arg0, arg1);
+        }
+    }
+
+    public static void DevLogTrace<T0, T1, T2>(this ILogger _logger, string message, T0 arg0, T1 arg1, T2 arg2)
+    {
+        if (_logger.IsEnabled(LogLevel.Trace))
+        {
+            _logger.LogTrace(message, arg0, arg1, arg2);
+        }
+    }
+
+    public static void DevLogTrace<T0, T1, T2, T3>(this ILogger _logger, string message, T0 arg0, T1 arg1, T2 arg2, T3 arg3)
+    {
+        if (_logger.IsEnabled(LogLevel.Trace))
+        {
+            _logger.LogTrace(message, arg0, arg1, arg2, arg3);
+        }
+    }
+    
+    public static void DevLogDebug(this ILogger logger, string message)
+    {
+        if (logger.IsEnabled(LogLevel.Debug))
+        {
+            logger.LogDebug(message);
+        }
+    }
+
+    public static void DevLogDebug<T0>(this ILogger logger, string message, T0 arg0)
+    {
+        if (logger.IsEnabled(LogLevel.Debug))
+        {
+            logger.LogDebug(message, arg0);
+        }
+    }
+
+    public static void DevLogDebug<T0, T1>(this ILogger logger, string message, T0 arg0, T1 arg1)
+    {
+        if (logger.IsEnabled(LogLevel.Debug))
+        {
+            logger.LogDebug(message, arg0, arg1);
+        }
+    }
+    
+    // todo: understand ordering of extension method visibility
+    // public static void LogDebug<T0, T1>(this ILogger logger, string message, T0 arg0, T1 arg1)
+    // {
+    //     if (logger.IsEnabled(LogLevel.Debug))
+    //     {
+    //         logger.LogDebug(message, arg0, arg1);
+    //     }
+    // }
+
+    public static void DevLogDebug<T0, T1, T2>(this ILogger logger, string message, T0 arg0, T1 arg1, T2 arg2)
+    {
+        if (logger.IsEnabled(LogLevel.Debug))
+        {
+            logger.LogDebug(message, arg0, arg1, arg2);
+        }
+    }
+
+    public static void DevLogDebug<T0, T1, T2, T3>(this ILogger logger, string message, T0 arg0, T1 arg1, T2 arg2, T3 arg3)
+    {
+        if (logger.IsEnabled(LogLevel.Debug))
+        {
+            logger.LogDebug(message, arg0, arg1, arg2, arg3);
+        }
+    }
+}


### PR DESCRIPTION
a) We do a lot of unstructured debug and trace logging. That's fine.
But in production, these log levels are often not used, so we could get around those code paths and allocations.

Probably a micro-optimisation, but part of the bigger logging effort.

b) we should formalize all logging messages which are Information and above

for reference: 

https://youtu.be/bnVfrd3lRv8
https://www.youtube.com/watch?v=a26zu-pyEyg