### PR TITLE
EF fixes

### DIFF
--- a/clients/src/ConsoleClientCredentialsFlow/ConsoleClientCredentialsFlow.csproj
+++ b/clients/src/ConsoleClientCredentialsFlow/ConsoleClientCredentialsFlow.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/hosts/EntityFramework/Pages/Admin/Clients/ClientRepository.cs
+++ b/hosts/EntityFramework/Pages/Admin/Clients/ClientRepository.cs
@@ -121,6 +121,8 @@ public class ClientRepository
         client.ClientId = model.ClientId.Trim();
         client.ClientName = model.Name?.Trim();
 
+        client.ClientSecrets.Add(new Duende.IdentityServer.Models.Secret(model.Secret.Sha256()));
+        
         if (model.Flow == Flow.ClientCredentials)
         {
             client.AllowedGrantTypes = GrantTypes.ClientCredentials;
@@ -128,6 +130,7 @@ public class ClientRepository
         else
         {
             client.AllowedGrantTypes = GrantTypes.Code;
+            client.AllowOfflineAccess = true;
         }
 
         _context.Clients.Add(client.ToEntity());

--- a/src/EntityFramework.Storage/Stores/ClientStore.cs
+++ b/src/EntityFramework.Storage/Stores/ClientStore.cs
@@ -58,22 +58,22 @@ public class ClientStore : IClientStore
     /// </returns>
     public virtual async Task<Duende.IdentityServer.Models.Client> FindClientByIdAsync(string clientId)
     {
-        var query = Context.Clients
-            .Where(x => x.ClientId == clientId)
-            .Include(x => x.AllowedCorsOrigins)
-            .Include(x => x.AllowedGrantTypes)
-            .Include(x => x.AllowedScopes)
-            .Include(x => x.Claims)
-            .Include(x => x.ClientSecrets)
-            .Include(x => x.IdentityProviderRestrictions)
-            .Include(x => x.PostLogoutRedirectUris)
-            .Include(x => x.Properties)
-            .Include(x => x.RedirectUris)
-            .AsNoTracking();
-            
-        var client = (await query.ToArrayAsync(CancellationTokenProvider.CancellationToken))
+        IQueryable<Entities.Client> baseQuery = Context.Clients
+            .Where(x => x.ClientId == clientId);
+
+        var client = (await baseQuery.ToArrayAsync())
             .SingleOrDefault(x => x.ClientId == clientId);
         if (client == null) return null;
+
+        await baseQuery.Include(x => x.AllowedCorsOrigins).SelectMany(c => c.AllowedCorsOrigins).LoadAsync();
+        await baseQuery.Include(x => x.AllowedGrantTypes).SelectMany(c => c.AllowedGrantTypes).LoadAsync();
+        await baseQuery.Include(x => x.AllowedScopes).SelectMany(c => c.AllowedScopes).LoadAsync();
+        await baseQuery.Include(x => x.Claims).SelectMany(c => c.Claims).LoadAsync();
+        await baseQuery.Include(x => x.ClientSecrets).SelectMany(c => c.ClientSecrets).LoadAsync();
+        await baseQuery.Include(x => x.IdentityProviderRestrictions).SelectMany(c => c.IdentityProviderRestrictions).LoadAsync();
+        await baseQuery.Include(x => x.PostLogoutRedirectUris).SelectMany(c => c.PostLogoutRedirectUris).LoadAsync();
+        await baseQuery.Include(x => x.Properties).SelectMany(c => c.Properties).LoadAsync();
+        await baseQuery.Include(x => x.RedirectUris).SelectMany(c => c.RedirectUris).LoadAsync();
 
         var model = client.ToModel();
 

--- a/src/EntityFramework.Storage/Stores/ClientStore.cs
+++ b/src/EntityFramework.Storage/Stores/ClientStore.cs
@@ -58,22 +58,23 @@ public class ClientStore : IClientStore
     /// </returns>
     public virtual async Task<Duende.IdentityServer.Models.Client> FindClientByIdAsync(string clientId)
     {
-        IQueryable<Entities.Client> baseQuery = Context.Clients
-            .Where(x => x.ClientId == clientId);
+        var query = Context.Clients
+          .Where(x => x.ClientId == clientId)
+          .Include(x => x.AllowedCorsOrigins)
+          .Include(x => x.AllowedGrantTypes)
+          .Include(x => x.AllowedScopes)
+          .Include(x => x.Claims)
+          .Include(x => x.ClientSecrets)
+          .Include(x => x.IdentityProviderRestrictions)
+          .Include(x => x.PostLogoutRedirectUris)
+          .Include(x => x.Properties)
+          .Include(x => x.RedirectUris)
+          .AsNoTracking()
+          .AsSplitQuery();
 
-        var client = (await baseQuery.ToArrayAsync())
-            .SingleOrDefault(x => x.ClientId == clientId);
+        var client = (await query.ToArrayAsync(CancellationTokenProvider.CancellationToken)).
+            SingleOrDefault(x => x.ClientId == clientId);
         if (client == null) return null;
-
-        await baseQuery.Include(x => x.AllowedCorsOrigins).SelectMany(c => c.AllowedCorsOrigins).LoadAsync();
-        await baseQuery.Include(x => x.AllowedGrantTypes).SelectMany(c => c.AllowedGrantTypes).LoadAsync();
-        await baseQuery.Include(x => x.AllowedScopes).SelectMany(c => c.AllowedScopes).LoadAsync();
-        await baseQuery.Include(x => x.Claims).SelectMany(c => c.Claims).LoadAsync();
-        await baseQuery.Include(x => x.ClientSecrets).SelectMany(c => c.ClientSecrets).LoadAsync();
-        await baseQuery.Include(x => x.IdentityProviderRestrictions).SelectMany(c => c.IdentityProviderRestrictions).LoadAsync();
-        await baseQuery.Include(x => x.PostLogoutRedirectUris).SelectMany(c => c.PostLogoutRedirectUris).LoadAsync();
-        await baseQuery.Include(x => x.Properties).SelectMany(c => c.Properties).LoadAsync();
-        await baseQuery.Include(x => x.RedirectUris).SelectMany(c => c.RedirectUris).LoadAsync();
 
         var model = client.ToModel();
 


### PR DESCRIPTION
This PR fixes two EF issues:

* Client Store query has been reverted to the v5.x style, which makes multiple round trips to avoid the matrix multiplication when an inner join is used for the various child tables. Customers were experiencing worse performance with the inner join.

Fixes: #694

* Quickstart Admin Pages for Client Creation: They were missing storing the client secret and the AllowOfflineAccess settings.