### PR TITLE
Fix issues were found with static analyzer PVS-Studio

### DIFF
--- a/src/EntityFramework.Storage/Stores/DeviceFlowStore.cs
+++ b/src/EntityFramework.Storage/Stores/DeviceFlowStore.cs
@@ -139,7 +139,7 @@ public class DeviceFlowStore : IDeviceFlowStore
         Logger.LogDebug("{userCode} found in database", userCode);
 
         existing.SubjectId = data.Subject?.FindFirst(JwtClaimTypes.Subject).Value;
-        existing.Data = entity.Data;
+        existing.Data = entity?.Data;
 
         try
         {

--- a/src/IdentityServer/Endpoints/DeviceAuthorizationEndpoint.cs
+++ b/src/IdentityServer/Endpoints/DeviceAuthorizationEndpoint.cs
@@ -113,7 +113,7 @@ internal class DeviceAuthorizationEndpoint : IEndpointHandler
 
     private void LogResponse(DeviceAuthorizationResponse response, DeviceAuthorizationRequestValidationResult requestResult)
     {
-        var clientId = $"{requestResult.ValidatedRequest.Client.ClientId} ({requestResult.ValidatedRequest.Client?.ClientName ?? "no name set"})";
+        var clientId = $"{requestResult.ValidatedRequest.Client?.ClientId} ({requestResult.ValidatedRequest.Client?.ClientName ?? "no name set"})";
 
         if (response.DeviceCode != null)
         {

--- a/src/IdentityServer/Endpoints/TokenEndpoint.cs
+++ b/src/IdentityServer/Endpoints/TokenEndpoint.cs
@@ -121,7 +121,7 @@ internal class TokenEndpoint : IEndpointHandler
 
     private void LogTokens(TokenResponse response, TokenRequestValidationResult requestResult)
     {
-        var clientId = $"{requestResult.ValidatedRequest.Client.ClientId} ({requestResult.ValidatedRequest.Client?.ClientName ?? "no name set"})";
+        var clientId = $"{requestResult.ValidatedRequest.Client?.ClientId} ({requestResult.ValidatedRequest.Client?.ClientName ?? "no name set"})";
         var subjectId = requestResult.ValidatedRequest.Subject?.GetSubjectId() ?? "no subject";
 
         if (response.IdentityToken != null)

--- a/src/IdentityServer/Events/BackchannelAuthenticationFailureEvent.cs
+++ b/src/IdentityServer/Events/BackchannelAuthenticationFailureEvent.cs
@@ -30,7 +30,7 @@ public class BackchannelAuthenticationFailureEvent : Event
 
             if (request.Subject != null && request.Subject.Identity.IsAuthenticated)
             {
-                SubjectId = request.Subject?.GetSubjectId();
+                SubjectId = request.Subject.GetSubjectId();
             }
         }
 

--- a/src/IdentityServer/Events/TokenIssuedFailureEvent.cs
+++ b/src/IdentityServer/Events/TokenIssuedFailureEvent.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 
@@ -32,7 +32,7 @@ public class TokenIssuedFailureEvent : Event
 
             if (request.Subject != null && request.Subject.Identity.IsAuthenticated)
             {
-                SubjectId = request.Subject?.GetSubjectId();
+                SubjectId = request.Subject.GetSubjectId();
             }
         }
 

--- a/src/IdentityServer/Extensions/HttpContextExtensions.cs
+++ b/src/IdentityServer/Extensions/HttpContextExtensions.cs
@@ -143,10 +143,10 @@ public static class HttpContextExtensions
         // if we have a logout message, then that take precedence over the current user
         if (logoutMessage?.ClientIds?.Any() == true)
         {
-            var clientIds = logoutMessage?.ClientIds;
+            var clientIds = logoutMessage.ClientIds;
 
             // check if current user is same, since we might have new clients (albeit unlikely)
-            if (currentSubId == logoutMessage?.SubjectId)
+            if (currentSubId == logoutMessage.SubjectId)
             {
                 clientIds = clientIds.Union(await userSession.GetClientListAsync());
                 clientIds = clientIds.Distinct();

--- a/src/IdentityServer/Extensions/PrincipalExtensions.cs
+++ b/src/IdentityServer/Extensions/PrincipalExtensions.cs
@@ -46,12 +46,14 @@ public static class PrincipalExtensions
     [DebuggerStepThrough]
     public static long GetAuthenticationTimeEpoch(this IIdentity identity)
     {
-        var id = identity as ClaimsIdentity;
-        var claim = id.FindFirst(JwtClaimTypes.AuthenticationTime);
+        if (identity is ClaimsIdentity id)
+        {
+            var claim = id.FindFirst(JwtClaimTypes.AuthenticationTime);
+            if (claim is null) throw new InvalidOperationException("auth_time is missing.");
+            return long.Parse(claim.Value);
+        }
 
-        if (claim == null) throw new InvalidOperationException("auth_time is missing.");
-           
-        return long.Parse(claim.Value);
+        throw new InvalidOperationException("auth_time is missing.");
     }
 
     /// <summary>
@@ -74,11 +76,34 @@ public static class PrincipalExtensions
     [DebuggerStepThrough]
     public static string GetSubjectId(this IIdentity identity)
     {
-        var id = identity as ClaimsIdentity;
-        var claim = id.FindFirst(JwtClaimTypes.Subject);
+        if (identity is ClaimsIdentity id)
+        {
+            var claim = id.FindFirst(JwtClaimTypes.Subject);
+            if (claim is null) throw new InvalidOperationException("sub claim is missing");
+            return claim.Value;
+        }
 
-        if (claim == null) throw new InvalidOperationException("sub claim is missing");
-        return claim.Value;
+        throw new InvalidOperationException("sub claim is missing");
+    }
+
+    /// <summary>
+    /// Gets the name.
+    /// </summary>
+    /// <param name="identity">The identity.</param>
+    /// <returns></returns>
+    /// <exception cref="System.InvalidOperationException">name claim is missing</exception>
+    [DebuggerStepThrough]
+    [Obsolete("This method will be removed in a future version. Use GetDisplayName instead.")]
+    public static string GetName(this IIdentity identity)
+    {
+        if (identity is ClaimsIdentity id)
+        {
+            var claim = id.FindFirst(JwtClaimTypes.Name);
+            if (claim is null) throw new InvalidOperationException("name claim is missing");
+            return claim.Value;
+        }
+
+        throw new InvalidOperationException("name claim is missing");
     }
 
     /// <summary>
@@ -111,23 +136,6 @@ public static class PrincipalExtensions
     }
 
     /// <summary>
-    /// Gets the name.
-    /// </summary>
-    /// <param name="identity">The identity.</param>
-    /// <returns></returns>
-    /// <exception cref="System.InvalidOperationException">name claim is missing</exception>
-    [DebuggerStepThrough]
-    [Obsolete("This method will be removed in a future version. Use GetDisplayName instead.")]
-    public static string GetName(this IIdentity identity)
-    {
-        var id = identity as ClaimsIdentity;
-        var claim = id.FindFirst(JwtClaimTypes.Name);
-
-        if (claim == null) throw new InvalidOperationException("name claim is missing");
-        return claim.Value;
-    }
-
-    /// <summary>
     /// Gets the authentication method.
     /// </summary>
     /// <param name="principal">The principal.</param>
@@ -139,17 +147,6 @@ public static class PrincipalExtensions
     }
 
     /// <summary>
-    /// Gets the authentication method claims.
-    /// </summary>
-    /// <param name="principal">The principal.</param>
-    /// <returns></returns>
-    [DebuggerStepThrough]
-    public static IEnumerable<Claim> GetAuthenticationMethods(this IPrincipal principal)
-    {
-        return principal.Identity.GetAuthenticationMethods();
-    }
-
-    /// <summary>
     /// Gets the authentication method.
     /// </summary>
     /// <param name="identity">The identity.</param>
@@ -158,11 +155,25 @@ public static class PrincipalExtensions
     [DebuggerStepThrough]
     public static string GetAuthenticationMethod(this IIdentity identity)
     {
-        var id = identity as ClaimsIdentity;
-        var claim = id.FindFirst(JwtClaimTypes.AuthenticationMethod);
+        if (identity is ClaimsIdentity id)
+        {
+            var claim = id.FindFirst(JwtClaimTypes.AuthenticationMethod);
+            if (claim is null) throw new InvalidOperationException("amr claim is missing");
+            return claim.Value;
+        }
 
-        if (claim == null) throw new InvalidOperationException("amr claim is missing");
-        return claim.Value;
+        throw new InvalidOperationException("amr claim is missing");
+    }
+
+    /// <summary>
+    /// Gets the authentication method claims.
+    /// </summary>
+    /// <param name="principal">The principal.</param>
+    /// <returns></returns>
+    [DebuggerStepThrough]
+    public static IEnumerable<Claim> GetAuthenticationMethods(this IPrincipal principal)
+    {
+        return principal.Identity.GetAuthenticationMethods();
     }
 
     /// <summary>
@@ -197,11 +208,14 @@ public static class PrincipalExtensions
     [DebuggerStepThrough]
     public static string GetIdentityProvider(this IIdentity identity)
     {
-        var id = identity as ClaimsIdentity;
-        var claim = id.FindFirst(JwtClaimTypes.IdentityProvider);
+        if (identity is ClaimsIdentity id)
+        {
+            var claim = id.FindFirst(JwtClaimTypes.IdentityProvider);
+            if (claim is null) throw new InvalidOperationException("idp claim is missing");
+            return claim.Value;
+        }
 
-        if (claim == null) throw new InvalidOperationException("idp claim is missing");
-        return claim.Value;
+        throw new InvalidOperationException("idp claim is missing");
     }
 
     /// <summary>

--- a/src/IdentityServer/Extensions/StringsExtensions.cs
+++ b/src/IdentityServer/Extensions/StringsExtensions.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
 using System.Text.Encodings.Web;
 
 namespace Duende.IdentityServer.Extensions;
@@ -18,17 +17,22 @@ internal static class StringExtensions
     [DebuggerStepThrough]
     public static string ToSpaceSeparatedString(this IEnumerable<string> list)
     {
-        if (list == null)
+        if (list is null)
         {
             return string.Empty;
         }
-        
-        return String.Join(' ', list);
+
+        return string.Join(' ', list);
     }
 
     [DebuggerStepThrough]
     public static IEnumerable<string> FromSpaceSeparatedString(this string input)
     {
+        if (string.IsNullOrEmpty(input))
+        {
+            return Enumerable.Empty<string>();
+        }
+
         input = input.Trim();
         return input.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries).ToList();
     }
@@ -126,7 +130,7 @@ internal static class StringExtensions
     [DebuggerStepThrough]
     public static string CleanUrlPath(this string url)
     {
-        if (String.IsNullOrWhiteSpace(url)) url = "/";
+        if (string.IsNullOrWhiteSpace(url)) url = "/";
 
         if (url != "/" && url.EndsWith("/"))
         {
@@ -186,13 +190,13 @@ internal static class StringExtensions
     [DebuggerStepThrough]
     public static string AddQueryString(this string url, string query)
     {
-        if (!url.Contains("?"))
+        if (!url.Contains('?'))
         {
-            url += "?";
+            url += '?';
         }
-        else if (!url.EndsWith("&"))
+        else if (!url.EndsWith('&'))
         {
-            url += "&";
+            url += '&';
         }
 
         return url + query;
@@ -207,9 +211,9 @@ internal static class StringExtensions
     [DebuggerStepThrough]
     public static string AddHashFragment(this string url, string query)
     {
-        if (!url.Contains("#"))
+        if (!url.Contains('#'))
         {
-            url += "#";
+            url += '#';
         }
 
         return url + query;
@@ -232,7 +236,7 @@ internal static class StringExtensions
             }
         }
 
-        return new NameValueCollection();           
+        return new NameValueCollection();
     }
 
     public static string GetOrigin(this string url)
@@ -254,7 +258,7 @@ internal static class StringExtensions
 
         return null;
     }
-        
+
     public static string Obfuscate(this string value)
     {
         var last4Chars = "****";

--- a/src/IdentityServer/ResponseHandling/Default/DiscoveryResponseGenerator.cs
+++ b/src/IdentityServer/ResponseHandling/Default/DiscoveryResponseGenerator.cs
@@ -509,7 +509,7 @@ public class DiscoveryResponseGenerator : IDiscoveryResponseGenerator
                     x5t = jsonWebKey.X5t,
                     e = jsonWebKey.E,
                     n = jsonWebKey.N,
-                    x5c = jsonWebKey.X5c?.Count == 0 ? null : jsonWebKey.X5c.ToArray(),
+                    x5c = jsonWebKey.X5c is null || jsonWebKey.X5c.Count == 0 ? null : jsonWebKey.X5c.ToArray(),
                     alg = jsonWebKey.Alg,
                     crv = jsonWebKey.Crv,
                     x = jsonWebKey.X,

--- a/src/IdentityServer/Services/Default/DefaultIdentityServerInteractionService.cs
+++ b/src/IdentityServer/Services/Default/DefaultIdentityServerInteractionService.cs
@@ -89,7 +89,7 @@ internal class DefaultIdentityServerInteractionService : IIdentityServerInteract
                 var sid = await _userSession.GetSessionIdAsync();
                 var msg = new Message<LogoutMessage>(new LogoutMessage
                 {
-                    SubjectId = user?.GetSubjectId(),
+                    SubjectId = user.GetSubjectId(),
                     SessionId = sid,
                     ClientIds = clientIds
                 }, _clock.UtcNow.UtcDateTime);

--- a/src/IdentityServer/Services/Default/KeyManagement/KeyManager.cs
+++ b/src/IdentityServer/Services/Default/KeyManagement/KeyManager.cs
@@ -435,7 +435,7 @@ public class KeyManager : IKeyManager
                         var key = _protector.Unprotect(x);
                         if (key == null)
                         {
-                            _logger.LogWarning("Key with kid {kid} failed to unprotect.", x.Id);
+                            _logger.LogWarning("Key with kid {kid} failed to unprotect.", x?.Id);
                         }
                         return key;
                     }

--- a/src/IdentityServer/Test/TestUserStore.cs
+++ b/src/IdentityServer/Test/TestUserStore.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 
@@ -44,7 +44,7 @@ public class TestUserStore
                 return true;
             }
                 
-            return user.Password.Equals(password);
+            return string.Equals(user.Password, password);
         }
             
         return false;

--- a/src/IdentityServer/Validation/Default/DefaultResourceValidator.cs
+++ b/src/IdentityServer/Validation/Default/DefaultResourceValidator.cs
@@ -37,11 +37,12 @@ public class DefaultResourceValidator : IResourceValidator
     /// <inheritdoc/>
     public virtual async Task<ResourceValidationResult> ValidateRequestedResourcesAsync(ResourceValidationRequest request)
     {
-        using var activity = Tracing.ActivitySource.StartActivity("DefaultResourceValidator.ValidateRequestedResources");
-        activity?.SetTag(Tracing.Properties.Scope, request.Scopes.ToSpaceSeparatedString());
-        activity?.SetTag(Tracing.Properties.Resource, request.ResourceIndicators.ToSpaceSeparatedString());
-        
         if (request == null) throw new ArgumentNullException(nameof(request));
+
+        using var activity = Tracing.ActivitySource.StartActivity("DefaultResourceValidator.ValidateRequestedResources");
+        activity?
+            .SetTag(Tracing.Properties.Scope, request.Scopes.ToSpaceSeparatedString())
+            .SetTag(Tracing.Properties.Resource, request.ResourceIndicators.ToSpaceSeparatedString());
 
         var result = new ResourceValidationResult();
 


### PR DESCRIPTION
**What issue does this PR address?**
I ran static analyzer PVS-Studio and have got a report with possible issues in the code. I fixed some of them.

**[src/EntityFramework.Storage/Stores/DeviceFlowStore.cs]**
*line 142:* `entity` possible has null value. Method `ToEntity` may return null value in case `model` or `deviceCode` or  `userCode` are null.
**[src/IdentityServer/Endpoints/DeviceAuthorizationEndpoint.cs]**
*line 116:* `requestResult.ValidatedRequest.Client` possible has null value. Next interpolated string parameters is verified the `Client` property: `requestResult.ValidatedRequest.Client?.ClientName`
**[src/IdentityServer/Endpoints/TokenEndpoint.cs]**
*line 124:* `requestResult.ValidatedRequest.Client` possible has null value. Next interpolated string parameters is verified the `Client` property: `requestResult.ValidatedRequest.Client?.ClientName`
**[src/IdentityServer/Events/BackchannelAuthenticationFailureEvent.cs]**
*line 33:* `request.Subject` is always not null (see check for null in the line 31)
**[src/IdentityServer/Events/TokenIssuedFailureEvent.cs]**
*line 35:* `request.Subject` is always not null (see check for null in the line 33)
**[src/IdentityServer/Extensions/HttpContextExtensions.cs]**
*line 146 and line 149:* `logoutMessage` is always not null (see check for null in line 144)
**[src/IdentityServer/Extensions/PrincipalExtensions.cs]**
*lines 49, 77, 123, 161, 200:* `id` may be null. Use pattern matching to avoid null value.
**[src/IdentityServer/Extensions/StringsExtensions.cs]**
*line 31:* In the `FromSpaceSeparatedString` didn't check for `input` parameter
**[src/IdentityServer/ResponseHandling/Default/DiscoveryResponseGenerator.cs]**
*line 512:* `jsonWebKey.X5c` may be null. The condition `jsonWebKey.X5c?.Count == 0` will be false in case `jsonWebKey.X5c` is null.
**[src/IdentityServer/Services/Default/DefaultIdentityServerInteractionService.cs]**
*line 92:* `user` is always not null (see check for null in the line 84)
**[src/IdentityServer/Services/Default/KeyManagement/KeyManager.cs]**
*line 438:* `x` may be null. See null check in the line 444
**[src/IdentityServer/Services/Default/OidcReturnUrlParser.cs]**
*lines 48-52:* Add null validation parameters in constructor that is used in the methods `ParseAsync` and `IsValidReturnUrl`
*lines 90-103:* Extract as local function
**[src/IdentityServer/Test/TestUserStore.cs]**
*line 47:* `user.Password` may be null. The condition `if (string.IsNullOrWhiteSpace(user.Password) && string.IsNullOrWhiteSpace(password))` will be false in case `user.Password` is null and `password` is string non-space value
**[src/IdentityServer/Validation/Default/DefaultResourceValidator.cs]**
*lines 40-43:* `request` may be null (see check for null in the line 44)