### PR TITLE
update session id and description for user interaction in device flow

### DIFF
--- a/clients/src/ConsoleDeviceFlow/Program.cs
+++ b/clients/src/ConsoleDeviceFlow/Program.cs
@@ -1,4 +1,4 @@
-﻿using Clients;
+using Clients;
 using IdentityModel;
 using IdentityModel.Client;
 using System;
@@ -35,7 +35,8 @@ namespace ConsoleDeviceFlow
             var response = await client.RequestDeviceAuthorizationAsync(new DeviceAuthorizationRequest
             {
                 Address = disco.DeviceAuthorizationEndpoint,
-                ClientId = "device"
+                ClientId = "device",
+                ClientCredentialStyle = ClientCredentialStyle.PostBody
             });
 
             if (response.IsError) throw new Exception(response.Error);

--- a/src/EntityFramework.Storage/Stores/DeviceFlowStore.cs
+++ b/src/EntityFramework.Storage/Stores/DeviceFlowStore.cs
@@ -140,6 +140,8 @@ public class DeviceFlowStore : IDeviceFlowStore
 
         existing.SubjectId = data.Subject?.FindFirst(JwtClaimTypes.Subject).Value;
         existing.Data = entity.Data;
+        existing.SessionId = data.SessionId;
+        existing.Description = data.Description;
 
         try
         {
@@ -194,6 +196,8 @@ public class DeviceFlowStore : IDeviceFlowStore
     /// <returns></returns>
     protected DeviceFlowCodes ToEntity(DeviceCode model, string deviceCode, string userCode)
     {
+        // TODO: consider removing this in v7.0 since it's not properly/fully used
+
         if (model == null || deviceCode == null || userCode == null) return null;
 
         return new DeviceFlowCodes
@@ -202,6 +206,8 @@ public class DeviceFlowStore : IDeviceFlowStore
             UserCode = userCode,
             ClientId = model.ClientId,
             SubjectId = model.Subject?.FindFirst(JwtClaimTypes.Subject).Value,
+            SessionId = model.SessionId,
+            Description = model.Description,
             CreationTime = model.CreationTime,
             Expiration = model.CreationTime.AddSeconds(model.Lifetime),
             Data = Serializer.Serialize(model)


### PR DESCRIPTION
In the device flow, when the user does their interaction and updates the grant we were not capturing the session id or the description from the user's interaction. This PR fixes that.

Related: https://github.com/DuendeSoftware/IdentityServer/issues/735