### PR TITLE
Remove setter from Properties on IdentityProvider

### DIFF
--- a/migrations/IdentityServerDb/SeedData.cs
+++ b/migrations/IdentityServerDb/SeedData.cs
@@ -107,7 +107,11 @@ public class SeedData
                 DisplayName = "Google",
                 Authority = "https://accounts.google.com",
                 ClientId = "998042782978-gkes3j509qj26omrh6orvrnu0klpflh6.apps.googleusercontent.com",
-                Scope = "openid profile email"
+                Scope = "openid profile email",
+                Properties = 
+                {
+                    { "foo", "bar" }
+                }
             }.ToEntity());
             context.SaveChanges();
         }

--- a/src/Storage/Models/IdentityProvider.cs
+++ b/src/Storage/Models/IdentityProvider.cs
@@ -78,7 +78,7 @@ public class IdentityProvider
     /// <summary>
     /// Protocol specific properties for the provider.
     /// </summary>
-    public Dictionary<string, string> Properties { get; set; } = new Dictionary<string, string>();
+    public Dictionary<string, string> Properties { get; } = new Dictionary<string, string>();
 
     /// <summary>
     /// Properties indexer


### PR DESCRIPTION
It's possible to overwrite the `Properties` dictionary, thus un-setting other properties on the `IdentityProvider` class:

```
new OidcProvider
            {
                Scheme = "google",
                DisplayName = "Google",
                Authority = "https://accounts.google.com",
                ClientId = "...",
                Scope = "openid profile email",
                Properties = new Dictionary<string, string>
                {
                    { "foo", "bar" }
                }
            }
```

This PR removes the setter to prevent this problem. The updated code from above would now look like this:

```
new OidcProvider
            {
                Scheme = "google",
                DisplayName = "Google",
                Authority = "https://accounts.google.com",
                ClientId = "...",
                Scope = "openid profile email",
                Properties = 
                {
                    { "foo", "bar" }
                }
            }
```
