### PR TITLE
Remove setter from Properties on IdentityProvider to ensure that the …

### DIFF
--- a/src/EntityFramework.Storage/Mappers/IdentityProviderMapperProfile.cs
+++ b/src/EntityFramework.Storage/Mappers/IdentityProviderMapperProfile.cs
@@ -29,17 +29,17 @@ public class IdentityProviderMapperProfile : Profile
 }
 
 class PropertiesConverter :
-    IValueConverter<Dictionary<string, string>, string>,
-    IValueConverter<string, Dictionary<string, string>>
+    IValueConverter<IReadOnlyDictionary<string, string>, string>,
+    IValueConverter<string, IReadOnlyDictionary<string, string>>
 {
     public static PropertiesConverter Converter = new PropertiesConverter();
 
-    public string Convert(Dictionary<string, string> sourceMember, ResolutionContext context)
+    public string Convert(IReadOnlyDictionary<string, string> sourceMember, ResolutionContext context)
     {
         return JsonSerializer.Serialize(sourceMember);
     }
 
-    public Dictionary<string, string> Convert(string sourceMember, ResolutionContext context)
+    public IReadOnlyDictionary<string, string> Convert(string sourceMember, ResolutionContext context)
     {
         if (String.IsNullOrWhiteSpace(sourceMember))
         {

--- a/src/Storage/Models/OidcProvider.cs
+++ b/src/Storage/Models/OidcProvider.cs
@@ -18,11 +18,25 @@ public class OidcProvider : IdentityProvider
     public OidcProvider() : base("oidc")
     {
     }
-        
+
+    /// <summary>
+    /// Ctor
+    /// </summary>
+    public OidcProvider(Action<IdentityProviderOptions> options) : base("oidc", options)
+    {
+    }
+
     /// <summary>
     /// Ctor
     /// </summary>
     public OidcProvider(IdentityProvider other) : base("oidc", other)
+    {
+    }
+
+    /// <summary>
+    /// Ctor
+    /// </summary>
+    public OidcProvider(IdentityProvider other, Action<IdentityProviderOptions> options) : base("oidc", other, options)
     {
     }
 


### PR DESCRIPTION
Remove setter from Properties on IdentityProvider to ensure that the  internally set properties are not overwritten

Based on **brockallen** pull request https://github.com/DuendeSoftware/IdentityServer/pull/858 

**What issue does this PR address?**
The usage of the Properties property on the IdentityProvider class is not intuitive to the outside consumer in that you can easily remove all the internally set properties that are done through the standard property setters.  For example, in the follow code, all of the internally set property values (e.g. Authority, ClientId, etc...) are deleted when Properties is set to a new Dictionary object.

```C#
var provider = new OidcProvider
{
    Scheme = "abc",
    DisplayName = "abc",
    Authority = authority,
    ResponseType = OpenIdConnectResponseType.Code,
    ClientId = clientId,
    ClientSecret = clientSecret,
    GetClaimsFromUserInfoEndpoint = true,
    Properties = new Dictionary<string, string>
    {
        { nameof(OpenIdConnectOptions.SaveTokens), "true" },
        { "SomeOtherProperty", "value2" }
    },
    Scope = string.Join(" ", new[] {
                OpenIdConnectScope.OpenId,
                OpenIdConnectScope.OpenIdProfile,
                OpenIdConnectScope.Email
            }),
    UsePkce = true
}
```
Given the power and complexity of the Dynamic Providers feature, this area should be "locked down" as much as possible to ensure that consumers use it correctly.

I propose exposing Properties only as an IReadOnlyDictionary, and only allow adding additional values (that don't get "in the way" of the internal ones) via an setup Action<> as shown:

```C#
public IdentityProvider(string type, Action<IdentityProviderOptions> setupAction) : this(type)
    .
    .
    .
    
context.IdentityProviders.Add(new OidcProvider(options =>
{
    options.AdditionalProperties = new Dictionary<string, string>
    { 
        { "foo", "bar" }
    };
})
{
    Scheme = "google",
    DisplayName = "Google",
    Authority = "https://accounts.google.com",
    ClientId = "998042782978-gkes3j509qj26omrh6orvrnu0klpflh6.apps.googleusercontent.com",
    Scope = "openid profile email",
}.ToEntity());
```
Exposing Properties as an IReadOnlyDictionary seems the best "defensive" option in that it doesn't allow for Clear(), Remove(), etc... after the object is constructed.  

To allow for AutoMapper to map to a private property, the property was given an explicit property setter as shown below.  AutoMapper will pass into this setter an IReadOnlyDictionary, so we need to enumerate all the KeyValuePairs to set them in the _properties field.

```C#
private Dictionary<string, string> _properties = new Dictionary<string, string>();
public IReadOnlyDictionary<string, string> Properties 
{
    get => _properties;
    // private setter for AutoMapper
    private set
    {
        foreach (var kvp in value)
            this[kvp.Key] = kvp.Value;
    }
}
```

And, it seems reasonable that the IdentityProviderOptions class will grow over time so this easily allows for more configuration in the future.