### PR TITLE
remove client store use from login page

### DIFF
--- a/hosts/AspNetIdentity/Pages/Account/Login/Index.cshtml.cs
+++ b/hosts/AspNetIdentity/Pages/Account/Login/Index.cshtml.cs
@@ -21,7 +21,6 @@ public class Index : PageModel
     private readonly UserManager<ApplicationUser> _userManager;
     private readonly SignInManager<ApplicationUser> _signInManager;
     private readonly IIdentityServerInteractionService _interaction;
-    private readonly IClientStore _clientStore;
     private readonly IEventService _events;
     private readonly IAuthenticationSchemeProvider _schemeProvider;
     private readonly IIdentityProviderStore _identityProviderStore;
@@ -33,7 +32,6 @@ public class Index : PageModel
         
     public Index(
         IIdentityServerInteractionService interaction,
-        IClientStore clientStore,
         IAuthenticationSchemeProvider schemeProvider,
         IIdentityProviderStore identityProviderStore,
         IEventService events,
@@ -43,7 +41,6 @@ public class Index : PageModel
         _userManager = userManager;
         _signInManager = signInManager;
         _interaction = interaction;
-        _clientStore = clientStore;
         _schemeProvider = schemeProvider;
         _identityProviderStore = identityProviderStore;
         _events = events;
@@ -189,17 +186,13 @@ public class Index : PageModel
 
 
         var allowLocal = true;
-        if (context?.Client.ClientId != null)
+        var client = context?.Client;
+        if (client != null)
         {
-            var client = await _clientStore.FindEnabledClientByIdAsync(context.Client.ClientId);
-            if (client != null)
+            allowLocal = client.EnableLocalLogin;
+            if (client.IdentityProviderRestrictions != null && client.IdentityProviderRestrictions.Any())
             {
-                allowLocal = client.EnableLocalLogin;
-
-                if (client.IdentityProviderRestrictions != null && client.IdentityProviderRestrictions.Any())
-                {
-                    providers = providers.Where(provider => client.IdentityProviderRestrictions.Contains(provider.AuthenticationScheme)).ToList();
-                }
+                providers = providers.Where(provider => client.IdentityProviderRestrictions.Contains(provider.AuthenticationScheme)).ToList();
             }
         }
 

--- a/hosts/main/Pages/Account/Login/Index.cshtml.cs
+++ b/hosts/main/Pages/Account/Login/Index.cshtml.cs
@@ -21,7 +21,6 @@ public class Index : PageModel
 {
     private readonly TestUserStore _users;
     private readonly IIdentityServerInteractionService _interaction;
-    private readonly IClientStore _clientStore;
     private readonly IEventService _events;
     private readonly IAuthenticationSchemeProvider _schemeProvider;
     private readonly IIdentityProviderStore _identityProviderStore;
@@ -33,7 +32,6 @@ public class Index : PageModel
         
     public Index(
         IIdentityServerInteractionService interaction,
-        IClientStore clientStore,
         IAuthenticationSchemeProvider schemeProvider,
         IIdentityProviderStore identityProviderStore,
         IEventService events,
@@ -43,12 +41,11 @@ public class Index : PageModel
         _users = users ?? throw new Exception("Please call 'AddTestUsers(TestUsers.Users)' on the IIdentityServerBuilder in Startup or remove the TestUserStore from the AccountController.");
             
         _interaction = interaction;
-        _clientStore = clientStore;
         _schemeProvider = schemeProvider;
         _identityProviderStore = identityProviderStore;
         _events = events;
     }
-        
+
     public async Task<IActionResult> OnGet(string returnUrl)
     {
         await BuildModelAsync(returnUrl);
@@ -209,17 +206,13 @@ public class Index : PageModel
 
 
         var allowLocal = true;
-        if (context?.Client.ClientId != null)
+        var client = context?.Client;
+        if (client != null)
         {
-            var client = await _clientStore.FindEnabledClientByIdAsync(context.Client.ClientId);
-            if (client != null)
+            allowLocal = client.EnableLocalLogin;
+            if (client.IdentityProviderRestrictions != null && client.IdentityProviderRestrictions.Any())
             {
-                allowLocal = client.EnableLocalLogin;
-
-                if (client.IdentityProviderRestrictions != null && client.IdentityProviderRestrictions.Any())
-                {
-                    providers = providers.Where(provider => client.IdentityProviderRestrictions.Contains(provider.AuthenticationScheme)).ToList();
-                }
+                providers = providers.Where(provider => client.IdentityProviderRestrictions.Contains(provider.AuthenticationScheme)).ToList();
             }
         }
 


### PR DESCRIPTION
It was unnecessary to load the *Client* on the login page, as it's already available via the *AuthorizationContext*

Fixes: #715