### PR TITLE
Fix DI registration to actually allow EF DbContext pooling

### DIFF
--- a/src/EntityFramework.Storage/Configuration/ServiceCollectionExtensions.cs
+++ b/src/EntityFramework.Storage/Configuration/ServiceCollectionExtensions.cs
@@ -85,7 +85,7 @@ public static class IdentityServerEntityFrameworkBuilderExtensions
             }
         }
 
-        services.AddScoped<IConfigurationDbContext, TContext>();
+        services.AddScoped<IConfigurationDbContext>(svcs => svcs.GetRequiredService<TContext>());
 
         return services;
     }
@@ -161,7 +161,7 @@ public static class IdentityServerEntityFrameworkBuilderExtensions
             }
         }
 
-        services.AddScoped<IPersistedGrantDbContext, TContext>();
+        services.AddScoped<IPersistedGrantDbContext>(svcs => svcs.GetRequiredService<TContext>());
         services.AddTransient<TokenCleanupService>();
 
         return services;

--- a/src/EntityFramework.Storage/DbContexts/ConfigurationDbContext.cs
+++ b/src/EntityFramework.Storage/DbContexts/ConfigurationDbContext.cs
@@ -30,17 +30,6 @@ public class ConfigurationDbContext : ConfigurationDbContext<ConfigurationDbCont
         : base(options)
     {
     }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="ConfigurationDbContext"/> class.
-    /// </summary>
-    /// <param name="options">The options.</param>
-    /// <param name="storeOptions"></param>
-    /// <exception cref="ArgumentNullException">storeOptions</exception>
-    public ConfigurationDbContext(DbContextOptions<ConfigurationDbContext> options, ConfigurationStoreOptions storeOptions)
-        : base(options, storeOptions)
-    {
-    }
 }
 
 /// <summary>
@@ -64,18 +53,6 @@ public class ConfigurationDbContext<TContext> : DbContext, IConfigurationDbConte
     public ConfigurationDbContext(DbContextOptions<TContext> options)
         : base(options)
     {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="ConfigurationDbContext"/> class.
-    /// </summary>
-    /// <param name="options">The options.</param>
-    /// <param name="storeOptions"></param>
-    /// <exception cref="ArgumentNullException">storeOptions</exception>
-    public ConfigurationDbContext(DbContextOptions<TContext> options, ConfigurationStoreOptions storeOptions)
-        : base(options)
-    {
-        StoreOptions = storeOptions;
     }
 
     /// <summary>

--- a/src/EntityFramework.Storage/DbContexts/ConfigurationDbContext.cs
+++ b/src/EntityFramework.Storage/DbContexts/ConfigurationDbContext.cs
@@ -43,7 +43,7 @@ public class ConfigurationDbContext<TContext> : DbContext, IConfigurationDbConte
     /// <summary>
     /// The store options.
     /// </summary>
-    public ConfigurationStoreOptions StoreOptions { get; private set; }
+    public ConfigurationStoreOptions StoreOptions { get; set; }
     
     /// <summary>
     /// Initializes a new instance of the <see cref="ConfigurationDbContext"/> class.

--- a/src/EntityFramework.Storage/DbContexts/PersistedGrantDbContext.cs
+++ b/src/EntityFramework.Storage/DbContexts/PersistedGrantDbContext.cs
@@ -28,17 +28,6 @@ public class PersistedGrantDbContext : PersistedGrantDbContext<PersistedGrantDbC
         : base(options)
     {
     }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="PersistedGrantDbContext"/> class.
-    /// </summary>
-    /// <param name="options">The options.</param>
-    /// <param name="storeOptions"></param>
-    /// <exception cref="ArgumentNullException">storeOptions</exception>
-    public PersistedGrantDbContext(DbContextOptions<PersistedGrantDbContext> options, OperationalStoreOptions storeOptions)
-        : base(options, storeOptions)
-    {
-    }
 }
 
 /// <summary>
@@ -62,18 +51,6 @@ public class PersistedGrantDbContext<TContext> : DbContext, IPersistedGrantDbCon
     public PersistedGrantDbContext(DbContextOptions options)
         : base(options)
     {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="PersistedGrantDbContext"/> class.
-    /// </summary>
-    /// <param name="options">The options.</param>
-    /// <param name="storeOptions"></param>
-    /// <exception cref="ArgumentNullException">storeOptions</exception>
-    public PersistedGrantDbContext(DbContextOptions options, OperationalStoreOptions storeOptions)
-        : base(options)
-    {
-        StoreOptions = storeOptions;
     }
 
     /// <inheritdoc/>

--- a/src/EntityFramework.Storage/DbContexts/PersistedGrantDbContext.cs
+++ b/src/EntityFramework.Storage/DbContexts/PersistedGrantDbContext.cs
@@ -41,7 +41,7 @@ public class PersistedGrantDbContext<TContext> : DbContext, IPersistedGrantDbCon
     /// <summary>
     /// The options for this store.
     /// </summary>
-    protected OperationalStoreOptions StoreOptions { get; private set; }
+    protected OperationalStoreOptions StoreOptions { get; set; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PersistedGrantDbContext"/> class.


### PR DESCRIPTION
Given that we have an interface abstraction on our EF DbContexts, it doesn't seem the normal creation was taking place in DI for the `ConfigurationDbContext` or `PersistedGrantDbContext` classes to allow EF's pooling. This PR fixes that, but has the side effect that we can't provide convenience ctors to accept the `OperationalStoreOptions` or `ConfigurationStoreOptions`, so those were also removed.