### PR TITLE
add more defensive check for server side session store in DI

### DIFF
--- a/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/SessionManagement.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/SessionManagement.cs
@@ -75,7 +75,14 @@ public static class SessionManagementServiceCollectionExtensions
     public static IIdentityServerBuilder AddServerSideSessionStore<T>(this IIdentityServerBuilder builder)
         where T : class, IServerSideSessionStore
     {
-        builder.Services.AddTransient<IServerSideSessionStore, T>();
+        builder.Services.AddTransient<IServerSideSessionStore>(svcs =>
+        {
+            if (svcs.GetService<IServerSideSessionsMarker>() == null) return null;
+            return svcs.GetRequiredService<T>();
+        });
+
+        builder.Services.AddTransient<T>();
+
         return builder;
     }
 }


### PR DESCRIPTION
When using our EF package, the [optional by design] server side session store is always added to DI, even though `AddServerSideSessions` is not called. As long as none of the server-side session coordination features are enabled, then this has no effect. But it's possible that this is added, server-side sessions are not being used, but one of the session coordination features is accidentally enabled, then it could cause unintended side effects for the processing of the client's request.

This PR adds a more defensive check to not allow any of the server side session store logic to be used if `AddServerSideSessions` is not called.