### PR TITLE
Add support for ClaimValueTypes.Double

### DIFF
--- a/src/IdentityServer/Extensions/TokenExtensions.cs
+++ b/src/IdentityServer/Extensions/TokenExtensions.cs
@@ -147,6 +147,11 @@ public static class TokenExtensions
         {
             return long.Parse(claim.Value);
         }
+        
+        if (claim.ValueType == ClaimValueTypes.Double)
+        {
+            return double.Parse(claim.Value);
+        }
 
         if (claim.ValueType == IdentityServerConstants.ClaimValueTypes.Json)
         {


### PR DESCRIPTION
uses `double.Parse()` for `ClaimValueTypes.Double`