### PR TITLE
Use private logger helper in LicenseValidator

### DIFF
--- a/src/IdentityServer/Validation/Default/LicenseValidator.cs
+++ b/src/IdentityServer/Validation/Default/LicenseValidator.cs
@@ -46,13 +46,13 @@ internal class LicenseValidator
         if (_license?.RedistributionFeature == true && !isDevelopment)
         {
             // for redistribution/prod scenarios, we want most of these to be at trace level
-            _errorLog = _informationLog = _debugLog = _logger.LogTrace;
+            _errorLog = _informationLog = _debugLog = LogToTrace;
         }
         else
         {
-            _errorLog = _logger.LogError;
-            _informationLog = _logger.LogInformation;
-            _debugLog = _logger.LogDebug;
+            _errorLog = LogToError;
+            _informationLog = LogToInformation;
+            _debugLog = LogToDebug;
         }
     }
 
@@ -246,5 +246,37 @@ internal class LicenseValidator
         }
 
         return null;
+    }
+    
+    private static void LogToTrace(string message, params object[] args)
+    {
+        if (_logger.IsEnabled(LogLevel.Trace))
+        {
+            LoggerExtensions.LogTrace(_logger, message, args);
+        }
+    }
+    
+    private static void LogToDebug(string message, params object[] args)
+    {
+        if (_logger.IsEnabled(LogLevel.Debug))
+        {
+            LoggerExtensions.LogDebug(_logger, message, args);
+        }
+    }
+    
+    private static void LogToInformation(string message, params object[] args)
+    {
+        if (_logger.IsEnabled(LogLevel.Information))
+        {
+            LoggerExtensions.LogInformation(_logger, message, args);
+        }
+    }
+    
+    private static void LogToError(string message, params object[] args)
+    {
+        if (_logger.IsEnabled(LogLevel.Error))
+        {
+            LoggerExtensions.LogError(_logger, message, args);
+        }
     }
 }


### PR DESCRIPTION
Fixes an issue with LicenseValidator where an object array is treated like a single value in our dev logger extensions.