### PR TITLE
Introduce option to emit/suppress iss parameter

### DIFF
--- a/src/IdentityServer/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
@@ -42,6 +42,11 @@ public class IdentityServerOptions
     /// Specifies whether scopes in JWTs are emitted as array or string
     /// </summary>
     public bool EmitScopesAsSpaceDelimitedStringInJwt { get; set; } = false;
+    
+    /// <summary>
+    /// Specifies whether authorize responses contain the iss parameter (https://www.rfc-editor.org/rfc/rfc9207.html)
+    /// </summary>
+    public bool EmitIssuerIdentificationResponseParameter { get; set; } = true;
         
     /// <summary>
     /// Specifies whether the s_hash claim gets emitted in identity tokens. Defaults to false.

--- a/src/IdentityServer/Endpoints/Results/AuthorizeResult.cs
+++ b/src/IdentityServer/Endpoints/Results/AuthorizeResult.cs
@@ -144,7 +144,7 @@ internal class AuthorizeResult : IEndpointResult
     private string BuildRedirectUri()
     {
         var uri = Response.RedirectUri;
-        var query = Response.ToNameValueCollection().ToQueryString();
+        var query = Response.ToNameValueCollection(_options).ToQueryString();
 
         if (Response.Request.ResponseMode == OidcConstants.ResponseModes.Query)
         {
@@ -173,7 +173,7 @@ internal class AuthorizeResult : IEndpointResult
         var url = Response.Request.RedirectUri;
         url = HtmlEncoder.Default.Encode(url);
         html = html.Replace("{uri}", url);
-        html = html.Replace("{body}", Response.ToNameValueCollection().ToFormPost());
+        html = html.Replace("{body}", Response.ToNameValueCollection(_options).ToFormPost());
 
         return html;
     }

--- a/src/IdentityServer/Extensions/AuthorizeResponseExtensions.cs
+++ b/src/IdentityServer/Extensions/AuthorizeResponseExtensions.cs
@@ -4,13 +4,14 @@
 
 using Duende.IdentityServer.Extensions;
 using System.Collections.Specialized;
+using Duende.IdentityServer.Configuration;
 using Duende.IdentityServer.ResponseHandling;
 
 namespace Duende.IdentityServer.Models;
 
 internal static class AuthorizeResponseExtensions
 {
-    public static NameValueCollection ToNameValueCollection(this AuthorizeResponse response)
+    public static NameValueCollection ToNameValueCollection(this AuthorizeResponse response, IdentityServerOptions options)
     {
         var collection = new NameValueCollection();
 
@@ -62,7 +63,10 @@ internal static class AuthorizeResponseExtensions
             
         if (response.Issuer.IsPresent())
         {
-            collection.Add("iss", response.Issuer);
+            if (options.EmitIssuerIdentificationResponseParameter)
+            {
+                collection.Add("iss", response.Issuer);    
+            }
         }
 
         return collection;


### PR DESCRIPTION
Some client libraries cannot process the iss response parameter.

This option allows suppressing the parameter.