### PR TITLE
add Id to License parsing

### DIFF
--- a/src/IdentityServer/Validation/Default/License.cs
+++ b/src/IdentityServer/Validation/Default/License.cs
@@ -17,6 +17,11 @@ internal class License
 
     public License(ClaimsPrincipal claims)
     {
+        if (Int32.TryParse(claims.FindFirst("id")?.Value, out var id))
+        {
+            Id = id;
+        }
+
         CompanyName = claims.FindFirst("company_name")?.Value;
         ContactInfo = claims.FindFirst("contact_info")?.Value;
 
@@ -175,6 +180,8 @@ internal class License
             }
         }
     }
+
+    public int Id { get; set; }
 
     public string CompanyName { get; set; }
     public string ContactInfo { get; set; }


### PR DESCRIPTION
This PR will now include the ID we emit in the license into the logs. We didn't always add the ID, so it might not be present.