### PR TITLE
make OperationalStoreOptions public on PersistedGrantDbContext

### DIFF
--- a/src/EntityFramework.Storage/DbContexts/PersistedGrantDbContext.cs
+++ b/src/EntityFramework.Storage/DbContexts/PersistedGrantDbContext.cs
@@ -41,7 +41,7 @@ public class PersistedGrantDbContext<TContext> : DbContext, IPersistedGrantDbCon
     /// <summary>
     /// The options for this store.
     /// </summary>
-    protected OperationalStoreOptions StoreOptions { get; set; }
+    public OperationalStoreOptions StoreOptions { get; set; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PersistedGrantDbContext"/> class.


### PR DESCRIPTION
This was protected, which was an oversight. It should be public to match the options on the ConfigurationDbContext.

Fixes: https://github.com/DuendeSoftware/Support/issues/102