### PR TITLE
ensure we capture milliseconds of the current DateTime when creating events

### DIFF
--- a/src/IdentityServer/Services/Default/DefaultEventService.cs
+++ b/src/IdentityServer/Services/Default/DefaultEventService.cs
@@ -113,7 +113,7 @@ public class DefaultEventService : IEventService
     protected virtual async Task PrepareEventAsync(Event evt)
     {
         evt.ActivityId = Context.HttpContext.TraceIdentifier;
-        evt.TimeStamp = Clock.UtcNow.UtcDateTime;
+        evt.TimeStamp = DateTime.UtcNow;
         evt.ProcessId = Process.GetCurrentProcess().Id;
 
         if (Context.HttpContext.Connection.LocalIpAddress != null)


### PR DESCRIPTION
The Microsoft provided ISystemClock doesn't capture milliseconds. This PR will use DateTime directly to ensure events have milliseconds in the created/timestamp field.

Context: https://github.com/DuendeSoftware/Support/issues/101#issuecomment-1167779325

A larger effort to rework is considered for the next major release: https://github.com/DuendeSoftware/IdentityServer/issues/949
