### PR TITLE
handle bad form data on token (and other) endpoints

### DIFF
--- a/src/IdentityServer/Endpoints/BackchannelAuthenticationEndpoint.cs
+++ b/src/IdentityServer/Endpoints/BackchannelAuthenticationEndpoint.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Duende.IdentityServer.Events;
 using IdentityModel;
+using System.IO;
 
 namespace Duende.IdentityServer.Endpoints;
 
@@ -54,7 +55,15 @@ internal class BackchannelAuthenticationEndpoint : IEndpointHandler
             return Error(OidcConstants.BackchannelAuthenticationRequestErrors.InvalidRequest);
         }
 
-        return await ProcessAuthenticationRequestAsync(context);
+        try
+        {
+            return await ProcessAuthenticationRequestAsync(context);
+        }
+        catch (InvalidDataException ex)
+        {
+            _logger.LogWarning(ex, "Invalid HTTP request for backchannel authentication endpoint");
+            return Error(OidcConstants.BackchannelAuthenticationRequestErrors.InvalidRequest);
+        }
     }
 
     private async Task<IEndpointResult> ProcessAuthenticationRequestAsync(HttpContext context)

--- a/src/IdentityServer/Endpoints/DeviceAuthorizationEndpoint.cs
+++ b/src/IdentityServer/Endpoints/DeviceAuthorizationEndpoint.cs
@@ -14,6 +14,7 @@ using IdentityModel;
 using Duende.IdentityServer.Extensions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using System.IO;
 
 namespace Duende.IdentityServer.Endpoints;
 
@@ -65,7 +66,15 @@ internal class DeviceAuthorizationEndpoint : IEndpointHandler
             return Error(OidcConstants.TokenErrors.InvalidRequest);
         }
 
-        return await ProcessDeviceAuthorizationRequestAsync(context);
+        try
+        {
+            return await ProcessDeviceAuthorizationRequestAsync(context);
+        }
+        catch (InvalidDataException ex)
+        {
+            _logger.LogWarning(ex, "Invalid HTTP request for device endpoint");
+            return Error(OidcConstants.TokenErrors.InvalidRequest);
+        }
     }
 
     private async Task<IEndpointResult> ProcessDeviceAuthorizationRequestAsync(HttpContext context)

--- a/src/IdentityServer/Endpoints/EndSessionEndpoint.cs
+++ b/src/IdentityServer/Endpoints/EndSessionEndpoint.cs
@@ -11,6 +11,7 @@ using Duende.IdentityServer.Validation;
 using Duende.IdentityServer.Extensions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using System.IO;
 
 namespace Duende.IdentityServer.Endpoints;
 
@@ -35,7 +36,23 @@ internal class EndSessionEndpoint : IEndpointHandler
     public async Task<IEndpointResult> ProcessAsync(HttpContext context)
     {
         using var activity = Tracing.BasicActivitySource.StartActivity(Constants.EndpointNames.EndSession + "Endpoint");
-        
+
+        try
+        {
+            return await ProcessEndSessionAsync(context);
+        }
+        catch (InvalidDataException ex)
+        {
+            _logger.LogWarning(ex, "Invalid HTTP request for end session endpoint");
+            return new StatusCodeResult(HttpStatusCode.BadRequest);
+        }
+    }
+
+
+    async Task<IEndpointResult> ProcessEndSessionAsync(HttpContext context)
+    {
+        using var activity = Tracing.BasicActivitySource.StartActivity(Constants.EndpointNames.EndSession + "Endpoint");
+
         NameValueCollection parameters;
         if (HttpMethods.IsGet(context.Request.Method))
         {

--- a/src/IdentityServer/Endpoints/IntrospectionEndpoint.cs
+++ b/src/IdentityServer/Endpoints/IntrospectionEndpoint.cs
@@ -13,6 +13,7 @@ using Duende.IdentityServer.ResponseHandling;
 using Duende.IdentityServer.Services;
 using Duende.IdentityServer.Validation;
 using Duende.IdentityServer.Extensions;
+using System.IO;
 
 namespace Duende.IdentityServer.Endpoints;
 
@@ -74,7 +75,15 @@ internal class IntrospectionEndpoint : IEndpointHandler
             return new StatusCodeResult(HttpStatusCode.UnsupportedMediaType);
         }
 
-        return await ProcessIntrospectionRequestAsync(context);
+        try
+        {
+            return await ProcessIntrospectionRequestAsync(context);
+        }
+        catch (InvalidDataException ex)
+        {
+            _logger.LogWarning(ex, "Invalid HTTP request for introspection endpoint");
+            return new StatusCodeResult(HttpStatusCode.BadRequest);
+        }
     }
 
     private async Task<IEndpointResult> ProcessIntrospectionRequestAsync(HttpContext context)

--- a/src/IdentityServer/Endpoints/TokenEndpoint.cs
+++ b/src/IdentityServer/Endpoints/TokenEndpoint.cs
@@ -14,6 +14,8 @@ using Duende.IdentityServer.Hosting;
 using Duende.IdentityServer.ResponseHandling;
 using Duende.IdentityServer.Services;
 using Duende.IdentityServer.Validation;
+using System;
+using System.IO;
 
 namespace Duende.IdentityServer.Endpoints;
 
@@ -69,7 +71,15 @@ internal class TokenEndpoint : IEndpointHandler
             return Error(OidcConstants.TokenErrors.InvalidRequest);
         }
 
-        return await ProcessTokenRequestAsync(context);
+        try
+        {
+            return await ProcessTokenRequestAsync(context);
+        }
+        catch(InvalidDataException ex)
+        {
+            _logger.LogWarning(ex, "Invalid HTTP request for token endpoint");
+            return Error(OidcConstants.TokenErrors.InvalidRequest);
+        }
     }
 
     private async Task<IEndpointResult> ProcessTokenRequestAsync(HttpContext context)

--- a/src/IdentityServer/Endpoints/TokenRevocationEndpoint.cs
+++ b/src/IdentityServer/Endpoints/TokenRevocationEndpoint.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 
@@ -14,6 +14,7 @@ using Duende.IdentityServer.Services;
 using Duende.IdentityServer.Validation;
 using Microsoft.AspNetCore.Http;
 using Duende.IdentityServer.Extensions;
+using System.IO;
 
 namespace Duende.IdentityServer.Endpoints;
 
@@ -74,9 +75,15 @@ internal class TokenRevocationEndpoint : IEndpointHandler
             return new StatusCodeResult(HttpStatusCode.UnsupportedMediaType);
         }
 
-        var response = await ProcessRevocationRequestAsync(context);
-
-        return response;
+        try
+        {
+            return await ProcessRevocationRequestAsync(context);
+        }
+        catch (InvalidDataException ex)
+        {
+            _logger.LogWarning(ex, "Invalid HTTP request for revocation endpoint");
+            return new StatusCodeResult(HttpStatusCode.BadRequest);
+        }
     }
 
     private async Task<IEndpointResult> ProcessRevocationRequestAsync(HttpContext context)


### PR DESCRIPTION
When an invalid form-url-encoded payload is submitted, IdentityServer throws and returns a 500 status code. It's more appropriate to return a 400 status code.

Fixes: https://github.com/DuendeSoftware/Support/issues/110