### PR TITLE
Allow for naming tables by convention.

### DIFF
--- a/src/EntityFramework.Storage/Extensions/ModelBuilderExtensions.cs
+++ b/src/EntityFramework.Storage/Extensions/ModelBuilderExtensions.cs
@@ -37,7 +37,6 @@ public static class ModelBuilderExtensions
         modelBuilder.Entity<Client>(client =>
         {
             client.ToTable(storeOptions.Client);
-
             client.HasKey(x => x.Id);
 
             client.Property(x => x.ClientId).HasMaxLength(200).IsRequired();

--- a/src/EntityFramework.Storage/Extensions/ModelBuilderExtensions.cs
+++ b/src/EntityFramework.Storage/Extensions/ModelBuilderExtensions.cs
@@ -17,7 +17,12 @@ public static class ModelBuilderExtensions
     private static EntityTypeBuilder<TEntity> ToTable<TEntity>(this EntityTypeBuilder<TEntity> entityTypeBuilder, TableConfiguration configuration)
         where TEntity : class
     {
-        return string.IsNullOrWhiteSpace(configuration.Schema) ? entityTypeBuilder.ToTable(configuration.Name) : entityTypeBuilder.ToTable(configuration.Name, configuration.Schema);
+        if (!string.IsNullOrWhiteSpace(configuration.Name))
+        {
+            return string.IsNullOrWhiteSpace(configuration.Schema) ? entityTypeBuilder.ToTable(configuration.Name) : entityTypeBuilder.ToTable(configuration.Name, configuration.Schema);
+        }
+
+        return entityTypeBuilder;
     }
 
     /// <summary>
@@ -32,6 +37,7 @@ public static class ModelBuilderExtensions
         modelBuilder.Entity<Client>(client =>
         {
             client.ToTable(storeOptions.Client);
+
             client.HasKey(x => x.Id);
 
             client.Property(x => x.ClientId).HasMaxLength(200).IsRequired();


### PR DESCRIPTION
**What issue does this PR address?**

Fixes https://github.com/DuendeSoftware/Support/issues/113

This PR will allow for naming EFCore tables via convention.

With this PR, this can be achieved with adding the following code to your `AddConfigurationStore()` and `AddOperationalStore()` methods.

```csharp
// Remove the IdentityServer default table names so that naming by convention (snake case) will be used.
foreach (var tableConfigurationProperty in options.GetType().GetProperties().Where(p => p.PropertyType == typeof(TableConfiguration)))
{
        if (tableConfigurationProperty.GetValue(options) is TableConfiguration tableConfiguration)
        {
	        tableConfiguration.Name = string.Empty;
        }
}
```

With the above code in place, you can use https://github.com/efcore/EFCore.NamingConventions as expected.
