### PR TITLE
support invalid_request when client_id is missing in client secret validator

### DIFF
--- a/src/IdentityServer/Endpoints/BackchannelAuthenticationEndpoint.cs
+++ b/src/IdentityServer/Endpoints/BackchannelAuthenticationEndpoint.cs
@@ -72,10 +72,9 @@ internal class BackchannelAuthenticationEndpoint : IEndpointHandler
 
         // validate client
         var clientResult = await _clientValidator.ValidateAsync(context);
-
-        if (clientResult.Client == null)
+        if (clientResult.IsError)
         {
-            return Error(OidcConstants.BackchannelAuthenticationRequestErrors.InvalidClient);
+            return Error(clientResult.Error ?? OidcConstants.BackchannelAuthenticationRequestErrors.InvalidClient);
         }
 
         // validate request

--- a/src/IdentityServer/Endpoints/DeviceAuthorizationEndpoint.cs
+++ b/src/IdentityServer/Endpoints/DeviceAuthorizationEndpoint.cs
@@ -83,7 +83,7 @@ internal class DeviceAuthorizationEndpoint : IEndpointHandler
 
         // validate client
         var clientResult = await _clientValidator.ValidateAsync(context);
-        if (clientResult.Client == null) return Error(OidcConstants.TokenErrors.InvalidClient);
+        if (clientResult.IsError) return Error(clientResult.Error ?? OidcConstants.TokenErrors.InvalidClient);
 
         // validate request
         var form = (await context.Request.ReadFormAsync()).AsNameValueCollection();

--- a/src/IdentityServer/Endpoints/TokenEndpoint.cs
+++ b/src/IdentityServer/Endpoints/TokenEndpoint.cs
@@ -88,10 +88,9 @@ internal class TokenEndpoint : IEndpointHandler
 
         // validate client
         var clientResult = await _clientValidator.ValidateAsync(context);
-
-        if (clientResult.Client == null)
+        if (clientResult.IsError)
         {
-            return Error(OidcConstants.TokenErrors.InvalidClient);
+            return Error(clientResult.Error ?? OidcConstants.TokenErrors.InvalidClient);
         }
 
         // validate request

--- a/src/IdentityServer/Endpoints/TokenRevocationEndpoint.cs
+++ b/src/IdentityServer/Endpoints/TokenRevocationEndpoint.cs
@@ -92,10 +92,9 @@ internal class TokenRevocationEndpoint : IEndpointHandler
 
         // validate client
         var clientValidationResult = await _clientValidator.ValidateAsync(context);
-
         if (clientValidationResult.IsError)
         {
-            return new TokenRevocationErrorResult(OidcConstants.TokenErrors.InvalidClient);
+            return new TokenRevocationErrorResult(clientValidationResult.Error ?? OidcConstants.TokenErrors.InvalidClient);
         }
 
         _logger.LogTrace("Client validation successful");

--- a/src/IdentityServer/Validation/Default/ClientSecretValidator.cs
+++ b/src/IdentityServer/Validation/Default/ClientSecretValidator.cs
@@ -53,7 +53,8 @@ public class ClientSecretValidator : IClientSecretValidator
 
         var fail = new ClientSecretValidationResult
         {
-            IsError = true
+            IsError = true,
+            Error = IdentityModel.OidcConstants.TokenErrors.InvalidClient
         };
 
         var parsedSecret = await _parser.ParseAsync(context);
@@ -62,6 +63,8 @@ public class ClientSecretValidator : IClientSecretValidator
             await RaiseFailureEventAsync("unknown", "No client id found");
 
             _logger.LogError("No client identifier found");
+
+            fail.Error = IdentityModel.OidcConstants.TokenErrors.InvalidRequest;
             return fail;
         }
 

--- a/test/IdentityServer.IntegrationTests/Endpoints/DeviceAuthorization/DeviceAuthorizationTests.cs
+++ b/test/IdentityServer.IntegrationTests/Endpoints/DeviceAuthorization/DeviceAuthorizationTests.cs
@@ -75,7 +75,7 @@ public class DeviceAuthorizationTests
 
     [Fact]
     [Trait("Category", Category)]
-    public async Task empty_request_should_return_InvalidClient()
+    public async Task empty_request_should_return_InvalidRequest()
     {
         var response = await _mockPipeline.BackChannelClient.PostAsync(IdentityServerPipeline.DeviceAuthorization,
             new FormUrlEncodedContent(new Dictionary<string, string>()));
@@ -85,7 +85,7 @@ public class DeviceAuthorizationTests
         var resultDto = ParseJsonBody<ErrorResultDto>(await response.Content.ReadAsStreamAsync());
 
         resultDto.Should().NotBeNull();
-        resultDto.error.Should().Be(OidcConstants.TokenErrors.InvalidClient);
+        resultDto.error.Should().Be(OidcConstants.TokenErrors.InvalidRequest);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes: https://github.com/DuendeSoftware/Support/issues/44