### PR TITLE
Adjust redirect URI validation

### DIFF
--- a/src/IdentityServer/Validation/Default/AuthorizeRequestValidator.cs
+++ b/src/IdentityServer/Validation/Default/AuthorizeRequestValidator.cs
@@ -344,7 +344,7 @@ internal class AuthorizeRequestValidator : IAuthorizeRequestValidator
             return Invalid(request, description: "Invalid redirect_uri");
         }
 
-        if (!Uri.IsWellFormedUriString(redirectUri, UriKind.Absolute))
+        if (!Uri.TryCreate(redirectUri, UriKind.RelativeOrAbsolute, out var uri) || !uri.IsAbsoluteUri)
         {
             LogError("malformed redirect_uri", redirectUri, request);
             return Invalid(request, description: "Invalid redirect_uri");

--- a/src/IdentityServer/Validation/Default/AuthorizeRequestValidator.cs
+++ b/src/IdentityServer/Validation/Default/AuthorizeRequestValidator.cs
@@ -344,7 +344,7 @@ internal class AuthorizeRequestValidator : IAuthorizeRequestValidator
             return Invalid(request, description: "Invalid redirect_uri");
         }
 
-        if (!Uri.TryCreate(redirectUri, UriKind.RelativeOrAbsolute, out var uri) || !uri.IsAbsoluteUri)
+        if (!Uri.TryCreate(redirectUri, UriKind.Absolute, out var uri) || uri.IsFile)
         {
             LogError("malformed redirect_uri", redirectUri, request);
             return Invalid(request, description: "Invalid redirect_uri");

--- a/test/IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ProtocolValidation_Invalid.cs
+++ b/test/IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ProtocolValidation_Invalid.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 
@@ -160,11 +160,12 @@ public class Authorize_ProtocolValidation_Invalid
     [Theory]
     [InlineData("malformed")]
     [InlineData("/malformed")]
+    [InlineData("file://callback.html")]
     [Trait("Category", Category)]
     public async Task Malformed_RedirectUri(string redirectUri)
     {
         var parameters = new NameValueCollection();
-        parameters.Add(OidcConstants.AuthorizeRequest.ClientId, "client");
+        parameters.Add(OidcConstants.AuthorizeRequest.ClientId, "codeclient");
         parameters.Add(OidcConstants.AuthorizeRequest.Scope, "openid");
         parameters.Add(OidcConstants.AuthorizeRequest.RedirectUri, redirectUri);
         parameters.Add(OidcConstants.AuthorizeRequest.ResponseType, OidcConstants.ResponseTypes.Code);

--- a/test/IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ProtocolValidation_Valid.cs
+++ b/test/IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ProtocolValidation_Valid.cs
@@ -257,4 +257,20 @@ public class Authorize_ProtocolValidation_Valid
             result.ValidatedRequest.SuppressedPromptModes.Should().BeEquivalentTo(new[] { OidcConstants.PromptModes.Consent, OidcConstants.PromptModes.Login });
         }
     }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task Valid_RedirectUri_With_Square_Brackets_In_Query_String()
+    {
+        var parameters = new NameValueCollection();
+        parameters.Add(OidcConstants.AuthorizeRequest.ClientId, "codeclient");
+        parameters.Add(OidcConstants.AuthorizeRequest.Scope, "openid");
+        parameters.Add(OidcConstants.AuthorizeRequest.RedirectUri, "https://server/cb?x[action]=login");
+        parameters.Add(OidcConstants.AuthorizeRequest.ResponseType, OidcConstants.ResponseTypes.Code);
+
+        var validator = Factory.CreateAuthorizeRequestValidator();
+        var result = await validator.ValidateAsync(parameters);
+
+        result.IsError.Should().Be(false);
+    }
 }

--- a/test/IdentityServer.UnitTests/Validation/Setup/TestClients.cs
+++ b/test/IdentityServer.UnitTests/Validation/Setup/TestClients.cs
@@ -33,7 +33,11 @@ internal class TestClients
 
                 RedirectUris = new List<string>
                 {
-                    "https://server/cb"
+                    "https://server/cb",
+                    "https://server/cb?x[action]=login",
+                    "file://callback.html",
+                    "malformed",
+                    "/malformed"
                 },
 
                 AuthorizationCodeLifetime = 60


### PR DESCRIPTION
**What issue does this PR address?**
A redirect URI with brackets in the query string is not valid anymore.
See issue [148](https://github.com/DuendeSoftware/Support/issues/148)
