### PR TITLE
fix URI validation to allow query params with encoded values

### DIFF
--- a/src/IdentityServer/Extensions/ResourceExtensions.cs
+++ b/src/IdentityServer/Extensions/ResourceExtensions.cs
@@ -146,7 +146,7 @@ public static class ResourceExtensions
         {
             foreach (var item in list)
             {
-                if (!Uri.IsWellFormedUriString(item, UriKind.Absolute))
+                if (!item.IsUri())
                 {
                     logger.LogDebug("Resource indicator {resource} is not a valid URI.", item);
                     return false;

--- a/src/IdentityServer/Extensions/StringsExtensions.cs
+++ b/src/IdentityServer/Extensions/StringsExtensions.cs
@@ -183,6 +183,22 @@ internal static class StringExtensions
     }
 
     [DebuggerStepThrough]
+    public static bool IsUri(this string input)
+    {
+        if (!Uri.TryCreate(input, UriKind.Absolute, out var uri))
+        {
+            return false;
+        }
+
+        if (uri.IsFile && !input.StartsWith(Uri.UriSchemeFile + "://", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    [DebuggerStepThrough]
     public static string AddQueryString(this string url, string query)
     {
         if (!url.Contains("?"))

--- a/src/IdentityServer/Services/Default/OidcReturnUrlParser.cs
+++ b/src/IdentityServer/Services/Default/OidcReturnUrlParser.cs
@@ -70,14 +70,8 @@ internal class OidcReturnUrlParser : IReturnUrlParser
     {
         using var activity = Tracing.ValidationActivitySource.StartActivity("OidcReturnUrlParser.IsValidReturnUrl");
         
-        if (_options.UserInteraction.AllowOriginInReturnUrl && returnUrl != null)
+        if (_options.UserInteraction.AllowOriginInReturnUrl && returnUrl.IsUri())
         {
-            if (!Uri.IsWellFormedUriString(returnUrl, UriKind.RelativeOrAbsolute))
-            {
-                _logger.LogTrace("returnUrl is not valid");
-                return false;
-            }
-
             var host = _urls.Origin;
             if (returnUrl.StartsWith(host, StringComparison.OrdinalIgnoreCase) == true)
             {

--- a/src/IdentityServer/Validation/Default/AuthorizeRequestValidator.cs
+++ b/src/IdentityServer/Validation/Default/AuthorizeRequestValidator.cs
@@ -344,7 +344,7 @@ internal class AuthorizeRequestValidator : IAuthorizeRequestValidator
             return Invalid(request, description: "Invalid redirect_uri");
         }
 
-        if (!Uri.IsWellFormedUriString(redirectUri, UriKind.Absolute))
+        if (!redirectUri.IsUri())
         {
             LogError("malformed redirect_uri", redirectUri, request);
             return Invalid(request, description: "Invalid redirect_uri");

--- a/src/IdentityServer/Validation/Default/DefaultClientConfigurationValidator.cs
+++ b/src/IdentityServer/Validation/Default/DefaultClientConfigurationValidator.cs
@@ -7,6 +7,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Duende.IdentityServer.Configuration;
+using Duende.IdentityServer.Extensions;
 
 namespace Duende.IdentityServer.Validation;
 
@@ -153,10 +154,10 @@ public class DefaultClientConfigurationValidator : IClientConfigurationValidator
             {
                 var fail = true;
 
-                if (!string.IsNullOrWhiteSpace(origin) && Uri.IsWellFormedUriString(origin, UriKind.Absolute))
+                if (!string.IsNullOrWhiteSpace(origin) && origin.IsUri())
                 {
                     var uri = new Uri(origin);
-                        
+                    
                     if (uri.AbsolutePath == "/" && !origin.EndsWith("/"))
                     {
                         fail = false;

--- a/test/IdentityServer.UnitTests/Extensions/StringExtensionsTests.cs
+++ b/test/IdentityServer.UnitTests/Extensions/StringExtensionsTests.cs
@@ -166,6 +166,7 @@ public class StringExtensionsTests
     public void IsUri_should_allow_uris()
     {
         "https://path".IsUri().Should().BeTrue();
+        "https://path?foo=[x]".IsUri().Should().BeTrue();
         "file://path".IsUri().Should().BeTrue();
     }
 

--- a/test/IdentityServer.UnitTests/Extensions/StringExtensionsTests.cs
+++ b/test/IdentityServer.UnitTests/Extensions/StringExtensionsTests.cs
@@ -160,4 +160,25 @@ public class StringExtensionsTests
         scopes[0].Should().Be("scope1");
         scopes[1].Should().Be("scope2");
     }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public void IsUri_should_allow_uris()
+    {
+        "https://path".IsUri().Should().BeTrue();
+        "file://path".IsUri().Should().BeTrue();
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public void IsUri_should_block_paths()
+    {
+        // especially on linux
+        // https://github.com/DuendeSoftware/Support/issues/148
+        "/path".IsUri().Should().BeFalse();
+        "//".IsUri().Should().BeFalse();
+        "://".IsUri().Should().BeFalse();
+        " ://".IsUri().Should().BeFalse();
+        " file://path".IsUri().Should().BeFalse();
+    }
 }


### PR DESCRIPTION
Fixes: https://github.com/DuendeSoftware/Support/issues/148