### PR TITLE
when renewing server-side session, create new entry if current session not found

### DIFF
--- a/src/EntityFramework.Storage/Stores/ServerSideSessionStore.cs
+++ b/src/EntityFramework.Storage/Stores/ServerSideSessionStore.cs
@@ -80,7 +80,7 @@ public class ServerSideSessionStore : IServerSideSessionStore
             await Context.SaveChangesAsync(cancellationToken);
             Logger.LogDebug("Created new server-side session {serverSideSessionKey} in database", session.Key);
         }
-        catch (DbUpdateConcurrencyException ex)
+        catch (DbUpdateException ex)
         {
             Logger.LogWarning("Exception creating new server-side session in database: {error}", ex.Message);
         }
@@ -150,7 +150,7 @@ public class ServerSideSessionStore : IServerSideSessionStore
             await Context.SaveChangesAsync(cancellationToken);
             Logger.LogDebug("Updated server-side session {serverSideSessionKey} in database", session.Key);
         }
-        catch (DbUpdateConcurrencyException ex)
+        catch (DbUpdateException ex)
         {
             Logger.LogWarning("Exception updating existing server side session {serverSideSessionKey} in database: {error}", session.Key, ex.Message);
         }
@@ -180,7 +180,7 @@ public class ServerSideSessionStore : IServerSideSessionStore
             await Context.SaveChangesAsync(cancellationToken);
             Logger.LogDebug("Deleted server-side session {serverSideSessionKey} in database", key);
         }
-        catch (DbUpdateConcurrencyException ex)
+        catch (DbUpdateException ex)
         {
             Logger.LogWarning("Exception deleting server-side session {serverSideSessionKey} in database: {error}", key, ex.Message);
         }
@@ -239,7 +239,7 @@ public class ServerSideSessionStore : IServerSideSessionStore
             await Context.SaveChangesAsync(cancellationToken);
             Logger.LogDebug("Removed {serverSideSessionCount} server-side sessions from database for {@filter}", entities.Length, filter);
         }
-        catch (DbUpdateConcurrencyException ex)
+        catch (DbUpdateException ex)
         {
             Logger.LogInformation("Error removing {serverSideSessionCount} server-side sessions from database for {@filter}: {error}", entities.Length, filter, ex.Message);
         }


### PR DESCRIPTION
This PR adds logic to create a new server-side session entry if trying to renew an entry but the DB record has been removed. Done as per guidance from: https://github.com/dotnet/aspnetcore/issues/41516#issuecomment-1178076544

Fixes: https://github.com/DuendeSoftware/Support/issues/161