### PR TITLE
remove unnecessary call to AsNoTracking

### DIFF
--- a/src/EntityFramework.Storage/Stores/ServerSideSessionStore.cs
+++ b/src/EntityFramework.Storage/Stores/ServerSideSessionStore.cs
@@ -163,7 +163,7 @@ public class ServerSideSessionStore : IServerSideSessionStore
         
         cancellationToken = cancellationToken == CancellationToken.None ? CancellationTokenProvider.CancellationToken : cancellationToken;
         
-        var entity = (await Context.ServerSideSessions.AsNoTracking().Where(x => x.Key == key)
+        var entity = (await Context.ServerSideSessions.Where(x => x.Key == key)
                         .ToArrayAsync(cancellationToken))
                     .SingleOrDefault(x => x.Key == key);
 


### PR DESCRIPTION
The *ServerSideSessionStore.DeleteSessionAsync* API was using the EF helper *AsNoTracking* on the entity it needed to delete. This prevents the record from being deleted in the database. This is a bug, so the call has been removed.