### PR TITLE
Switch to latest CodeQL due to bug

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -49,6 +49,7 @@ jobs:
       uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
+        tools: latest
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -47,7 +47,7 @@ namespace build
             Target(Targets.CodeQL, () =>
             {
                 //Run("dotnet", $"clean {solutionCodeQL} -c Release -v m --nologo");
-                Run("dotnet", $"build --project {solutionCodeQL} -c Release --nologo");
+                Run("dotnet", $"build {solutionCodeQL} -c Release --nologo");
             });
 
             Target(Targets.SignBinary, DependsOn(Targets.Build, Targets.RestoreTools), () =>


### PR DESCRIPTION
CodeQL init has a bug - this switches to the latest tooling. Will revert to stable once the fix has landed.