### PR TITLE
filter consumed grants in the persisted grant service

### DIFF
--- a/src/IdentityServer/Services/Default/DefaultPersistedGrantService.cs
+++ b/src/IdentityServer/Services/Default/DefaultPersistedGrantService.cs
@@ -43,8 +43,10 @@ public class DefaultPersistedGrantService : IPersistedGrantService
         using var activity = Tracing.ServiceActivitySource.StartActivity("DefaultPersistedGrantService.GetAllGrants");
         
         if (String.IsNullOrWhiteSpace(subjectId)) throw new ArgumentNullException(nameof(subjectId));
-            
-        var grants = (await _store.GetAllAsync(new PersistedGrantFilter { SubjectId = subjectId })).ToArray();
+
+        var grants = (await _store.GetAllAsync(new PersistedGrantFilter { SubjectId = subjectId }))
+            .Where(x => x.ConsumedTime == null) // filter consumed grants
+            .ToArray();
 
         try
         {


### PR DESCRIPTION
When refresh tokens are renewed, the old entry in the grants store is marked with a consumed time. This value is used in the refresh token service to decide if an old refresh token is being re-used and if a grace period is allowed. The persisted grant service does not load refresh tokens thru the refresh token service, and instead directly consumes the persisted grant store. This means refresh tokens marked as consumed can still appear as if they are outstanding when a user uses the self-service "Grants" UI page. 

This PR filters the consumed grants from the persisted grant service and thus the self-service "Grants" UI page.

Fixes: #1061