### PR TITLE
Fix PersistedGrantFilter.Validate()

### DIFF
--- a/src/Storage/Extensions/PersistedGrantFilterExtensions.cs
+++ b/src/Storage/Extensions/PersistedGrantFilterExtensions.cs
@@ -18,12 +18,14 @@ public static class PersistedGrantFilterExtensions
     /// <param name="filter"></param>
     public static void Validate(this PersistedGrantFilter filter)
     {
-        if (filter == null) throw new ArgumentNullException(nameof(filter));
+        if (filter is null) throw new ArgumentNullException(nameof(filter));
 
-        if ((String.IsNullOrWhiteSpace(filter.ClientId) || filter.ClientIds == null)&&
-            String.IsNullOrWhiteSpace(filter.SessionId) &&
-            String.IsNullOrWhiteSpace(filter.SubjectId) &&
-            (String.IsNullOrWhiteSpace(filter.Type) || filter.Types == null))
+        var noFilterValueSet =
+            string.IsNullOrWhiteSpace(filter.ClientId) && filter.ClientIds.IsNullOrEmpty() &&
+            string.IsNullOrWhiteSpace(filter.SessionId) &&
+            string.IsNullOrWhiteSpace(filter.SubjectId) &&
+            string.IsNullOrWhiteSpace(filter.Type) && filter.Types.IsNullOrEmpty();
+        if (noFilterValueSet)
         {
             throw new ArgumentException("No filter values set.", nameof(filter));
         }

--- a/test/EntityFramework.Storage.IntegrationTests/Stores/PersistedGrantStoreTests.cs
+++ b/test/EntityFramework.Storage.IntegrationTests/Stores/PersistedGrantStoreTests.cs
@@ -183,6 +183,22 @@ public class PersistedGrantStoreTests : IntegrationTest<PersistedGrantStoreTests
                 SessionId = "s1",
                 Type = "t3"
             })).ToList().Count.Should().Be(0);
+            (await store.GetAllAsync(new PersistedGrantFilter
+            {
+                ClientIds = new List<string>() { "c1", "c2" }
+            })).ToList().Count.Should().Be(8);
+            (await store.GetAllAsync(new PersistedGrantFilter
+            {
+                Types = new List<string>() { "t3", "t2" }
+            })).ToList().Count.Should().Be(5);
+            (await store.GetAllAsync(new PersistedGrantFilter
+            {
+                ClientId = "c1"
+            })).ToList().Count.Should().Be(4);
+            (await store.GetAllAsync(new PersistedGrantFilter
+            {
+                Type = "t3"
+            })).ToList().Count.Should().Be(1);
         }
     }
 
@@ -419,6 +435,55 @@ public class PersistedGrantStoreTests : IntegrationTest<PersistedGrantStoreTests
                 Type = "t3"
             });
             context.PersistedGrants.Count().Should().Be(10);
+        }
+
+        PopulateDb();
+        using (var context = new PersistedGrantDbContext(options))
+        {
+            var store = new PersistedGrantStore(context, FakeLogger<PersistedGrantStore>.Create(), new NoneCancellationTokenProvider());
+
+            await store.RemoveAllAsync(new PersistedGrantFilter
+            {
+                ClientIds = new List<string>() { "c1", "c2" }
+            });
+            context.PersistedGrants.Count().Should().Be(2);
+        }
+
+        PopulateDb();
+        using (var context = new PersistedGrantDbContext(options))
+        {
+            var store = new PersistedGrantStore(context, FakeLogger<PersistedGrantStore>.Create(), new NoneCancellationTokenProvider());
+
+            await store.RemoveAllAsync(new PersistedGrantFilter
+            {
+                Types = new List<string>() { "t3", "t2" }
+            });
+            context.PersistedGrants.Count().Should().Be(5);
+        }
+
+
+        PopulateDb();
+        using (var context = new PersistedGrantDbContext(options))
+        {
+            var store = new PersistedGrantStore(context, FakeLogger<PersistedGrantStore>.Create(), new NoneCancellationTokenProvider());
+
+            await store.RemoveAllAsync(new PersistedGrantFilter
+            {
+                ClientId = "c1"
+            });
+            context.PersistedGrants.Count().Should().Be(6);
+        }
+
+        PopulateDb();
+        using (var context = new PersistedGrantDbContext(options))
+        {
+            var store = new PersistedGrantStore(context, FakeLogger<PersistedGrantStore>.Create(), new NoneCancellationTokenProvider());
+
+            await store.RemoveAllAsync(new PersistedGrantFilter
+            {
+                Type = "t3"
+            });
+            context.PersistedGrants.Count().Should().Be(9);
         }
     }
 


### PR DESCRIPTION
**What issue does this PR address?**
The PersistedGrantFilter.Validate() method verifies that the filter is not null and contains at least one filter value, but the way it's coded it does not allow the following:
* Only set the ClientId
* Only set the ClientIds
* Only set the Type
* Only set the Types


I think IdentityServer does not call the grant store with filters that follow the previous cases, that's why the Validate() call is not throwing exceptions right now. But the grant store implementations do contain the necessary logic (for example, see [this line](https://github.com/DuendeSoftware/IdentityServer/blob/50e71c72eb3905acc9fda4e0fa86c2510db665ea/src/IdentityServer/Stores/InMemory/InMemoryPersistedGrantStore.cs#L90)) to work on these cases, that's why I think that what I'm reporting is a bug.

I've added some integration tests to verify that the stores work fine in these four cases.

**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
