### PR TITLE
Verify refresh token creation and lifetime in test

### DIFF
--- a/test/IdentityServer.UnitTests/Services/Default/DefaultRefreshTokenServiceTests.cs
+++ b/test/IdentityServer.UnitTests/Services/Default/DefaultRefreshTokenServiceTests.cs
@@ -287,6 +287,9 @@ public class DefaultRefreshTokenServiceTests
 
         oldToken.ConsumedTime.Should().Be(now);
         newToken.ConsumedTime.Should().BeNull();
+
+        newToken.CreationTime.Should().Be(oldToken.CreationTime);
+        newToken.Lifetime.Should().Be(oldToken.Lifetime);
     }
         
     [Fact]


### PR DESCRIPTION
Update the unit tests for refresh token to ensure that CreationTime and Lifetime properties do not change when renewed (TokenUsage.OneTimeOnly).
