### PR TITLE
Introduce filter to allow suppression of unhandled exception logs in IdentityServer middleware

### DIFF
--- a/src/IdentityServer/Configuration/DependencyInjection/Options/LoggingOptions.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/Options/LoggingOptions.cs
@@ -2,8 +2,11 @@
 // See LICENSE in the project root for license information.
 
 
+using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using IdentityModel;
+using Microsoft.AspNetCore.Http;
 
 namespace Duende.IdentityServer.Configuration;
 
@@ -48,4 +51,10 @@ public class LoggingOptions
         {
             OidcConstants.AuthorizeRequest.IdTokenHint
         };
+
+    /// <summary>
+    /// Called when the IdentityServer middleware detects an unhandled exception, and is used to determine if the exception is logged.
+    /// Returns true to emit the log, false to suppress.
+    /// </summary>
+    public Func<HttpContext, Exception, bool> UnhandledExceptionLoggingFilter = (context, exception) => !(context.RequestAborted.IsCancellationRequested && exception is TaskCanceledException);
 }

--- a/src/IdentityServer/Hosting/IdentityServerMiddleware.cs
+++ b/src/IdentityServer/Hosting/IdentityServerMiddleware.cs
@@ -109,13 +109,10 @@ public class IdentityServerMiddleware
                 return;
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (options.Logging.UnhandledExceptionLoggingFilter?.Invoke(context, ex) is not false)
         {
-            if (options.Logging.UnhandledExceptionLoggingFilter?.Invoke(context, ex) is not false)
-            {
-                await events.RaiseAsync(new UnhandledExceptionEvent(ex));
-                _logger.LogCritical(ex, "Unhandled exception: {exception}", ex.Message);
-            }
+            await events.RaiseAsync(new UnhandledExceptionEvent(ex));
+            _logger.LogCritical(ex, "Unhandled exception: {exception}", ex.Message);
 
             throw;
         }


### PR DESCRIPTION
Allows customers to decide if our catch block around any IdentityServer endpoints will emit a log entry when there is an unhandled exception. The default, and primary use case is to suppress logs when the HTTP connection is cancelled early (e.g. a user navigates away or cancelled the browser request) and EF internally is detecting this and throwing the TaskCancelledException.

Fixes: https://github.com/DuendeSoftware/IdentityServer/issues/1040