### PR TITLE
Set the base class AuthenticationSchemeOptions as the restriction

### DIFF
--- a/src/IdentityServer/Hosting/DynamicProviders/Configuration/ConfigureAuthenticationContext.cs
+++ b/src/IdentityServer/Hosting/DynamicProviders/Configuration/ConfigureAuthenticationContext.cs
@@ -14,7 +14,7 @@ namespace Duende.IdentityServer.Hosting.DynamicProviders;
 /// <typeparam name="TAuthenticationOptions"></typeparam>
 /// <typeparam name="TIdentityProvider"></typeparam>
 public class ConfigureAuthenticationContext<TAuthenticationOptions, TIdentityProvider>
-    where TAuthenticationOptions : RemoteAuthenticationOptions
+    where TAuthenticationOptions : AuthenticationSchemeOptions
     where TIdentityProvider : IdentityProvider
 {
     /// <summary>

--- a/src/IdentityServer/Hosting/DynamicProviders/Configuration/ConfigureAuthenticationOptions.cs
+++ b/src/IdentityServer/Hosting/DynamicProviders/Configuration/ConfigureAuthenticationOptions.cs
@@ -16,7 +16,7 @@ namespace Duende.IdentityServer.Hosting.DynamicProviders;
 /// <typeparam name="TAuthenticationOptions"></typeparam>
 /// <typeparam name="TIdentityProvider"></typeparam>
 public abstract class ConfigureAuthenticationOptions<TAuthenticationOptions, TIdentityProvider> : IConfigureNamedOptions<TAuthenticationOptions>
-    where TAuthenticationOptions : RemoteAuthenticationOptions
+    where TAuthenticationOptions : AuthenticationSchemeOptions
     where TIdentityProvider : IdentityProvider
 {
     private readonly IHttpContextAccessor _httpContextAccessor;


### PR DESCRIPTION
Set the base class AuthenticationSchemeOptions as the restriction instead of RemoteAuthenticationOptions for ConfigureAuthenticationOptions.

The code doesn't require any of the functionality of RemoteAuthenticationOptions and it is not a correct assumption that every remote or special scheme would derive from RemoteAuthenticationOptions. It is an opinionated base class that assumes remote authentication is done in specific ways. Using the base AuthenticationSchemeOptions gives more flexibility.