### PR TITLE
add exception to UnhandledExceptionEvent

### DIFF
--- a/src/IdentityServer/Events/UnhandledExceptionEvent.cs
+++ b/src/IdentityServer/Events/UnhandledExceptionEvent.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 
@@ -19,10 +19,11 @@ public class UnhandledExceptionEvent : Event
     public UnhandledExceptionEvent(Exception ex)
         : base(EventCategories.Error,
             "Unhandled Exception",
-            EventTypes.Error, 
+            EventTypes.Error,
             EventIds.UnhandledException,
             ex.Message)
     {
+        Exception = ex;
         Details = ex.ToString();
     }
 
@@ -33,4 +34,12 @@ public class UnhandledExceptionEvent : Event
     /// The details.
     /// </value>
     public string Details { get; set; }
+
+    /// <summary>
+    /// Gets or sets the exception.
+    /// </summary>
+    /// <value>
+    /// The exception.
+    /// </value>
+    public Exception Exception { get; set; }
 }


### PR DESCRIPTION
**What issue does this PR address?**

When implementing a custom `EventSink` currently there is no access to the exception that was thrown when the event is of the type `UnhandledExceptionEvent`. The only way to get any information about the exception is to look at the string representation of the exception stored in the `Details` property of `UnhandledExceptionEvent`.

Access to the `Exception` type might be important, especially if the sink forwards the events to a framework / tool that supports exceptions. This is for example the case in certain logging frameworks. At the moment the default sink logs all the events with `_logger.LogInformation("{@event}", evt);`. In case of the `UnhandledExceptionEvent` it would be preferable to log it by providing the exception as separate parameter with `_logger.LogInformation(evt.Exception, "{@event}", evt);` so that the logging framework has access to it. At the moment it isn't possible to achieve this with a custom sink. With the change this would become possible.
