### PR TITLE
Make in memory identity providers not OIDC specific

### DIFF
--- a/src/IdentityServer/Hosting/DynamicProviders/DynamicSchemes/IdentityServerBuilderDynamicSchemesExtensions.cs
+++ b/src/IdentityServer/Hosting/DynamicProviders/DynamicSchemes/IdentityServerBuilderDynamicSchemesExtensions.cs
@@ -1,0 +1,29 @@
+using Duende.IdentityServer.Hosting.DynamicProviders;
+using Duende.IdentityServer.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Extensions.DependencyInjection;
+/// <summary>
+/// Add extension methods for configuring generic dynamic providers.
+/// </summary>
+public static class IdentityServerBuilderDynamicSchemesExtensions
+{
+    /// <summary>
+    /// Adds the in memory identity provider store.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    /// <param name="providers"></param>
+    /// <returns></returns>
+    public static IIdentityServerBuilder AddInMemoryIdentityProviders(
+        this IIdentityServerBuilder builder, IEnumerable<IdentityProvider> providers)
+    {
+        builder.Services.AddSingleton(providers);
+        builder.AddIdentityProviderStore<InMemoryIdentityProviderStore>();
+
+        return builder;
+    }
+}

--- a/src/IdentityServer/Hosting/DynamicProviders/Oidc/IdentityServerBuilderOidcExtensions.cs
+++ b/src/IdentityServer/Hosting/DynamicProviders/Oidc/IdentityServerBuilderOidcExtensions.cs
@@ -7,6 +7,7 @@ using Duende.IdentityServer.Models;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.Extensions.DependencyInjection;
@@ -49,8 +50,6 @@ public static class IdentityServerBuilderOidcExtensions
     /// <returns></returns>
     public static IIdentityServerBuilder AddInMemoryOidcProviders(this IIdentityServerBuilder builder, IEnumerable<OidcProvider> providers)
     {
-        builder.Services.AddSingleton(providers);
-        builder.AddIdentityProviderStore<InMemoryOidcProviderStore>();
-        return builder;
+        return builder.AddInMemoryIdentityProviders(providers);
     }
 }

--- a/src/IdentityServer/Hosting/DynamicProviders/Store/InMemoryIdentityProviderStore.cs
+++ b/src/IdentityServer/Hosting/DynamicProviders/Store/InMemoryIdentityProviderStore.cs
@@ -9,11 +9,11 @@ using System.Threading.Tasks;
 
 namespace Duende.IdentityServer.Hosting.DynamicProviders;
 
-class InMemoryOidcProviderStore : IIdentityProviderStore
+class InMemoryIdentityProviderStore : IIdentityProviderStore
 {
-    private readonly IEnumerable<OidcProvider> _providers;
+    private readonly IEnumerable<IdentityProvider> _providers;
 
-    public InMemoryOidcProviderStore(IEnumerable<OidcProvider> providers)
+    public InMemoryIdentityProviderStore(IEnumerable<IdentityProvider> providers)
     {
         _providers = providers;
     }

--- a/test/IdentityServer.IntegrationTests/Hosting/DynamicProvidersTests.cs
+++ b/test/IdentityServer.IntegrationTests/Hosting/DynamicProvidersTests.cs
@@ -155,7 +155,7 @@ public class DynamicProvidersTests
                 .AddInMemoryIdentityResources(new IdentityResource[] { })
                 .AddInMemoryOidcProviders(_oidcProviders)
                 .AddInMemoryCaching()
-                .AddIdentityProviderStoreCache<InMemoryOidcProviderStore>()
+                .AddIdentityProviderStoreCache<InMemoryIdentityProviderStore>()
                 .AddDeveloperSigningCredential(persistKey: false);
 
             services.ConfigureAll<OpenIdConnectOptions>(options =>


### PR DESCRIPTION
There is really nothing OIDC specific with the InMemoryOidcProviderStore. By changing it to use the IdentityProviders base class, it can be reused for SAML2 providers as well.
