### PR TITLE
Refresh Token Consumption Rework

### DIFF
--- a/src/EntityFramework.Storage/Options/OperationalStoreOptions.cs
+++ b/src/EntityFramework.Storage/Options/OperationalStoreOptions.cs
@@ -87,6 +87,14 @@ public class OperationalStoreOptions
     public bool RemoveConsumedTokens { get; set; } = false;
 
     /// <summary>
+    /// Gets or sets the consumed token cleanup delay (in seconds). The default
+    /// is 0. This delay is the amount of time that must elapse before tokens
+    /// marked as consumed can be deleted. Note that only refresh tokens with
+    /// OneTimeOnly usage can be marked as consumed.
+    /// </summary>
+    public int ConsumedTokenCleanupDelay { get; set; } = 0;
+
+    /// <summary>
     /// Gets or sets the token cleanup interval (in seconds). The default is 3600 (1 hour).
     /// </summary>
     /// <value>

--- a/src/EntityFramework.Storage/TokenCleanup/TokenCleanupService.cs
+++ b/src/EntityFramework.Storage/TokenCleanup/TokenCleanupService.cs
@@ -126,10 +126,13 @@ public class TokenCleanupService
     {
         var found = Int32.MaxValue;
 
+        var delay = TimeSpan.FromSeconds(_options.ConsumedTokenCleanupDelay);
+        var consumedTimeThreshold = DateTime.UtcNow.Subtract(delay);
+
         while (found >= _options.TokenCleanupBatchSize)
         {
             var expiredGrants = await _persistedGrantDbContext.PersistedGrants
-                .Where(x => x.ConsumedTime < DateTime.UtcNow)
+                .Where(x => x.ConsumedTime < consumedTimeThreshold)
                 .OrderBy(x => x.ConsumedTime)
                 .Take(_options.TokenCleanupBatchSize)
                 .ToArrayAsync(cancellationToken);

--- a/src/Storage/Stores/Serialization/PersistentGrantSerializer.cs
+++ b/src/Storage/Stores/Serialization/PersistentGrantSerializer.cs
@@ -19,6 +19,13 @@ public class PersistentGrantOptions
     /// Data protect the persisted grants "data" column.
     /// </summary>
     public bool DataProtectData { get; set; } = true;
+
+    /// <summary>
+    /// Delete one time only refresh tokens when they are used to obtain a new
+    /// token. If false, one time only refresh tokens will instead be marked as
+    /// Consumed.
+    /// </summary>
+    public bool DeleteOneTimeOnlyRefreshTokensOnUse { get; set; } = true;
 }
 
 /// <summary>

--- a/test/IdentityServer.UnitTests/Validation/Setup/Factory.cs
+++ b/test/IdentityServer.UnitTests/Validation/Setup/Factory.cs
@@ -51,7 +51,7 @@ internal static class Factory
         {
             issuerNameService = new TestIssuerNameService(options.IssuerUri);
         }
-            
+
         if (resourceStore == null)
         {
             resourceStore = new InMemoryResourcesStore(TestScopes.GetIdentity(), TestScopes.GetApis(), TestScopes.GetScopes());
@@ -66,7 +66,7 @@ internal static class Factory
         {
             profile = new TestProfileService();
         }
-            
+
         if (deviceCodeValidator == null)
         {
             deviceCodeValidator = new TestDeviceCodeValidator();
@@ -113,7 +113,7 @@ internal static class Factory
                 refreshTokenStore,
                 profile);
         }
-            
+
         return new TokenRequestValidator(
             options,
             issuerNameService,
@@ -127,17 +127,26 @@ internal static class Factory
             resourceValidator,
             resourceStore,
             refreshTokenService,
-            new TestEventService(), 
-            new StubClock(), 
+            new TestEventService(),
+            new StubClock(),
             TestLogger.Create<TokenRequestValidator>());
     }
 
     private static IRefreshTokenService CreateRefreshTokenService(IRefreshTokenStore store, IProfileService profile)
     {
+        return CreateRefreshTokenService(store, profile, new PersistentGrantOptions());
+    }
+
+    private static IRefreshTokenService CreateRefreshTokenService(
+        IRefreshTokenStore store, 
+        IProfileService profile,
+        PersistentGrantOptions options)
+    {
         var service = new DefaultRefreshTokenService(
             store,
             profile,
             new StubClock(),
+            options,
             TestLogger.Create<DefaultRefreshTokenService>());
 
         return service;


### PR DESCRIPTION
This PR adds two new configuration options related to the handling of refresh tokens. The intent of both settings is to alleviate some of the database pressure associated with marking refresh tokens as consumed.

First, `DeleteOneTimeOnlyRefreshTokensOnUse` controls what happens to OneTimeUse tokens when they are used. They can now be either marked as consumed or deleted immediately. The idea here is that, if you aren't making use of the consumed tokens, you can safely delete them immediately. _The default is to immediately delete._

Second, `ConsumedTokenCleanupDelay` delays deletion of consumed tokens in the token cleanup job. The intent of the delay is to allow users to keep tokens for some period of time (perhaps a short delay to allow "lenient" one-time use refresh tokens that can be reused for a short interval, or perhaps a longer delay to allow for auditing, etc). _This interval defaults to 0._

We also should consider if we will change the defaults of `EnableTokenCleanup` and/or `RemoveConsumedTokens` - but perhaps changes to defaults belong in 7.0, rather than 6.3.
