### PR TITLE
Samples use duende access token management

### DIFF
--- a/clients/src/APIs/ResourceBasedApi/Program.cs
+++ b/clients/src/APIs/ResourceBasedApi/Program.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
 using Serilog;
 using Serilog.Events;
 using Serilog.Sinks.SystemConsole.Themes;
@@ -16,7 +17,7 @@ namespace ResourceBasedApi
             BuildWebHost(args).Run();
         }
 
-        public static IWebHost BuildWebHost(string[] args)
+        public static IHost BuildWebHost(string[] args)
         {
             Log.Logger = new LoggerConfiguration()
                 .MinimumLevel.Verbose()
@@ -27,8 +28,11 @@ namespace ResourceBasedApi
                 .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level}] {SourceContext}{NewLine}{Message:lj}{NewLine}{Exception}{NewLine}", theme: AnsiConsoleTheme.Code)
                 .CreateLogger();
 
-            return WebHost.CreateDefaultBuilder(args)
-                    .UseStartup<Startup>()
+            return Host.CreateDefaultBuilder(args)
+                    .ConfigureWebHostDefaults(webBuilder =>
+                    {
+                        webBuilder.UseStartup<Startup>();
+                    })
                     .UseSerilog()
                     .Build();
         }

--- a/clients/src/APIs/SimpleApi/Program.cs
+++ b/clients/src/APIs/SimpleApi/Program.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
 using Serilog;
 using Serilog.Events;
 using Serilog.Sinks.SystemConsole.Themes;
@@ -16,7 +17,7 @@ namespace SampleApi
             BuildWebHost(args).Run();
         }
 
-        public static IWebHost BuildWebHost(string[] args)
+        public static IHost BuildWebHost(string[] args)
         {
             Log.Logger = new LoggerConfiguration()
                 .MinimumLevel.Verbose()
@@ -27,10 +28,13 @@ namespace SampleApi
                 .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level}] {SourceContext}{NewLine}{Message:lj}{NewLine}{Exception}{NewLine}", theme: AnsiConsoleTheme.Code)
                 .CreateLogger();
 
-            return WebHost.CreateDefaultBuilder(args)
-                    .UseStartup<Startup>()
-                    .UseSerilog()
-                    .Build();
+            return Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                })
+                .UseSerilog()
+                .Build();
         }
     }
 }

--- a/clients/src/MvcAutomaticTokenManagement/MvcAutomaticTokenManagement.csproj
+++ b/clients/src/MvcAutomaticTokenManagement/MvcAutomaticTokenManagement.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="IdentityModel.AspNetCore" Version="4.0.0"/>
+        <PackageReference Include="Duende.AccessTokenManagement.OpenIdConnect" Version="1.0.0"/>
         <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.0"/>
         <PackageReference Include="Serilog.AspNetCore" Version="4.1.0"/>
 

--- a/clients/src/MvcAutomaticTokenManagement/Program.cs
+++ b/clients/src/MvcAutomaticTokenManagement/Program.cs
@@ -41,7 +41,7 @@ namespace MvcCode
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     webBuilder.UseStartup<Startup>();
-                    webBuilder.UseSerilog();
-                });
+                })
+                .UseSerilog();
     }
 }

--- a/clients/src/MvcAutomaticTokenManagement/Startup.cs
+++ b/clients/src/MvcAutomaticTokenManagement/Startup.cs
@@ -44,7 +44,7 @@ namespace MvcCode
                     options.Events.OnSigningOut = async e =>
                     {
                         // automatically revoke refresh token at signout time
-                        await e.HttpContext.RevokeUserRefreshTokenAsync();
+                        await e.HttpContext.RevokeRefreshTokenAsync();
                     };
                 })
                 .AddOpenIdConnect("oidc", options =>
@@ -77,7 +77,7 @@ namespace MvcCode
                 });
 
             // add automatic token management
-            services.AddAccessTokenManagement();
+            services.AddOpenIdConnectAccessTokenManagement();
 
             // add HTTP client to call protected API
             services.AddUserAccessTokenHttpClient("client", configureClient: client =>

--- a/clients/src/MvcCode/Controllers/HomeController.cs
+++ b/clients/src/MvcCode/Controllers/HomeController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -26,7 +26,7 @@ namespace MvcCode.Controllers
 
         public IActionResult Secure() => View();
 
-        public IActionResult Logout() => SignOut("oidc");
+        public IActionResult Logout() => SignOut("oidc", "Cookies");
         
         public async Task<IActionResult> CallApi()
         {

--- a/clients/src/MvcCode/Views/Shared/_Layout.cshtml
+++ b/clients/src/MvcCode/Views/Shared/_Layout.cshtml
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
@@ -24,9 +24,15 @@
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Secure">Secure</a>
                         </li>
-                        <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Logout">Logout</a>
-                        </li>
+                        @if (Context.User.Identity.IsAuthenticated)
+                        {
+                            <li class="nav-item">
+                                <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="CallApi">Call API</a>
+                            </li>
+                            <li class="nav-item">
+                                <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Logout">Logout</a>
+                            </li>
+                        }
                     </ul>
                 </div>
             </div>

--- a/clients/src/MvcJarJwt/Program.cs
+++ b/clients/src/MvcJarJwt/Program.cs
@@ -41,7 +41,7 @@ namespace MvcCode
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     webBuilder.UseStartup<Startup>();
-                    webBuilder.UseSerilog();
-                });
+                })
+                .UseSerilog();
     }
 }

--- a/clients/src/MvcJarUriJwt/Program.cs
+++ b/clients/src/MvcJarUriJwt/Program.cs
@@ -41,7 +41,7 @@ namespace MvcCode
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     webBuilder.UseStartup<Startup>();
-                    webBuilder.UseSerilog();
-                });
+                })
+                .UseSerilog();
     }
 }


### PR DESCRIPTION
- Use Duende.AccessTokenManagement in the MvcAutomaticTokenManagement client
- Move the call to UseSerilog in several other clients as well (the extension method on IWebHost is deprecated in favor of one on IHost)
- Fix the logout button in the MvcCode client