### PR TITLE
EmitIssuerIdentificationResponseParameter is reflected in discovery

### DIFF
--- a/src/IdentityServer/ResponseHandling/Default/DiscoveryResponseGenerator.cs
+++ b/src/IdentityServer/ResponseHandling/Default/DiscoveryResponseGenerator.cs
@@ -360,8 +360,8 @@ public class DiscoveryResponseGenerator : IDiscoveryResponseGenerator
                 entries.Add(OidcConstants.Discovery.RequestUriParameterSupported, true);
             }
         }
-            
-        entries.Add(OidcConstants.Discovery.AuthorizationResponseIssParameterSupported, true);
+
+        entries.Add(OidcConstants.Discovery.AuthorizationResponseIssParameterSupported, Options.EmitIssuerIdentificationResponseParameter);
 
         if (Options.MutualTls.Enabled)
         {


### PR DESCRIPTION
In the discovery document, set `authorization_response_iss_parameter_supported` to match the value of `EmitIssuerIdentificationResponseParameter`.
