### PR TITLE
Improve error logging in serversidesession cleanup

### DIFF
--- a/src/IdentityServer/Hosting/ServerSideSessionCleanupHost.cs
+++ b/src/IdentityServer/Hosting/ServerSideSessionCleanupHost.cs
@@ -144,7 +144,7 @@ public class ServerSideSessionCleanupHost : IHostedService
         }
         catch (Exception ex)
         {
-            _logger.LogError("Exception removing expired sessions: {exception}", ex.Message);
+            _logger.LogError(ex, "Exception removing expired sessions");
         }
     }
 }


### PR DESCRIPTION
Log the entire exception, including stack trace, when errors occur in server side session cleanup.