### PR TITLE
fix bug with resource indicators and not passing offline_access

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1939,3 +1939,7 @@ indent_size=2
 indent_style=space
 indent_size=4
 tab_width=4
+
+
+# IDE1006: Naming Styles
+dotnet_diagnostic.IDE1006.severity = none

--- a/src/IdentityServer/Validation/Default/AuthorizeRequestValidator.cs
+++ b/src/IdentityServer/Validation/Default/AuthorizeRequestValidator.cs
@@ -633,7 +633,6 @@ internal class AuthorizeRequestValidator : IAuthorizeRequestValidator
             Client = request.Client,
             Scopes = request.RequestedScopes,
             ResourceIndicators = resourceIndicators,
-            IncludeNonIsolatedApiResources = request.RequestedScopes.Contains(OidcConstants.StandardScopes.OfflineAccess),
         });
 
         if (!validatedResources.Succeeded)

--- a/src/IdentityServer/Validation/Default/BackchannelAuthenticationRequestValidator.cs
+++ b/src/IdentityServer/Validation/Default/BackchannelAuthenticationRequestValidator.cs
@@ -158,7 +158,6 @@ internal class BackchannelAuthenticationRequestValidator : IBackchannelAuthentic
             Client = _validatedRequest.Client,
             Scopes = _validatedRequest.RequestedScopes,
             ResourceIndicators = resourceIndicators,
-            IncludeNonIsolatedApiResources = _validatedRequest.RequestedScopes.Contains(OidcConstants.StandardScopes.OfflineAccess),
         });
 
         if (!validatedResources.Succeeded)

--- a/src/IdentityServer/Validation/Default/TokenRequestValidator.cs
+++ b/src/IdentityServer/Validation/Default/TokenRequestValidator.cs
@@ -340,8 +340,6 @@ internal class TokenRequestValidator : ITokenRequestValidator
             Client = _validatedRequest.Client,
             Scopes = _validatedRequest.AuthorizationCode.RequestedScopes,
             ResourceIndicators = _validatedRequest.AuthorizationCode.RequestedResourceIndicators,
-            // if we are issuing a refresh token, then we need to allow the non-isolated resource
-            IncludeNonIsolatedApiResources = _validatedRequest.AuthorizationCode.RequestedScopes.Contains(OidcConstants.StandardScopes.OfflineAccess)
         });
 
         if (!validatedResources.Succeeded)
@@ -612,8 +610,6 @@ internal class TokenRequestValidator : ITokenRequestValidator
             Client = _validatedRequest.Client,
             Scopes = _validatedRequest.RefreshToken.AuthorizedScopes,
             ResourceIndicators = resourceIndicators,
-            // we're issuing refresh token, so we need to allow for non-isolated resource
-            IncludeNonIsolatedApiResources = true,
         });
 
         if (!validatedResources.Succeeded)
@@ -780,8 +776,6 @@ internal class TokenRequestValidator : ITokenRequestValidator
             Client = _validatedRequest.Client,
             Scopes = _validatedRequest.BackChannelAuthenticationRequest.AuthorizedScopes,
             ResourceIndicators = _validatedRequest.BackChannelAuthenticationRequest.RequestedResourceIndicators,
-            // if we are issuing a refresh token, then we need to allow the non-isolated resource
-            IncludeNonIsolatedApiResources = _validatedRequest.BackChannelAuthenticationRequest.RequestedScopes.Contains(OidcConstants.StandardScopes.OfflineAccess)
         });
 
         if (!validatedResources.Succeeded)
@@ -953,8 +947,6 @@ internal class TokenRequestValidator : ITokenRequestValidator
             Client = _validatedRequest.Client,
             Scopes = requestedScopes,
             ResourceIndicators = resourceIndicators,
-            // if the client is passing explicit scopes, we want to exclude the non-isolated resource scenaio from validation
-            IncludeNonIsolatedApiResources = parameters.Get(OidcConstants.TokenRequest.Scope).IsMissing()
         });
 
         if (!resourceValidationResult.Succeeded)

--- a/src/IdentityServer/Validation/Models/ResourceValidationRequest.cs
+++ b/src/IdentityServer/Validation/Models/ResourceValidationRequest.cs
@@ -3,6 +3,7 @@
 
 
 using Duende.IdentityServer.Models;
+using System;
 using System.Collections.Generic;
 
 namespace Duende.IdentityServer.Validation;
@@ -31,5 +32,6 @@ public class ResourceValidationRequest
     /// Flag that indicates that validation should allow requested scopes to match non-isolated resources.
     /// If set to false, then only the scopes that match the exact resource indicators requested will be allowed.
     /// </summary>
+    [Obsolete("IncludeNonIsolatedApiResources is no longer used and will be removed in a future version.")]
     public bool IncludeNonIsolatedApiResources { get; set; }
 }

--- a/test/IdentityServer.IntegrationTests/Endpoints/Token/ResourceTests.cs
+++ b/test/IdentityServer.IntegrationTests/Endpoints/Token/ResourceTests.cs
@@ -506,7 +506,7 @@ public class ResourceTests
             tokenResponse.Error.Should().Be("invalid_target");
         }
     }
-        
+
 
     [Fact]
     [Trait("Category", Category)]

--- a/test/IdentityServer.UnitTests/Validation/ResourceValidation.cs
+++ b/test/IdentityServer.UnitTests/Validation/ResourceValidation.cs
@@ -312,24 +312,7 @@ public class ResourceValidation
 
     [Fact]
     [Trait("Category", Category)]
-    public async Task resource_indicator_should_include_all_apis_that_match_scope_and_only_the_resources_requested()
-    {
-        var validator = Factory.CreateResourceValidator(_subject);
-        var result = await validator.ValidateRequestedResourcesAsync(new ResourceValidationRequest
-        {
-            Client = _resourceClient,
-            Scopes = new[] { "scope1" },
-            ResourceIndicators = new[] { "isolated1" }
-        });
-
-        result.Succeeded.Should().BeTrue();
-        result.Resources.ApiResources.Select(x => x.Name).Should().BeEquivalentTo(new[] { "isolated1" });
-        result.Resources.ApiScopes.Select(x => x.Name).Should().BeEquivalentTo(new[] { "scope1" });
-    }
-        
-    [Fact]
-    [Trait("Category", Category)]
-    public async Task IncludeNonIsolatedApiResources_should_allow_include_all_resources_that_match_scope()
+    public async Task should_include_all_resources_that_match_scope()
     {
         var validator = Factory.CreateResourceValidator(_subject);
         var result = await validator.ValidateRequestedResourcesAsync(new ResourceValidationRequest
@@ -337,12 +320,12 @@ public class ResourceValidation
             Client = _resourceClient,
             Scopes = new[] { "scope1", "offline_access" },
             ResourceIndicators = new[] { "isolated1" },
-            IncludeNonIsolatedApiResources = true,
         });
 
         result.Succeeded.Should().BeTrue();
         result.Resources.ApiResources.Select(x => x.Name).Should().BeEquivalentTo(new[] { "resource1", "isolated1" });
         result.Resources.ApiScopes.Select(x => x.Name).Should().BeEquivalentTo(new[] { "scope1" });
+        result.Resources.OfflineAccess.Should().BeTrue();
     }
 
     [Fact]
@@ -380,7 +363,7 @@ public class ResourceValidation
 
     [Fact]
     [Trait("Category", Category)]
-    public async Task scope_not_in_resource_should_fail()
+    public async Task resource_without_matching_scope_in_request_should_fail()
     {
         var validator = Factory.CreateResourceValidator(_subject);
         var result = await validator.ValidateRequestedResourcesAsync(new ResourceValidationRequest


### PR DESCRIPTION
When resource indicators were used without offline_access, we had some logic on the authorize endpoint request that was trying to limit or filter the resources in the request. That produced odd "aud" claim results in the access token depending on if the resource requested was isolated or not, and did not allow the request on the token endpoint from actually indicating the resource to use when the code was being exchanged. This PR removes that special casing and allows the resource param on token endpoint to actually control this behavior. 

Related: https://github.com/DuendeSoftware/Support/issues/414
Related: https://github.com/DuendeSoftware/Support/issues/415