### PR TITLE
add support for unmet_authentication_requirements

### DIFF
--- a/src/IdentityServer/Endpoints/Results/AuthorizeResult.cs
+++ b/src/IdentityServer/Endpoints/Results/AuthorizeResult.cs
@@ -82,8 +82,9 @@ internal class AuthorizeResult : IEndpointResult
             Response.Error == OidcConstants.AuthorizeErrors.AccountSelectionRequired ||
             Response.Error == OidcConstants.AuthorizeErrors.LoginRequired ||
             Response.Error == OidcConstants.AuthorizeErrors.ConsentRequired ||
-            Response.Error == OidcConstants.AuthorizeErrors.InteractionRequired || 
-            Response.Error == OidcConstants.AuthorizeErrors.TemporarilyUnavailable;
+            Response.Error == OidcConstants.AuthorizeErrors.InteractionRequired ||
+            Response.Error == OidcConstants.AuthorizeErrors.TemporarilyUnavailable ||
+            Response.Error == "unmet_authentication_requirements"; // TODO: update once IdentityModel updated
 
         if (isSafeError)
         {

--- a/src/IdentityServer/Models/Messages/ConsentResponse.cs
+++ b/src/IdentityServer/Models/Messages/ConsentResponse.cs
@@ -89,4 +89,9 @@ public enum AuthorizationError
     /// Temporarily unavailable
     /// </summary>
     TemporarilyUnavailable,
+
+    /// <summary>
+    /// Unmet Authentication Requirements
+    /// </summary>
+    UnmetAuthenticationRequirements,
 }

--- a/src/IdentityServer/ResponseHandling/Default/AuthorizeInteractionResponseGenerator.cs
+++ b/src/IdentityServer/ResponseHandling/Default/AuthorizeInteractionResponseGenerator.cs
@@ -94,6 +94,7 @@ public class AuthorizeInteractionResponseGenerator : IAuthorizeInteractionRespon
                 AuthorizationError.InteractionRequired => OidcConstants.AuthorizeErrors.InteractionRequired,
                 AuthorizationError.LoginRequired => OidcConstants.AuthorizeErrors.LoginRequired,
                 AuthorizationError.TemporarilyUnavailable => OidcConstants.AuthorizeErrors.TemporarilyUnavailable,
+                AuthorizationError.UnmetAuthenticationRequirements => "unmet_authentication_requirements", // TODO: update once IdentityModel updated
                 _ => OidcConstants.AuthorizeErrors.AccessDenied
             };
                 
@@ -315,6 +316,7 @@ public class AuthorizeInteractionResponseGenerator : IAuthorizeInteractionRespon
                         AuthorizationError.InteractionRequired => OidcConstants.AuthorizeErrors.InteractionRequired,
                         AuthorizationError.LoginRequired => OidcConstants.AuthorizeErrors.LoginRequired,
                         AuthorizationError.TemporarilyUnavailable => OidcConstants.AuthorizeErrors.TemporarilyUnavailable,
+                        AuthorizationError.UnmetAuthenticationRequirements => "unmet_authentication_requirements", // TODO: update once IdentityModel updated
                         _ => OidcConstants.AuthorizeErrors.AccessDenied
                     };
                         


### PR DESCRIPTION
This adds support for the new unmet_authentication_requirements added in "OAuth 2.0 Step-up Authentication Challenge Protocol": https://datatracker.ietf.org/doc/html/draft-ietf-oauth-step-up-authn-challenge

Closes #1133