### PR TITLE
Fixes ToOptimizedRawValues to handle multiple resource values when combined with resource indicators

### DIFF
--- a/src/IdentityServer/Extensions/ValidatedAuthorizeRequestExtensions.cs
+++ b/src/IdentityServer/Extensions/ValidatedAuthorizeRequestExtensions.cs
@@ -157,7 +157,10 @@ public static class ValidatedAuthorizeRequestExtensions
                     key == OidcConstants.AuthorizeRequest.ResponseType || 
                     request.RequestObjectValues.All(x => x.Type != key))
                 {
-                    collection.Add(key, request.Raw[key]);
+                    foreach(var value in request.Raw.GetValues(key))
+                    {
+                        collection.Add(key, value);
+                    }
                 }
             }
 

--- a/test/IdentityServer.UnitTests/Extensions/ValidatedAuthorizeRequestExtensionsTests.cs
+++ b/test/IdentityServer.UnitTests/Extensions/ValidatedAuthorizeRequestExtensionsTests.cs
@@ -3,6 +3,7 @@
 
 
 using Duende.IdentityServer.Validation;
+using IdentityModel;
 using Xunit;
 
 namespace UnitTests.Extensions;
@@ -25,5 +26,23 @@ public class ValidatedAuthorizeRequestExtensionsTests
         {
             request.RemoveAcrValue(acr);
         }
+    }
+
+    [Fact]
+    public void ToOptimizedFullDictionary_should_return_dictionary_with_array_for_repeated_keys_when_request_objects_are_used()
+    {
+        var request = new ValidatedAuthorizeRequest()
+        {
+            Raw = new System.Collections.Specialized.NameValueCollection
+            {
+                { OidcConstants.AuthorizeRequest.Request, "Request object here" },
+                { OidcConstants.AuthorizeRequest.Resource, "Resource1" },
+                { OidcConstants.AuthorizeRequest.Resource, "Resource2" },
+            }
+        };
+
+        var res = request.ToOptimizedFullDictionary();
+
+        Assert.Equal(2, res[OidcConstants.AuthorizeRequest.Resource].Length);
     }
 }


### PR DESCRIPTION
This is a redo of the the merge in PR https://github.com/DuendeSoftware/IdentityServer/pull/1118, which accidentally included too many commits into the release branch (and is now reverted).