### PR TITLE
When cookie is re-issued ensure the issuer is captured in the ticket

### DIFF
--- a/src/IdentityServer/Services/Default/DefaultSessionCoordinationService.cs
+++ b/src/IdentityServer/Services/Default/DefaultSessionCoordinationService.cs
@@ -119,7 +119,8 @@ public class DefaultSessionCoordinationService : ISessionCoordinationService
             {
                 SubjectId = session.SubjectId,
                 SessionId = session.SessionId,
-                ClientIds = session.ClientIds
+                ClientIds = session.ClientIds,
+                Issuer = session.Issuer,
             });
         }
     }

--- a/src/IdentityServer/Stores/Default/ServerSideTicketStore.cs
+++ b/src/IdentityServer/Stores/Default/ServerSideTicketStore.cs
@@ -145,6 +145,11 @@ public class ServerSideTicketStore : IServerSideTicketStore
             session.SessionId = sid;
         }
 
+        if (ticket.GetIssuer() == null)
+        {
+            // when issuing a new cookie on top of an existing cookie, the AuthenticationTicket passed above is new (and not the prior one loaded from the ticket store)
+            ticket.SetIssuer(await _issuerNameService.GetCurrentAsync());
+        }
         session.Renewed = ticket.GetIssued();
         session.Expires = ticket.GetExpiration();
         session.DisplayName = name;


### PR DESCRIPTION
When using server side sessions, if a user's session is re-created (via another call to SignInAsync) and there is an existing session, a new AuthenticationTicket was passed in without the issuer property that we require. This PR detects that condition and now captures the issuer property. This issuer property is needed when performing back channel logout notifications. 

Closes https://github.com/DuendeSoftware/IdentityServer/issues/1138
Related https://github.com/DuendeSoftware/Support/issues/420
