### PR TITLE
add empty stores by default

### DIFF
--- a/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -30,6 +30,7 @@ using Duende.IdentityServer.Services.KeyManagement;
 using Microsoft.Extensions.Logging;
 using Duende.IdentityServer.Hosting.DynamicProviders;
 using Duende.IdentityServer.Internal;
+using Duende.IdentityServer.Stores.Empty;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -168,6 +169,9 @@ public static class IdentityServerBuilderExtensionsCore
         builder.Services.TryAddTransient<IBackchannelAuthenticationUserValidator, NopBackchannelAuthenticationUserValidator>();
 
         builder.Services.TryAddTransient(typeof(IConcurrencyLock<>), typeof(DefaultConcurrencyLock<>));
+
+        builder.Services.TryAddTransient<IClientStore, EmptyClientStore>();
+        builder.Services.TryAddTransient<IResourceStore, EmptyResourceStore>();
 
         return builder;
     }

--- a/src/IdentityServer/Stores/Empty/EmptyClientStore.cs
+++ b/src/IdentityServer/Stores/Empty/EmptyClientStore.cs
@@ -1,0 +1,12 @@
+using Duende.IdentityServer.Models;
+using System.Threading.Tasks;
+
+namespace Duende.IdentityServer.Stores.Empty;
+
+internal class EmptyClientStore : IClientStore
+{
+    public Task<Client> FindClientByIdAsync(string clientId)
+    {
+        return Task.FromResult<Client>(null);
+    }
+}

--- a/src/IdentityServer/Stores/Empty/EmptyResourceStore.cs
+++ b/src/IdentityServer/Stores/Empty/EmptyResourceStore.cs
@@ -1,0 +1,34 @@
+using Duende.IdentityServer.Models;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Duende.IdentityServer.Stores.Empty;
+
+internal class EmptyResourceStore : IResourceStore
+{
+    public Task<IEnumerable<ApiResource>> FindApiResourcesByNameAsync(IEnumerable<string> apiResourceNames)
+    {
+        return Task.FromResult(Enumerable.Empty<ApiResource>());
+    }
+
+    public Task<IEnumerable<ApiResource>> FindApiResourcesByScopeNameAsync(IEnumerable<string> scopeNames)
+    {
+        return Task.FromResult(Enumerable.Empty<ApiResource>());
+    }
+
+    public Task<IEnumerable<ApiScope>> FindApiScopesByNameAsync(IEnumerable<string> scopeNames)
+    {
+        return Task.FromResult(Enumerable.Empty<ApiScope>());
+    }
+
+    public Task<IEnumerable<IdentityResource>> FindIdentityResourcesByScopeNameAsync(IEnumerable<string> scopeNames)
+    {
+        return Task.FromResult(Enumerable.Empty<IdentityResource>());
+    }
+
+    public Task<Resources> GetAllResourcesAsync()
+    {
+        return Task.FromResult(new Resources() { OfflineAccess = true });
+    }
+}


### PR DESCRIPTION
IdentityServer requires an IClientStore and an IResourceStore to function. This PR adds empty/nop implementations by default. This allows adding the services and middleware with no config such that it at least runs without any exceptions due to the lack of services added to DI.

Closes: https://github.com/DuendeSoftware/IdentityServer/issues/1100