### PR TITLE
Update audience logic for private key JWT client authN

### DIFF
--- a/src/IdentityServer/Validation/Default/PrivateKeyJwtSecretValidator.cs
+++ b/src/IdentityServer/Validation/Default/PrivateKeyJwtSecretValidator.cs
@@ -92,9 +92,13 @@ public class PrivateKeyJwtSecretValidator : ISecretValidator
         {
             // token endpoint URL
             string.Concat(_urls.BaseUrl.EnsureTrailingSlash(), Constants.ProtocolRoutePaths.Token),
-            // TODO: remove the issuer URL in a future major release?
+            // issuer URL + token (legacy support)
+            string.Concat((await _issuerNameService.GetCurrentAsync()).EnsureTrailingSlash(), Constants.ProtocolRoutePaths.Token),
             // issuer URL
-            string.Concat((await _issuerNameService.GetCurrentAsync()).EnsureTrailingSlash(), Constants.ProtocolRoutePaths.Token)
+            await _issuerNameService.GetCurrentAsync(),
+            // CIBA endpoint: https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html#auth_request
+            string.Concat(_urls.BaseUrl.EnsureTrailingSlash(), Constants.ProtocolRoutePaths.BackchannelAuthentication),
+            // TODO: PAR once added
         }.Distinct();
 
         var tokenValidationParameters = new TokenValidationParameters


### PR DESCRIPTION
This PR updates the `aud` claim check for private key JWT client authentication based on the CIBA and PAR specs. PAR is not yet implemented, so once it is this will need to be augmented for the new PAR endpoint as well.

Related: https://github.com/DuendeSoftware/IdentityServer/issues/983