### PR TITLE
Add support for OIDC prompt=create

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -16,7 +16,7 @@
 
     <ItemGroup>
         <!--our stuff -->
-        <PackageReference Update="IdentityModel" Version="6.0.0"/>
+        <PackageReference Update="IdentityModel" Version="6.1.0-preview.2"/>
 
         <!--build related-->
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>

--- a/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -30,6 +30,7 @@ using Duende.IdentityServer.Services.KeyManagement;
 using Microsoft.Extensions.Logging;
 using Duende.IdentityServer.Hosting.DynamicProviders;
 using Duende.IdentityServer.Internal;
+using Duende.IdentityServer.Stores.Empty;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -168,6 +169,9 @@ public static class IdentityServerBuilderExtensionsCore
         builder.Services.TryAddTransient<IBackchannelAuthenticationUserValidator, NopBackchannelAuthenticationUserValidator>();
 
         builder.Services.TryAddTransient(typeof(IConcurrencyLock<>), typeof(DefaultConcurrencyLock<>));
+
+        builder.Services.TryAddTransient<IClientStore, EmptyClientStore>();
+        builder.Services.TryAddTransient<IResourceStore, EmptyResourceStore>();
 
         return builder;
     }

--- a/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -23,6 +23,7 @@ using Duende.IdentityServer.Models;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication;
 using static Duende.IdentityServer.Constants;
+using static Duende.IdentityServer.IdentityServerConstants;
 using Duende.IdentityServer.Extensions;
 using Duende.IdentityServer.Hosting.FederatedSignOut;
 using Duende.IdentityServer.Services.Default;

--- a/src/IdentityServer/Configuration/DependencyInjection/Options/UserInteractionOptions.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/Options/UserInteractionOptions.cs
@@ -3,6 +3,7 @@
 
 
 using Duende.IdentityServer.Extensions;
+using System.Collections.Generic;
 
 namespace Duende.IdentityServer.Configuration;
 
@@ -111,4 +112,9 @@ public class UserInteractionOptions
     /// Flag that allows return URL validation to accept full URL that includes the IdentityServer origin. Defaults to false.
     /// </summary>
     public bool AllowOriginInReturnUrl { get; set; }
+
+    /// <summary>
+    /// The collection of OIDC prompt modes supported and that will be published in discovery.
+    /// </summary>
+    public ICollection<string> PromptValuesSupported { get; set; } = new HashSet<string>(Constants.SupportedPromptModes);
 }

--- a/src/IdentityServer/Constants.cs
+++ b/src/IdentityServer/Constants.cs
@@ -196,20 +196,6 @@ internal static class Constants
         }
     }
 
-    public static class EndpointNames
-    {
-        public const string Authorize = "Authorize";
-        public const string BackchannelAuthentication = "BackchannelAuthentication";
-        public const string Token = "Token";
-        public const string DeviceAuthorization = "DeviceAuthorization";
-        public const string Discovery = "Discovery";
-        public const string Introspection = "Introspection";
-        public const string Revocation = "Revocation";
-        public const string EndSession = "Endsession";
-        public const string CheckSession = "Checksession";
-        public const string UserInfo = "Userinfo";
-    }
-
     public static class ProtocolRoutePaths
     {
         public const string ConnectPathPrefix       = "connect";

--- a/src/IdentityServer/Constants.cs
+++ b/src/IdentityServer/Constants.cs
@@ -110,7 +110,8 @@ internal static class Constants
         OidcConstants.PromptModes.None,
         OidcConstants.PromptModes.Login,
         OidcConstants.PromptModes.Consent,
-        OidcConstants.PromptModes.SelectAccount
+        OidcConstants.PromptModes.SelectAccount,
+        "create", // OidcConstants.PromptModes.Create, // TODO: update to constant once IdentityModel updated
     };
 
     public const string SuppressedPrompt = "suppressed_" + OidcConstants.AuthorizeRequest.Prompt;

--- a/src/IdentityServer/Endpoints/AuthorizeCallbackEndpoint.cs
+++ b/src/IdentityServer/Endpoints/AuthorizeCallbackEndpoint.cs
@@ -34,7 +34,7 @@ internal class AuthorizeCallbackEndpoint : AuthorizeEndpointBase
 
     public override async Task<IEndpointResult> ProcessAsync(HttpContext context)
     {
-        using var activity = Tracing.BasicActivitySource.StartActivity(Constants.EndpointNames.Authorize + "CallbackEndpoint");
+        using var activity = Tracing.BasicActivitySource.StartActivity(IdentityServerConstants.EndpointNames.Authorize + "CallbackEndpoint");
         
         if (!HttpMethods.IsGet(context.Request.Method))
         {

--- a/src/IdentityServer/Endpoints/AuthorizeEndpoint.cs
+++ b/src/IdentityServer/Endpoints/AuthorizeEndpoint.cs
@@ -35,7 +35,7 @@ internal class AuthorizeEndpoint : AuthorizeEndpointBase
 
     public override async Task<IEndpointResult> ProcessAsync(HttpContext context)
     {
-        using var activity = Tracing.BasicActivitySource.StartActivity(Constants.EndpointNames.Authorize + "Endpoint");
+        using var activity = Tracing.BasicActivitySource.StartActivity(IdentityServerConstants.EndpointNames.Authorize + "Endpoint");
 
         Logger.LogDebug("Start authorize request");
 

--- a/src/IdentityServer/Endpoints/BackchannelAuthenticationEndpoint.cs
+++ b/src/IdentityServer/Endpoints/BackchannelAuthenticationEndpoint.cs
@@ -44,7 +44,7 @@ internal class BackchannelAuthenticationEndpoint : IEndpointHandler
 
     public async Task<IEndpointResult> ProcessAsync(HttpContext context)
     {
-        using var activity = Tracing.BasicActivitySource.StartActivity(Constants.EndpointNames.BackchannelAuthentication + "Endpoint");
+        using var activity = Tracing.BasicActivitySource.StartActivity(IdentityServerConstants.EndpointNames.BackchannelAuthentication + "Endpoint");
         
         _logger.LogTrace("Processing backchannel authentication request.");
 

--- a/src/IdentityServer/Endpoints/CheckSessionEndpoint.cs
+++ b/src/IdentityServer/Endpoints/CheckSessionEndpoint.cs
@@ -22,7 +22,7 @@ internal class CheckSessionEndpoint : IEndpointHandler
 
     public Task<IEndpointResult> ProcessAsync(HttpContext context)
     {
-        using var activity = Tracing.BasicActivitySource.StartActivity(Constants.EndpointNames.CheckSession + "Endpoint");
+        using var activity = Tracing.BasicActivitySource.StartActivity(IdentityServerConstants.EndpointNames.CheckSession + "Endpoint");
         
         IEndpointResult result;
 

--- a/src/IdentityServer/Endpoints/DeviceAuthorizationEndpoint.cs
+++ b/src/IdentityServer/Endpoints/DeviceAuthorizationEndpoint.cs
@@ -55,7 +55,7 @@ internal class DeviceAuthorizationEndpoint : IEndpointHandler
     /// <exception cref="System.NotImplementedException"></exception>
     public async Task<IEndpointResult> ProcessAsync(HttpContext context)
     {
-        using var activity = Tracing.BasicActivitySource.StartActivity(Constants.EndpointNames.DeviceAuthorization + "Endpoint");
+        using var activity = Tracing.BasicActivitySource.StartActivity(IdentityServerConstants.EndpointNames.DeviceAuthorization + "Endpoint");
         
         _logger.LogTrace("Processing device authorize request.");
 

--- a/src/IdentityServer/Endpoints/DiscoveryEndpoint.cs
+++ b/src/IdentityServer/Endpoints/DiscoveryEndpoint.cs
@@ -38,7 +38,7 @@ internal class DiscoveryEndpoint : IEndpointHandler
 
     public async Task<IEndpointResult> ProcessAsync(HttpContext context)
     {
-        using var activity = Tracing.BasicActivitySource.StartActivity(Constants.EndpointNames.Discovery + "Endpoint");
+        using var activity = Tracing.BasicActivitySource.StartActivity(IdentityServerConstants.EndpointNames.Discovery + "Endpoint");
         
         _logger.LogTrace("Processing discovery request.");
 

--- a/src/IdentityServer/Endpoints/DiscoveryKeyEndpoint.cs
+++ b/src/IdentityServer/Endpoints/DiscoveryKeyEndpoint.cs
@@ -32,7 +32,7 @@ internal class DiscoveryKeyEndpoint : IEndpointHandler
 
     public async Task<IEndpointResult> ProcessAsync(HttpContext context)
     {
-        using var activity = Tracing.BasicActivitySource.StartActivity(Constants.EndpointNames.Discovery + "Endpoint");
+        using var activity = Tracing.BasicActivitySource.StartActivity(IdentityServerConstants.EndpointNames.Discovery + "Endpoint");
         
         _logger.LogTrace("Processing discovery request.");
 

--- a/src/IdentityServer/Endpoints/EndSessionCallbackEndpoint.cs
+++ b/src/IdentityServer/Endpoints/EndSessionCallbackEndpoint.cs
@@ -27,7 +27,7 @@ internal class EndSessionCallbackEndpoint : IEndpointHandler
 
     public async Task<IEndpointResult> ProcessAsync(HttpContext context)
     {
-        using var activity = Tracing.BasicActivitySource.StartActivity(Constants.EndpointNames.EndSession + "CallbackEndpoint");
+        using var activity = Tracing.BasicActivitySource.StartActivity(IdentityServerConstants.EndpointNames.EndSession + "CallbackEndpoint");
         
         if (!HttpMethods.IsGet(context.Request.Method))
         {

--- a/src/IdentityServer/Endpoints/EndSessionEndpoint.cs
+++ b/src/IdentityServer/Endpoints/EndSessionEndpoint.cs
@@ -35,7 +35,7 @@ internal class EndSessionEndpoint : IEndpointHandler
 
     public async Task<IEndpointResult> ProcessAsync(HttpContext context)
     {
-        using var activity = Tracing.BasicActivitySource.StartActivity(Constants.EndpointNames.EndSession + "Endpoint");
+        using var activity = Tracing.BasicActivitySource.StartActivity(IdentityServerConstants.EndpointNames.EndSession + "Endpoint");
 
         try
         {
@@ -51,7 +51,7 @@ internal class EndSessionEndpoint : IEndpointHandler
 
     async Task<IEndpointResult> ProcessEndSessionAsync(HttpContext context)
     {
-        using var activity = Tracing.BasicActivitySource.StartActivity(Constants.EndpointNames.EndSession + "Endpoint");
+        using var activity = Tracing.BasicActivitySource.StartActivity(IdentityServerConstants.EndpointNames.EndSession + "Endpoint");
 
         NameValueCollection parameters;
         if (HttpMethods.IsGet(context.Request.Method))

--- a/src/IdentityServer/Endpoints/IntrospectionEndpoint.cs
+++ b/src/IdentityServer/Endpoints/IntrospectionEndpoint.cs
@@ -58,7 +58,7 @@ internal class IntrospectionEndpoint : IEndpointHandler
     /// <returns></returns>
     public async Task<IEndpointResult> ProcessAsync(HttpContext context)
     {
-        using var activity = Tracing.BasicActivitySource.StartActivity(Constants.EndpointNames.Introspection + "Endpoint");
+        using var activity = Tracing.BasicActivitySource.StartActivity(IdentityServerConstants.EndpointNames.Introspection + "Endpoint");
         
         _logger.LogTrace("Processing introspection request.");
 

--- a/src/IdentityServer/Endpoints/TokenEndpoint.cs
+++ b/src/IdentityServer/Endpoints/TokenEndpoint.cs
@@ -59,7 +59,7 @@ internal class TokenEndpoint : IEndpointHandler
     /// <returns></returns>
     public async Task<IEndpointResult> ProcessAsync(HttpContext context)
     {
-        using var activity = Tracing.BasicActivitySource.StartActivity(Constants.EndpointNames.Token + "Endpoint");
+        using var activity = Tracing.BasicActivitySource.StartActivity(IdentityServerConstants.EndpointNames.Token + "Endpoint");
         
         _logger.LogTrace("Processing token request.");
 

--- a/src/IdentityServer/Endpoints/TokenRevocationEndpoint.cs
+++ b/src/IdentityServer/Endpoints/TokenRevocationEndpoint.cs
@@ -59,7 +59,7 @@ internal class TokenRevocationEndpoint : IEndpointHandler
     /// <returns></returns>
     public async Task<IEndpointResult> ProcessAsync(HttpContext context)
     {
-        using var activity = Tracing.BasicActivitySource.StartActivity(Constants.EndpointNames.Revocation + "Endpoint");
+        using var activity = Tracing.BasicActivitySource.StartActivity(IdentityServerConstants.EndpointNames.Revocation + "Endpoint");
         
         _logger.LogTrace("Processing revocation request.");
 

--- a/src/IdentityServer/Endpoints/UserInfoEndpoint.cs
+++ b/src/IdentityServer/Endpoints/UserInfoEndpoint.cs
@@ -51,7 +51,7 @@ internal class UserInfoEndpoint : IEndpointHandler
     /// <returns></returns>
     public async Task<IEndpointResult> ProcessAsync(HttpContext context)
     {
-        using var activity = Tracing.BasicActivitySource.StartActivity(Constants.EndpointNames.UserInfo + "Endpoint");
+        using var activity = Tracing.BasicActivitySource.StartActivity(IdentityServerConstants.EndpointNames.UserInfo + "Endpoint");
         
         if (!HttpMethods.IsGet(context.Request.Method) && !HttpMethods.IsPost(context.Request.Method))
         {

--- a/src/IdentityServer/Events/BackchannelAuthenticationFailureEvent.cs
+++ b/src/IdentityServer/Events/BackchannelAuthenticationFailureEvent.cs
@@ -34,7 +34,7 @@ public class BackchannelAuthenticationFailureEvent : Event
             }
         }
 
-        Endpoint = Constants.EndpointNames.BackchannelAuthentication;
+        Endpoint = IdentityServerConstants.EndpointNames.BackchannelAuthentication;
         Error = error;
         ErrorDescription = description;
     }
@@ -58,7 +58,7 @@ public class BackchannelAuthenticationFailureEvent : Event
             }
         }
 
-        Endpoint = Constants.EndpointNames.BackchannelAuthentication;
+        Endpoint = IdentityServerConstants.EndpointNames.BackchannelAuthentication;
         Error = result.Error;
         ErrorDescription = result.ErrorDescription;
     }

--- a/src/IdentityServer/Events/BackchannelAuthenticationSuccessEvent.cs
+++ b/src/IdentityServer/Events/BackchannelAuthenticationSuccessEvent.cs
@@ -22,7 +22,7 @@ public class BackchannelAuthenticationSuccessEvent : Event
     {
         ClientId = request.ValidatedRequest.Client.ClientId;
         ClientName = request.ValidatedRequest.Client.ClientName;
-        Endpoint = Constants.EndpointNames.BackchannelAuthentication;
+        Endpoint = IdentityServerConstants.EndpointNames.BackchannelAuthentication;
         SubjectId = request.ValidatedRequest.Subject?.GetSubjectId();
         Scopes = request.ValidatedRequest.ValidatedResources.RawScopeValues.ToSpaceSeparatedString();
     }

--- a/src/IdentityServer/Events/DeviceAuthorizationFailureEvent.cs
+++ b/src/IdentityServer/Events/DeviceAuthorizationFailureEvent.cs
@@ -28,7 +28,7 @@ public class DeviceAuthorizationFailureEvent : Event
                 
         }
 
-        Endpoint = Constants.EndpointNames.DeviceAuthorization;
+        Endpoint = IdentityServerConstants.EndpointNames.DeviceAuthorization;
         Error = result.Error;
         ErrorDescription = result.ErrorDescription;
     }

--- a/src/IdentityServer/Events/DeviceAuthorizationSuccessEvent.cs
+++ b/src/IdentityServer/Events/DeviceAuthorizationSuccessEvent.cs
@@ -24,7 +24,7 @@ public class DeviceAuthorizationSuccessEvent : Event
     {
         ClientId = request.ValidatedRequest.Client?.ClientId;
         ClientName = request.ValidatedRequest.Client?.ClientName;
-        Endpoint = Constants.EndpointNames.DeviceAuthorization;
+        Endpoint = IdentityServerConstants.EndpointNames.DeviceAuthorization;
         Scopes = request.ValidatedRequest.ValidatedResources?.RawScopeValues.ToSpaceSeparatedString();
     }
 

--- a/src/IdentityServer/Events/TokenIssuedFailureEvent.cs
+++ b/src/IdentityServer/Events/TokenIssuedFailureEvent.cs
@@ -36,7 +36,7 @@ public class TokenIssuedFailureEvent : Event
             }
         }
 
-        Endpoint = Constants.EndpointNames.Authorize;
+        Endpoint = IdentityServerConstants.EndpointNames.Authorize;
         Error = error;
         ErrorDescription = description;
     }
@@ -61,7 +61,7 @@ public class TokenIssuedFailureEvent : Event
             }
         }
 
-        Endpoint = Constants.EndpointNames.Token;
+        Endpoint = IdentityServerConstants.EndpointNames.Token;
         Error = result.Error;
         ErrorDescription = result.ErrorDescription;
     }

--- a/src/IdentityServer/Events/TokenIssuedSuccessEvent.cs
+++ b/src/IdentityServer/Events/TokenIssuedSuccessEvent.cs
@@ -26,7 +26,7 @@ public class TokenIssuedSuccessEvent : Event
         ClientId = response.Request.ClientId;
         ClientName = response.Request.Client.ClientName;
         RedirectUri = response.RedirectUri;
-        Endpoint = Constants.EndpointNames.Authorize;
+        Endpoint = IdentityServerConstants.EndpointNames.Authorize;
         SubjectId = response.Request.Subject.GetSubjectId();
         Scopes = response.Scope;
         GrantType = response.Request.GrantType;
@@ -57,7 +57,7 @@ public class TokenIssuedSuccessEvent : Event
     {
         ClientId = request.ValidatedRequest.Client.ClientId;
         ClientName = request.ValidatedRequest.Client.ClientName;
-        Endpoint = Constants.EndpointNames.Token;
+        Endpoint = IdentityServerConstants.EndpointNames.Token;
         SubjectId = request.ValidatedRequest.Subject?.GetSubjectId();
         GrantType = request.ValidatedRequest.GrantType;
 

--- a/src/IdentityServer/Events/UserLoginFailureEvent.cs
+++ b/src/IdentityServer/Events/UserLoginFailureEvent.cs
@@ -33,7 +33,7 @@ public class UserLoginFailureEvent : Event
         }
         else
         {
-            Endpoint = Constants.EndpointNames.Token;
+            Endpoint = IdentityServerConstants.EndpointNames.Token;
         }
     }
 

--- a/src/IdentityServer/Events/UserLoginSuccessEvent.cs
+++ b/src/IdentityServer/Events/UserLoginSuccessEvent.cs
@@ -34,7 +34,7 @@ public class UserLoginSuccessEvent : Event
         }
         else
         {
-            Endpoint = Constants.EndpointNames.Token;
+            Endpoint = IdentityServerConstants.EndpointNames.Token;
         }
         ClientId = clientId;
     }
@@ -61,7 +61,7 @@ public class UserLoginSuccessEvent : Event
         }
         else
         {
-            Endpoint = Constants.EndpointNames.Token;
+            Endpoint = IdentityServerConstants.EndpointNames.Token;
         }
     }
 

--- a/src/IdentityServer/Extensions/EndpointOptionsExtensions.cs
+++ b/src/IdentityServer/Extensions/EndpointOptionsExtensions.cs
@@ -13,15 +13,15 @@ internal static class EndpointOptionsExtensions
     {
         return endpoint?.Name switch
         {
-            Constants.EndpointNames.Authorize => options.EnableAuthorizeEndpoint,
-            Constants.EndpointNames.CheckSession => options.EnableCheckSessionEndpoint,
-            Constants.EndpointNames.DeviceAuthorization => options.EnableDeviceAuthorizationEndpoint,
-            Constants.EndpointNames.Discovery => options.EnableDiscoveryEndpoint,
-            Constants.EndpointNames.EndSession => options.EnableEndSessionEndpoint,
-            Constants.EndpointNames.Introspection => options.EnableIntrospectionEndpoint,
-            Constants.EndpointNames.Revocation => options.EnableTokenRevocationEndpoint,
-            Constants.EndpointNames.Token => options.EnableTokenEndpoint,
-            Constants.EndpointNames.UserInfo => options.EnableUserInfoEndpoint,
+            IdentityServerConstants.EndpointNames.Authorize => options.EnableAuthorizeEndpoint,
+            IdentityServerConstants.EndpointNames.CheckSession => options.EnableCheckSessionEndpoint,
+            IdentityServerConstants.EndpointNames.DeviceAuthorization => options.EnableDeviceAuthorizationEndpoint,
+            IdentityServerConstants.EndpointNames.Discovery => options.EnableDiscoveryEndpoint,
+            IdentityServerConstants.EndpointNames.EndSession => options.EnableEndSessionEndpoint,
+            IdentityServerConstants.EndpointNames.Introspection => options.EnableIntrospectionEndpoint,
+            IdentityServerConstants.EndpointNames.Revocation => options.EnableTokenRevocationEndpoint,
+            IdentityServerConstants.EndpointNames.Token => options.EnableTokenEndpoint,
+            IdentityServerConstants.EndpointNames.UserInfo => options.EnableUserInfoEndpoint,
             _ => true
         };
     }

--- a/src/IdentityServer/Extensions/ValidatedAuthorizeRequestExtensions.cs
+++ b/src/IdentityServer/Extensions/ValidatedAuthorizeRequestExtensions.cs
@@ -32,9 +32,22 @@ public static class ValidatedAuthorizeRequestExtensions
             }
             suppress.Append(OidcConstants.PromptModes.SelectAccount);
         }
+        // TODO: update to constant once IdentityModel updated
+        if (request.PromptModes.Contains("create"))
+        {
+            if (suppress.Length > 0)
+            {
+                suppress.Append(" ");
+            }
+            suppress.Append("create");
+        }
 
         request.Raw.Add(Constants.SuppressedPrompt, suppress.ToString());
-        request.PromptModes = request.PromptModes.Except(new[] { OidcConstants.PromptModes.Login, OidcConstants.PromptModes.SelectAccount }).ToArray();
+        request.PromptModes = request.PromptModes.Except(new[] { 
+            OidcConstants.PromptModes.Login, 
+            OidcConstants.PromptModes.SelectAccount,
+            "create"
+        }).ToArray();
     }
 
     public static string GetPrefixedAcrValue(this ValidatedAuthorizeRequest request, string prefix)

--- a/src/IdentityServer/IdentityServerConstants.cs
+++ b/src/IdentityServer/IdentityServerConstants.cs
@@ -93,9 +93,7 @@ public static class IdentityServerConstants
         public const string AuthorizationCodeValidation = "AuthorizationCodeValidation";
         public const string UserInfoRequestValidation = "UserInfoRequestValidation";
         public const string DeviceCodeValidation = "DeviceCodeValidation";
-
-        public const string BackchannelAuthenticationRequestIdValidation =
-            "BackchannelAuthenticationRequestIdValidation";
+        public const string BackchannelAuthenticationRequestIdValidation = "BackchannelAuthenticationRequestIdValidation";
     }
 
 
@@ -190,5 +188,19 @@ public static class IdentityServerConstants
         public static readonly string Services = Duende.IdentityServer.Tracing.TraceNames.Services;
         
         public static readonly string ServiceVersion = Duende.IdentityServer.Tracing.ServiceVersion;
+    }
+
+    public static class EndpointNames
+    {
+        public const string Authorize = "Authorize";
+        public const string BackchannelAuthentication = "BackchannelAuthentication";
+        public const string Token = "Token";
+        public const string DeviceAuthorization = "DeviceAuthorization";
+        public const string Discovery = "Discovery";
+        public const string Introspection = "Introspection";
+        public const string Revocation = "Revocation";
+        public const string EndSession = "Endsession";
+        public const string CheckSession = "Checksession";
+        public const string UserInfo = "Userinfo";
     }
 }

--- a/src/IdentityServer/ResponseHandling/Default/AuthorizeInteractionResponseGenerator.cs
+++ b/src/IdentityServer/ResponseHandling/Default/AuthorizeInteractionResponseGenerator.cs
@@ -137,7 +137,9 @@ public class AuthorizeInteractionResponseGenerator : IAuthorizeInteractionRespon
         using var activity = Tracing.BasicActivitySource.StartActivity("AuthorizeInteractionResponseGenerator.ProcessLogin");
         
         if (request.PromptModes.Contains(OidcConstants.PromptModes.Login) ||
-            request.PromptModes.Contains(OidcConstants.PromptModes.SelectAccount))
+            request.PromptModes.Contains(OidcConstants.PromptModes.SelectAccount) ||
+            // TODO: update to constant once IdentityModel updated
+            request.PromptModes.Contains("create"))
         {
             Logger.LogInformation("Showing login: request contains prompt={0}", request.PromptModes.ToSpaceSeparatedString());
 

--- a/src/IdentityServer/ResponseHandling/Default/DiscoveryResponseGenerator.cs
+++ b/src/IdentityServer/ResponseHandling/Default/DiscoveryResponseGenerator.cs
@@ -359,6 +359,12 @@ public class DiscoveryResponseGenerator : IDiscoveryResponseGenerator
             {
                 entries.Add(OidcConstants.Discovery.RequestUriParameterSupported, true);
             }
+
+            if (Options.UserInteraction.PromptValuesSupported?.Any() == true)
+            {
+                // TODO: update to constant once IdentityModel updated
+                entries.Add("prompt_values_supported", Options.UserInteraction.PromptValuesSupported.ToArray());
+            }
         }
 
         entries.Add(OidcConstants.Discovery.AuthorizationResponseIssParameterSupported, Options.EmitIssuerIdentificationResponseParameter);

--- a/src/IdentityServer/Services/Default/KeyManagement/KeyManager.cs
+++ b/src/IdentityServer/Services/Default/KeyManagement/KeyManager.cs
@@ -12,6 +12,7 @@ using Duende.IdentityServer.Configuration;
 using Microsoft.AspNetCore.Authentication;
 using Duende.IdentityServer.Extensions;
 using Duende.IdentityServer.Internal;
+using System.Security.Cryptography;
 
 namespace Duende.IdentityServer.Services.KeyManagement;
 
@@ -439,9 +440,13 @@ public class KeyManager : IKeyManager
                         }
                         return key;
                     }
+                    catch(CryptographicException ex)
+                    {
+                        _logger.LogError(ex, "Error unprotecting the IdentityServer signing key with kid {kid}. This is likely due to the ASP.NET Core data protection key that was used to protect it is not available. This could occur because data protection has not been configured properly for your load balanced environment, or the IdentityServer signing key store was populated with keys from a different environment with different ASP.NET Core data protection keys. Once you have corrected the problem and if you keep getting this error then it is safe to delete the specific IdentityServer signing key with that kid.", x?.Id);
+                    }
                     catch (Exception ex)
                     {
-                        _logger.LogError(ex, "Error unprotecting key with kid {kid}.", x?.Id);
+                        _logger.LogError(ex, "Error loading key with kid {kid}.", x?.Id);
                     }
                     return null;
                 })

--- a/src/IdentityServer/Stores/Empty/EmptyClientStore.cs
+++ b/src/IdentityServer/Stores/Empty/EmptyClientStore.cs
@@ -1,0 +1,12 @@
+using Duende.IdentityServer.Models;
+using System.Threading.Tasks;
+
+namespace Duende.IdentityServer.Stores.Empty;
+
+internal class EmptyClientStore : IClientStore
+{
+    public Task<Client> FindClientByIdAsync(string clientId)
+    {
+        return Task.FromResult<Client>(null);
+    }
+}

--- a/src/IdentityServer/Stores/Empty/EmptyResourceStore.cs
+++ b/src/IdentityServer/Stores/Empty/EmptyResourceStore.cs
@@ -1,0 +1,34 @@
+using Duende.IdentityServer.Models;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Duende.IdentityServer.Stores.Empty;
+
+internal class EmptyResourceStore : IResourceStore
+{
+    public Task<IEnumerable<ApiResource>> FindApiResourcesByNameAsync(IEnumerable<string> apiResourceNames)
+    {
+        return Task.FromResult(Enumerable.Empty<ApiResource>());
+    }
+
+    public Task<IEnumerable<ApiResource>> FindApiResourcesByScopeNameAsync(IEnumerable<string> scopeNames)
+    {
+        return Task.FromResult(Enumerable.Empty<ApiResource>());
+    }
+
+    public Task<IEnumerable<ApiScope>> FindApiScopesByNameAsync(IEnumerable<string> scopeNames)
+    {
+        return Task.FromResult(Enumerable.Empty<ApiScope>());
+    }
+
+    public Task<IEnumerable<IdentityResource>> FindIdentityResourcesByScopeNameAsync(IEnumerable<string> scopeNames)
+    {
+        return Task.FromResult(Enumerable.Empty<IdentityResource>());
+    }
+
+    public Task<Resources> GetAllResourcesAsync()
+    {
+        return Task.FromResult(new Resources() { OfflineAccess = true });
+    }
+}

--- a/src/IdentityServer/Validation/Default/AuthorizeRequestValidator.cs
+++ b/src/IdentityServer/Validation/Default/AuthorizeRequestValidator.cs
@@ -362,7 +362,8 @@ internal class AuthorizeRequestValidator : IAuthorizeRequestValidator
         //////////////////////////////////////////////////////////
         // check if redirect_uri is valid
         //////////////////////////////////////////////////////////
-        if (await _uriValidator.IsRedirectUriValidAsync(redirectUri, request.Client) == false)
+        var uriContext = new RedirectUriValidationContext(redirectUri, request);
+        if (await _uriValidator.IsRedirectUriValidAsync(uriContext) == false)
         {
             LogError("Invalid redirect_uri", redirectUri, request);
             return Invalid(request, OidcConstants.AuthorizeErrors.InvalidRequest, "Invalid redirect_uri");

--- a/src/IdentityServer/Validation/Default/AuthorizeRequestValidator.cs
+++ b/src/IdentityServer/Validation/Default/AuthorizeRequestValidator.cs
@@ -734,7 +734,7 @@ internal class AuthorizeRequestValidator : IAuthorizeRequestValidator
         if (prompt.IsPresent())
         {
             var prompts = prompt.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-            if (prompts.All(p => Constants.SupportedPromptModes.Contains(p)))
+            if (prompts.All(p => _options.UserInteraction.PromptValuesSupported?.Contains(p) == true))
             {
                 if (prompts.Contains(OidcConstants.PromptModes.None) && prompts.Length > 1)
                 {
@@ -746,6 +746,9 @@ internal class AuthorizeRequestValidator : IAuthorizeRequestValidator
             }
             else
             {
+                // TODO: change to error in a major release
+                // https://github.com/DuendeSoftware/IdentityServer/issues/845#issuecomment-1405377531
+                // https://openid.net/specs/openid-connect-prompt-create-1_0.html#name-authorization-request
                 _logger.LogDebug("Unsupported prompt mode - ignored: " + prompt);
             }
         }
@@ -754,7 +757,7 @@ internal class AuthorizeRequestValidator : IAuthorizeRequestValidator
         if (suppressed_prompt.IsPresent())
         {
             var prompts = suppressed_prompt.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-            if (prompts.All(p => Constants.SupportedPromptModes.Contains(p)))
+            if (prompts.All(p => _options.UserInteraction.PromptValuesSupported?.Contains(p) == true))
             {
                 if (prompts.Contains(OidcConstants.PromptModes.None) && prompts.Length > 1)
                 {

--- a/src/IdentityServer/Validation/Default/LicenseValidator.cs
+++ b/src/IdentityServer/Validation/Default/LicenseValidator.cs
@@ -103,7 +103,7 @@ internal class LicenseValidator
 
             if (_options.KeyManagement.Enabled && !_license.KeyManagementFeature)
             {
-                errors.Add("You have automatic key management enabled, but you do not have a valid license for that feature of Duende IdentityServer.");
+                errors.Add("You have automatic key management enabled, but you do not have a valid license for that feature of Duende IdentityServer. Either upgrade your license or disable automatic key management by setting the KeyManagement.Enabled property to false on the IdentityServerOptions.");
             }
         }
 
@@ -161,7 +161,7 @@ internal class LicenseValidator
                 if (_issuers.Count > _license.IssuerLimit)
                 {
                     _errorLog.Invoke(
-                        "Your license for Duende IdentityServer only permits {issuerLimit} number of issuers. You have processed requests for {issuerCount}. The issuers used were: {issuers}.",
+                        "Your license for Duende IdentityServer only permits {issuerLimit} number of issuers. You have processed requests for {issuerCount}. The issuers used were: {issuers}. This might be due to your server being accessed via different URLs or a direct IP and/or you have reverse proxy or a gateway involved. This suggests a network infrastructure configuration problem, or you are deliberately hosting multiple URLs and require an upgraded license.",
                         new object[] { _license.IssuerLimit, _issuers.Count, _issuers.Keys.ToArray() });
                 }
             }

--- a/src/IdentityServer/Validation/Default/PrivateKeyJwtSecretValidator.cs
+++ b/src/IdentityServer/Validation/Default/PrivateKeyJwtSecretValidator.cs
@@ -92,9 +92,13 @@ public class PrivateKeyJwtSecretValidator : ISecretValidator
         {
             // token endpoint URL
             string.Concat(_urls.BaseUrl.EnsureTrailingSlash(), Constants.ProtocolRoutePaths.Token),
-            // TODO: remove the issuer URL in a future major release?
+            // issuer URL + token (legacy support)
+            string.Concat((await _issuerNameService.GetCurrentAsync()).EnsureTrailingSlash(), Constants.ProtocolRoutePaths.Token),
             // issuer URL
-            string.Concat((await _issuerNameService.GetCurrentAsync()).EnsureTrailingSlash(), Constants.ProtocolRoutePaths.Token)
+            await _issuerNameService.GetCurrentAsync(),
+            // CIBA endpoint: https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html#auth_request
+            string.Concat(_urls.BaseUrl.EnsureTrailingSlash(), Constants.ProtocolRoutePaths.BackchannelAuthentication),
+            // TODO: PAR once added
         }.Distinct();
 
         var tokenValidationParameters = new TokenValidationParameters

--- a/src/IdentityServer/Validation/IRedirectUriValidator.cs
+++ b/src/IdentityServer/Validation/IRedirectUriValidator.cs
@@ -1,8 +1,11 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 
 using Duende.IdentityServer.Models;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Security.Claims;
 using System.Threading.Tasks;
 
 namespace Duende.IdentityServer.Validation;
@@ -19,7 +22,12 @@ public interface IRedirectUriValidator
     /// <param name="client">The client.</param>
     /// <returns><c>true</c> is the URI is valid; <c>false</c> otherwise.</returns>
     Task<bool> IsRedirectUriValidAsync(string requestedUri, Client client);
-        
+
+    /// <summary>
+    /// Determines whether a redirect URI is valid for a client.
+    /// </summary>
+    Task<bool> IsRedirectUriValidAsync(RedirectUriValidationContext context) => IsRedirectUriValidAsync(context.RequestedUri, context.Client);
+
     /// <summary>
     /// Determines whether a post logout URI is valid for a client.
     /// </summary>
@@ -27,4 +35,48 @@ public interface IRedirectUriValidator
     /// <param name="client">The client.</param>
     /// <returns><c>true</c> is the URI is valid; <c>false</c> otherwise.</returns>
     Task<bool> IsPostLogoutRedirectUriValidAsync(string requestedUri, Client client);
+}
+
+/// <summary>
+/// Models the context for validating a client's redirect URI
+/// </summary>
+public class RedirectUriValidationContext
+{
+    /// <summary>
+    /// Default ctor
+    /// </summary>
+    public RedirectUriValidationContext()
+    {
+    }
+
+    /// <summary>
+    /// ctor
+    /// </summary>
+    public RedirectUriValidationContext(string redirectUri, ValidatedAuthorizeRequest request)
+    {
+        RequestedUri = redirectUri;
+        Client = request.Client;
+        RequestParameters = request.Raw;
+        RequestObjectValues = request.RequestObjectValues;
+    }
+
+    /// <summary>
+    /// The URI to validate for the client
+    /// </summary>
+    public string RequestedUri { get; set; }
+
+    /// <summary>
+    /// The client
+    /// </summary>
+    public Client Client { get; set; }
+
+    /// <summary>
+    /// Gets or sets the request parameters
+    /// </summary>
+    public NameValueCollection RequestParameters { get; set; }
+
+    /// <summary>
+    /// Validated request object values
+    /// </summary>
+    public IEnumerable<Claim> RequestObjectValues { get; set; }
 }

--- a/test/IdentityServer.IntegrationTests/Endpoints/Authorize/AuthorizeTests.cs
+++ b/test/IdentityServer.IntegrationTests/Endpoints/Authorize/AuthorizeTests.cs
@@ -1285,6 +1285,48 @@ public class AuthorizeTests
         response.Headers.Location.ToString().Should().Contain("id_token=");
     }
 
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task prompt_create_should_show_login_page_and_preserve_prompt_values()
+    {
+        await _mockPipeline.LoginAsync("bob");
+
+        var url = _mockPipeline.CreateAuthorizeUrl(
+            clientId: "client3",
+            responseType: "id_token",
+            scope: "openid profile",
+            redirectUri: "https://client3/callback",
+            state: "123_state",
+            nonce: "123_nonce",
+            extra: new { prompt = "create" }
+        );
+        var response = await _mockPipeline.BrowserClient.GetAsync(url);
+
+        _mockPipeline.LoginWasCalled.Should().BeTrue();
+        _mockPipeline.LoginRequest.PromptModes.Should().Contain("create");
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task prompt_create_and_login_should_show_login_page_and_preserve_prompt_values()
+    {
+        await _mockPipeline.LoginAsync("bob");
+
+        var url = _mockPipeline.CreateAuthorizeUrl(
+            clientId: "client3",
+            responseType: "id_token",
+            scope: "openid profile",
+            redirectUri: "https://client3/callback",
+            state: "123_state",
+            nonce: "123_nonce",
+            extra: new { prompt = "create login" }
+        );
+        var response = await _mockPipeline.BrowserClient.GetAsync(url);
+
+        _mockPipeline.LoginWasCalled.Should().BeTrue();
+        _mockPipeline.LoginRequest.PromptModes.Should().BeEquivalentTo(new[] { "create", "login" });
+    }
+
 
     [Theory]
     [InlineData((Type) null)]

--- a/test/IdentityServer.IntegrationTests/Endpoints/EndSession/EndSessionTests.cs
+++ b/test/IdentityServer.IntegrationTests/Endpoints/EndSession/EndSessionTests.cs
@@ -595,4 +595,77 @@ public class EndSessionTests
 
         _mockPipeline.BackChannelMessageHandler.InvokeWasCalled.Should().BeTrue();
     }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task back_channel_json_errors_can_be_logged()
+    {
+        var resp = new HttpResponseMessage(HttpStatusCode.BadRequest);
+        var json = JsonSerializer.Serialize(new { error = "some_error" });
+        resp.Content = new StringContent(json, Encoding.UTF8, "application/json");
+        _mockPipeline.BackChannelMessageHandler.Response = resp;
+
+        await _mockPipeline.LoginAsync("bob");
+
+        var response = await _mockPipeline.RequestAuthorizationEndpointAsync(
+            clientId: "client3",
+            responseType: "id_token",
+            scope: "openid",
+            redirectUri: "https://client3/callback",
+            state: "123_state",
+            nonce: "123_nonce");
+        response.Should().NotBeNull();
+
+        await _mockPipeline.BrowserClient.GetAsync(IdentityServerPipeline.EndSessionEndpoint);
+
+        _mockPipeline.BackChannelMessageHandler.InvokeWasCalled.Should().BeTrue();
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task back_channel_bad_json_errors_can_be_logged()
+    {
+        var resp = new HttpResponseMessage(HttpStatusCode.BadRequest);
+        var json = "*#U#NFONSLKHND $#KLN#NFM NOT GOOD JSON  @OM><@<><@>@<?>@@";
+        resp.Content = new StringContent(json, Encoding.UTF8, "application/json");
+        _mockPipeline.BackChannelMessageHandler.Response = resp;
+
+        await _mockPipeline.LoginAsync("bob");
+
+        var response = await _mockPipeline.RequestAuthorizationEndpointAsync(
+            clientId: "client3",
+            responseType: "id_token",
+            scope: "openid",
+            redirectUri: "https://client3/callback",
+            state: "123_state",
+            nonce: "123_nonce");
+        response.Should().NotBeNull();
+
+        await _mockPipeline.BrowserClient.GetAsync(IdentityServerPipeline.EndSessionEndpoint);
+
+        _mockPipeline.BackChannelMessageHandler.InvokeWasCalled.Should().BeTrue();
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task back_channel_errors_no_content_can_be_logged()
+    {
+        var resp = new HttpResponseMessage(HttpStatusCode.BadRequest);
+        _mockPipeline.BackChannelMessageHandler.Response = resp;
+
+        await _mockPipeline.LoginAsync("bob");
+
+        var response = await _mockPipeline.RequestAuthorizationEndpointAsync(
+            clientId: "client3",
+            responseType: "id_token",
+            scope: "openid",
+            redirectUri: "https://client3/callback",
+            state: "123_state",
+            nonce: "123_nonce");
+        response.Should().NotBeNull();
+
+        await _mockPipeline.BrowserClient.GetAsync(IdentityServerPipeline.EndSessionEndpoint);
+
+        _mockPipeline.BackChannelMessageHandler.InvokeWasCalled.Should().BeTrue();
+    }
 }

--- a/test/IdentityServer.UnitTests/Extensions/EndpointOptionsExtensionsTests.cs
+++ b/test/IdentityServer.UnitTests/Extensions/EndpointOptionsExtensionsTests.cs
@@ -24,7 +24,7 @@ public class EndpointOptionsExtensionsTests
         Assert.Equal(
             expectedIsEndpointEnabled,
             _options.IsEndpointEnabled(
-                CreateTestEndpoint(Constants.EndpointNames.Authorize)));
+                CreateTestEndpoint(IdentityServerConstants.EndpointNames.Authorize)));
     }
 
     [Theory]
@@ -37,7 +37,7 @@ public class EndpointOptionsExtensionsTests
         Assert.Equal(
             expectedIsEndpointEnabled,
             _options.IsEndpointEnabled(
-                CreateTestEndpoint(Constants.EndpointNames.CheckSession)));
+                CreateTestEndpoint(IdentityServerConstants.EndpointNames.CheckSession)));
     }
 
     [Theory]
@@ -50,7 +50,7 @@ public class EndpointOptionsExtensionsTests
         Assert.Equal(
             expectedIsEndpointEnabled,
             _options.IsEndpointEnabled(
-                CreateTestEndpoint(Constants.EndpointNames.DeviceAuthorization)));
+                CreateTestEndpoint(IdentityServerConstants.EndpointNames.DeviceAuthorization)));
     }
 
     [Theory]
@@ -63,7 +63,7 @@ public class EndpointOptionsExtensionsTests
         Assert.Equal(
             expectedIsEndpointEnabled,
             _options.IsEndpointEnabled(
-                CreateTestEndpoint(Constants.EndpointNames.Discovery)));
+                CreateTestEndpoint(IdentityServerConstants.EndpointNames.Discovery)));
     }
 
     [Theory]
@@ -76,7 +76,7 @@ public class EndpointOptionsExtensionsTests
         Assert.Equal(
             expectedIsEndpointEnabled,
             _options.IsEndpointEnabled(
-                CreateTestEndpoint(Constants.EndpointNames.EndSession)));
+                CreateTestEndpoint(IdentityServerConstants.EndpointNames.EndSession)));
     }
 
     [Theory]
@@ -89,7 +89,7 @@ public class EndpointOptionsExtensionsTests
         Assert.Equal(
             expectedIsEndpointEnabled,
             _options.IsEndpointEnabled(
-                CreateTestEndpoint(Constants.EndpointNames.Introspection)));
+                CreateTestEndpoint(IdentityServerConstants.EndpointNames.Introspection)));
     }
 
     [Theory]
@@ -102,7 +102,7 @@ public class EndpointOptionsExtensionsTests
         Assert.Equal(
             expectedIsEndpointEnabled,
             _options.IsEndpointEnabled(
-                CreateTestEndpoint(Constants.EndpointNames.Token)));
+                CreateTestEndpoint(IdentityServerConstants.EndpointNames.Token)));
     }
 
     [Theory]
@@ -115,7 +115,7 @@ public class EndpointOptionsExtensionsTests
         Assert.Equal(
             expectedIsEndpointEnabled,
             _options.IsEndpointEnabled(
-                CreateTestEndpoint(Constants.EndpointNames.Revocation)));
+                CreateTestEndpoint(IdentityServerConstants.EndpointNames.Revocation)));
     }
 
     [Theory]
@@ -128,7 +128,7 @@ public class EndpointOptionsExtensionsTests
         Assert.Equal(
             expectedIsEndpointEnabled,
             _options.IsEndpointEnabled(
-                CreateTestEndpoint(Constants.EndpointNames.UserInfo)));
+                CreateTestEndpoint(IdentityServerConstants.EndpointNames.UserInfo)));
     }
 
     private Endpoint CreateTestEndpoint(string name)

--- a/test/IdentityServer.UnitTests/Hosting/EndpointRouterTests.cs
+++ b/test/IdentityServer.UnitTests/Hosting/EndpointRouterTests.cs
@@ -96,7 +96,7 @@ public class EndpointRouterTests
     [Fact]
     public void Find_should_return_null_for_disabled_endpoint()
     {
-        _endpoints.Add(new Duende.IdentityServer.Hosting.Endpoint(Constants.EndpointNames.Authorize, "/ep1", typeof(MyEndpointHandler)));
+        _endpoints.Add(new Duende.IdentityServer.Hosting.Endpoint(IdentityServerConstants.EndpointNames.Authorize, "/ep1", typeof(MyEndpointHandler)));
         _endpoints.Add(new Duende.IdentityServer.Hosting.Endpoint("ep2", "/ep2", typeof(MyOtherEndpointHandler)));
 
         _options.Endpoints.EnableAuthorizeEndpoint = false;


### PR DESCRIPTION
This PR adds support for the OIDC prompt=create extension: 

https://openid.net/specs/openid-connect-prompt-create-1_0.html

Closes: https://github.com/DuendeSoftware/IdentityServer/issues/432

Docs needed: New PromptValuesSupported property on the UserInteractionOptions, and how this affects the values in discovery and request processing.