### PR TITLE
Add support for OIDC prompt=create

### DIFF
--- a/clients/src/MvcCode/Startup.cs
+++ b/clients/src/MvcCode/Startup.cs
@@ -12,6 +12,7 @@ using IdentityModel.Client;
 using Microsoft.Extensions.Configuration;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
+using System.Threading.Tasks;
 
 namespace MvcCode
 {
@@ -80,6 +81,12 @@ namespace MvcCode
                     {
                         NameClaimType = JwtClaimTypes.Name,
                         RoleClaimType = JwtClaimTypes.Role,
+                    };
+
+                    options.Events.OnRedirectToIdentityProvider = ctx =>
+                    {
+                        // ctx.ProtocolMessage.Prompt = "create";
+                        return Task.CompletedTask;
                     };
                 });
             

--- a/hosts/main/IdentityServerExtensions.cs
+++ b/hosts/main/IdentityServerExtensions.cs
@@ -25,6 +25,8 @@ internal static class IdentityServerExtensions
                 options.Endpoints.EnableJwtRequestUri = true;
 
                 options.ServerSideSessions.UserDisplayNameClaimType = JwtClaimTypes.Name;
+
+                options.UserInteraction.CreateAccountUrl = "/Account/Create";
             })
             //.AddServerSideSessions()
             .AddInMemoryClients(Clients.Get())

--- a/hosts/main/Pages/Account/Create/Index.cshtml
+++ b/hosts/main/Pages/Account/Create/Index.cshtml
@@ -1,0 +1,32 @@
+@page
+@model IdentityServerHost.Pages.Create.Index
+
+<div class="login-page">
+    <div class="lead">
+        <h1>Create Account</h1>
+    </div>
+
+    <partial name="_ValidationSummary" />
+
+    <div class="row">
+
+        <div class="col-sm-6">
+            <form asp-page="/Account/Create/Index">
+                <input type="hidden" asp-for="Input.ReturnUrl" />
+
+                <div class="form-group">
+                    <label asp-for="Input.Username"></label>
+                    <input class="form-control" placeholder="Username" asp-for="Input.Username" autofocus>
+                </div>
+                <div class="form-group">
+                    <label asp-for="Input.Password"></label>
+                    <input type="password" class="form-control" placeholder="Password" asp-for="Input.Password" autocomplete="off">
+                </div>
+
+                <button class="btn btn-primary" name="Input.Button" value="create">Create</button>
+                <button class="btn btn-secondary" name="Input.Button" value="cancel">Cancel</button>
+            </form>
+        </div>
+        
+    </div>
+</div>

--- a/hosts/main/Pages/Account/Create/Index.cshtml
+++ b/hosts/main/Pages/Account/Create/Index.cshtml
@@ -22,6 +22,14 @@
                     <label asp-for="Input.Password"></label>
                     <input type="password" class="form-control" placeholder="Password" asp-for="Input.Password" autocomplete="off">
                 </div>
+                <div class="form-group">
+                    <label asp-for="Input.Name"></label>
+                    <input type="text" class="form-control" placeholder="Name" asp-for="Input.Name">
+                </div>
+                <div class="form-group">
+                    <label asp-for="Input.Email"></label>
+                    <input type="email" class="form-control" placeholder="Email" asp-for="Input.Email" >
+                </div>
 
                 <button class="btn btn-primary" name="Input.Button" value="create">Create</button>
                 <button class="btn btn-secondary" name="Input.Button" value="cancel">Cancel</button>

--- a/hosts/main/Pages/Account/Create/Index.cshtml.cs
+++ b/hosts/main/Pages/Account/Create/Index.cshtml.cs
@@ -1,0 +1,88 @@
+using Duende.IdentityServer;
+using Duende.IdentityServer.Events;
+using Duende.IdentityServer.Models;
+using Duende.IdentityServer.Services;
+using Duende.IdentityServer.Stores;
+using Duende.IdentityServer.Test;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace IdentityServerHost.Pages.Create;
+
+[SecurityHeaders]
+[AllowAnonymous]
+public class Index : PageModel
+{
+    private readonly TestUserStore _users;
+    private readonly IIdentityServerInteractionService _interaction;
+    private readonly IEventService _events;
+    private readonly IAuthenticationSchemeProvider _schemeProvider;
+    private readonly IIdentityProviderStore _identityProviderStore;
+
+    [BindProperty]
+    public InputModel Input { get; set; }
+        
+    public Index(
+        IIdentityServerInteractionService interaction,
+        IAuthenticationSchemeProvider schemeProvider,
+        IIdentityProviderStore identityProviderStore,
+        IEventService events,
+        TestUserStore users = null)
+    {
+        // this is where you would plug in your own custom identity management library (e.g. ASP.NET Identity)
+        _users = users ?? throw new Exception("Please call 'AddTestUsers(TestUsers.Users)' on the IIdentityServerBuilder in Startup or remove the TestUserStore from the AccountController.");
+            
+        _interaction = interaction;
+        _schemeProvider = schemeProvider;
+        _identityProviderStore = identityProviderStore;
+        _events = events;
+    }
+
+    public IActionResult OnGet(string returnUrl)
+    {
+        Input = new InputModel { ReturnUrl = returnUrl };
+        return Page();
+    }
+        
+    public async Task<IActionResult> OnPost()
+    {
+        // check if we are in the context of an authorization request
+        var context = await _interaction.GetAuthorizationContextAsync(Input.ReturnUrl);
+
+        // the user clicked the "cancel" button
+        if (Input.Button != "create")
+        {
+            if (context != null)
+            {
+                // if the user cancels, send a result back into IdentityServer as if they 
+                // denied the consent (even if this client does not require consent).
+                // this will send back an access denied OIDC error response to the client.
+                await _interaction.DenyAuthorizationAsync(context, AuthorizationError.AccessDenied);
+
+                // we can trust model.ReturnUrl since GetAuthorizationContextAsync returned non-null
+                if (context.IsNativeClient())
+                {
+                    // The client is native, so this change in how to
+                    // return the response is for better UX for the end user.
+                    return this.LoadingPage(Input.ReturnUrl);
+                }
+
+                return Redirect(Input.ReturnUrl);
+            }
+            else
+            {
+                // since we don't have a valid context, then we just go back to the home page
+                return Redirect("~/");
+            }
+        }
+
+        if (ModelState.IsValid)
+        {
+
+        }
+
+        return Page();
+    }
+}

--- a/hosts/main/Pages/Account/Create/InputModel.cs
+++ b/hosts/main/Pages/Account/Create/InputModel.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+using System.ComponentModel.DataAnnotations;
+
+namespace IdentityServerHost.Pages.Create;
+
+public class InputModel
+{
+    [Required]
+    public string Username { get; set; }
+        
+    [Required]
+    public string Password { get; set; }
+        
+    public string ReturnUrl { get; set; }
+
+    public string Button { get; set; }
+}

--- a/hosts/main/Pages/Account/Create/InputModel.cs
+++ b/hosts/main/Pages/Account/Create/InputModel.cs
@@ -10,10 +10,13 @@ public class InputModel
 {
     [Required]
     public string Username { get; set; }
-        
+
     [Required]
     public string Password { get; set; }
-        
+
+    public string Name { get; set; }
+    public string Email { get; set; }
+
     public string ReturnUrl { get; set; }
 
     public string Button { get; set; }

--- a/src/IdentityServer/Configuration/DependencyInjection/Options/UserInteractionOptions.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/Options/UserInteractionOptions.cs
@@ -61,6 +61,22 @@ public class UserInteractionOptions
     public string ConsentReturnUrlParameter { get; set; } = Constants.UIConstants.DefaultRoutePathParams.Consent;
 
     /// <summary>
+    /// Gets or sets the create account (or register) URL, for use with the OIDC prompt parameter. If a local URL, the value must start with a leading slash.
+    /// </summary>
+    /// <value>
+    /// The create account URL.
+    /// </value>
+    public string CreateAccountUrl { get; set; } // null by default to omit support in discovery
+
+    /// <summary>
+    /// Gets or sets the create account (or register) return URL parameter.
+    /// </summary>
+    /// <value>
+    /// The create account return URL parameter.
+    /// </value>
+    public string CreateAccountReturnUrlParameter { get; set; } = Constants.UIConstants.DefaultRoutePathParams.CreateAccount;
+
+    /// <summary>
     /// Gets or sets the error URL. If a local URL, the value must start with a leading slash.
     /// </summary>
     /// <value>
@@ -115,6 +131,7 @@ public class UserInteractionOptions
 
     /// <summary>
     /// The collection of OIDC prompt modes supported and that will be published in discovery.
+    /// The value "create" is omitted unless the CreateAccountUrl value is set.
     /// </summary>
-    public ICollection<string> PromptValuesSupported { get; set; } = new HashSet<string>(Constants.SupportedPromptModes);
+    internal ICollection<string> PromptValuesSupported { get; set; } = new HashSet<string>(Constants.SupportedPromptModes);
 }

--- a/src/IdentityServer/Configuration/DependencyInjection/Options/UserInteractionOptions.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/Options/UserInteractionOptions.cs
@@ -3,6 +3,7 @@
 
 
 using Duende.IdentityServer.Extensions;
+using System.Collections.Generic;
 
 namespace Duende.IdentityServer.Configuration;
 
@@ -111,4 +112,9 @@ public class UserInteractionOptions
     /// Flag that allows return URL validation to accept full URL that includes the IdentityServer origin. Defaults to false.
     /// </summary>
     public bool AllowOriginInReturnUrl { get; set; }
+
+    /// <summary>
+    /// The collection of OIDC prompt modes supported and that will be published in discovery.
+    /// </summary>
+    public ICollection<string> PromptValuesSupported { get; set; } = new HashSet<string>(Constants.SupportedPromptModes);
 }

--- a/src/IdentityServer/Configuration/IdentityServerApplicationBuilderExtensions.cs
+++ b/src/IdentityServer/Configuration/IdentityServerApplicationBuilderExtensions.cs
@@ -8,6 +8,7 @@ using Duende.IdentityServer.Hosting;
 using Duende.IdentityServer.Hosting.DynamicProviders;
 using Duende.IdentityServer.Stores;
 using Duende.IdentityServer.Validation;
+using IdentityModel;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -131,16 +132,23 @@ public static class IdentityServerApplicationBuilderExtensions
     {
         if (options.IssuerUri.IsPresent()) logger.LogDebug("Custom IssuerUri set to {0}", options.IssuerUri);
             
-        // todo: perhaps different logging messages?
+        // these three are dynamically populated later from the cookie handler options
         //if (options.UserInteraction.LoginUrl.IsMissing()) throw new InvalidOperationException("LoginUrl is not configured");
         //if (options.UserInteraction.LoginReturnUrlParameter.IsMissing()) throw new InvalidOperationException("LoginReturnUrlParameter is not configured");
         //if (options.UserInteraction.LogoutUrl.IsMissing()) throw new InvalidOperationException("LogoutUrl is not configured");
+
         if (options.UserInteraction.LogoutIdParameter.IsMissing()) throw new InvalidOperationException("LogoutIdParameter is not configured");
         if (options.UserInteraction.ErrorUrl.IsMissing()) throw new InvalidOperationException("ErrorUrl is not configured");
         if (options.UserInteraction.ErrorIdParameter.IsMissing()) throw new InvalidOperationException("ErrorIdParameter is not configured");
         if (options.UserInteraction.ConsentUrl.IsMissing()) throw new InvalidOperationException("ConsentUrl is not configured");
         if (options.UserInteraction.ConsentReturnUrlParameter.IsMissing()) throw new InvalidOperationException("ConsentReturnUrlParameter is not configured");
         if (options.UserInteraction.CustomRedirectReturnUrlParameter.IsMissing()) throw new InvalidOperationException("CustomRedirectReturnUrlParameter is not configured");
+        if (options.UserInteraction.CreateAccountUrl.IsPresent())
+        {
+            if (options.UserInteraction.CreateAccountReturnUrlParameter.IsMissing()) throw new InvalidOperationException("CreateAccountReturnUrlParameter is not configured");
+            // if CreateAccountUrl is set, then we internally add to the collection of what we support
+            options.UserInteraction.PromptValuesSupported.Add(OidcConstants.PromptModes.Create);
+        }
 
         if (options.Authentication.CheckSessionCookieName.IsMissing()) throw new InvalidOperationException("CheckSessionCookieName is not configured");
 

--- a/src/IdentityServer/Constants.cs
+++ b/src/IdentityServer/Constants.cs
@@ -110,7 +110,8 @@ internal static class Constants
         OidcConstants.PromptModes.None,
         OidcConstants.PromptModes.Login,
         OidcConstants.PromptModes.Consent,
-        OidcConstants.PromptModes.SelectAccount
+        OidcConstants.PromptModes.SelectAccount,
+        OidcConstants.PromptModes.Create,
     };
 
     public const string SuppressedPrompt = "suppressed_" + OidcConstants.AuthorizeRequest.Prompt;

--- a/src/IdentityServer/Constants.cs
+++ b/src/IdentityServer/Constants.cs
@@ -111,7 +111,8 @@ internal static class Constants
         OidcConstants.PromptModes.Login,
         OidcConstants.PromptModes.Consent,
         OidcConstants.PromptModes.SelectAccount,
-        OidcConstants.PromptModes.Create,
+        // Create not in here by default -- it's added if customer sets the CreateAccountUrl user interaction option
+        //OidcConstants.PromptModes.Create, 
     };
 
     public const string SuppressedPrompt = "suppressed_" + OidcConstants.AuthorizeRequest.Prompt;
@@ -181,6 +182,7 @@ internal static class Constants
             public const string Error = "errorId";
             public const string Login = "returnUrl";
             public const string Consent = "returnUrl";
+            public const string CreateAccount = "returnUrl";
             public const string Logout = "logoutId";
             public const string EndSessionCallback = "endSessionId";
             public const string Custom = "returnUrl";

--- a/src/IdentityServer/Endpoints/AuthorizeEndpointBase.cs
+++ b/src/IdentityServer/Endpoints/AuthorizeEndpointBase.cs
@@ -124,15 +124,19 @@ internal abstract class AuthorizeEndpointBase : IEndpointHandler
             }
             if (interactionResult.IsLogin)
             {
-                return new LoginPageResult(request);
+                return new LoginPageResult(request, _options);
             }
             if (interactionResult.IsConsent)
             {
-                return new ConsentPageResult(request);
+                return new ConsentPageResult(request, _options);
             }
             if (interactionResult.IsRedirect)
             {
-                return new CustomRedirectResult(request, interactionResult.RedirectUrl);
+                return new CustomRedirectResult(request, interactionResult.RedirectUrl, _options);
+            }
+            if (interactionResult.IsCreateAccount)
+            {
+                return new CreateAccountPageResult(request, _options);
             }
 
             var response = await _authorizeResponseGenerator.CreateResponseAsync(request);

--- a/src/IdentityServer/Endpoints/AuthorizeEndpointBase.cs
+++ b/src/IdentityServer/Endpoints/AuthorizeEndpointBase.cs
@@ -118,25 +118,29 @@ internal abstract class AuthorizeEndpointBase : IEndpointHandler
 
             // determine user interaction
             var interactionResult = await _interactionGenerator.ProcessInteractionAsync(request, consent?.Data);
-            if (interactionResult.IsError)
+            if (interactionResult.ResponseType == InteractionResponseType.Error)
             {
                 return await CreateErrorResultAsync("Interaction generator error", request, interactionResult.Error, interactionResult.ErrorDescription, false);
             }
-            if (interactionResult.IsLogin)
+            
+            if (interactionResult.ResponseType == InteractionResponseType.UserInteraction)
             {
-                return new LoginPageResult(request, _options);
-            }
-            if (interactionResult.IsConsent)
-            {
-                return new ConsentPageResult(request, _options);
-            }
-            if (interactionResult.IsRedirect)
-            {
-                return new CustomRedirectResult(request, interactionResult.RedirectUrl, _options);
-            }
-            if (interactionResult.IsCreateAccount)
-            {
-                return new CreateAccountPageResult(request, _options);
+                if (interactionResult.IsLogin)
+                {
+                    return new LoginPageResult(request, _options);
+                }
+                if (interactionResult.IsConsent)
+                {
+                    return new ConsentPageResult(request, _options);
+                }
+                if (interactionResult.IsRedirect)
+                {
+                    return new CustomRedirectResult(request, interactionResult.RedirectUrl, _options);
+                }
+                if (interactionResult.IsCreateAccount)
+                {
+                    return new CreateAccountPageResult(request, _options);
+                }
             }
 
             var response = await _authorizeResponseGenerator.CreateResponseAsync(request);

--- a/src/IdentityServer/Endpoints/Results/AuthorizeInteractionPageResult.cs
+++ b/src/IdentityServer/Endpoints/Results/AuthorizeInteractionPageResult.cs
@@ -20,20 +20,20 @@ namespace Duende.IdentityServer.Endpoints.Results;
 /// Result for an interactive page
 /// </summary>
 /// <seealso cref="IEndpointResult" />
-public abstract class InteractivePageResult : IEndpointResult
+public abstract class AuthorizeInteractionPageResult : IEndpointResult
 {
     private readonly ValidatedAuthorizeRequest _request;
     private string _redirectUrl;
     private string _returnUrlParameterName;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="InteractivePageResult"/> class.
+    /// Initializes a new instance of the <see cref="AuthorizeInteractionPageResult"/> class.
     /// </summary>
     /// <param name="request">The request.</param>
     /// <param name="redirectUrl"></param>
     /// <param name="returnUrlParameterName"></param>
     /// <exception cref="System.ArgumentNullException">request</exception>
-    public InteractivePageResult(ValidatedAuthorizeRequest request, string redirectUrl, string returnUrlParameterName)
+    public AuthorizeInteractionPageResult(ValidatedAuthorizeRequest request, string redirectUrl, string returnUrlParameterName)
     {
         _request = request ?? throw new ArgumentNullException(nameof(request));
         _redirectUrl = redirectUrl ?? throw new ArgumentNullException(nameof(redirectUrl));

--- a/src/IdentityServer/Endpoints/Results/ConsentPageResult.cs
+++ b/src/IdentityServer/Endpoints/Results/ConsentPageResult.cs
@@ -10,7 +10,7 @@ namespace Duende.IdentityServer.Endpoints.Results;
 /// <summary>
 /// Result for consent page
 /// </summary>
-public class ConsentPageResult : InteractivePageResult
+public class ConsentPageResult : AuthorizeInteractionPageResult
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="ConsentPageResult"/> class.

--- a/src/IdentityServer/Endpoints/Results/ConsentPageResult.cs
+++ b/src/IdentityServer/Endpoints/Results/ConsentPageResult.cs
@@ -3,8 +3,6 @@
 
 
 using Duende.IdentityServer.Configuration;
-using Duende.IdentityServer.Services;
-using Duende.IdentityServer.Stores;
 using Duende.IdentityServer.Validation;
 
 namespace Duende.IdentityServer.Endpoints.Results;
@@ -22,15 +20,6 @@ public class ConsentPageResult : InteractivePageResult
     /// <exception cref="System.ArgumentNullException">request</exception>
     public ConsentPageResult(ValidatedAuthorizeRequest request, IdentityServerOptions options)
         : base(request, options.UserInteraction.ConsentUrl, options.UserInteraction.ConsentReturnUrlParameter)
-    {
-    }
-
-    internal ConsentPageResult(
-        ValidatedAuthorizeRequest request,
-        IdentityServerOptions options,
-        IServerUrls urls,
-        IAuthorizationParametersMessageStore authorizationParametersMessageStore = null) 
-        : base(request, options.UserInteraction.ConsentUrl, options.UserInteraction.ConsentReturnUrlParameter, urls, authorizationParametersMessageStore)
     {
     }
 }

--- a/src/IdentityServer/Endpoints/Results/CreateAccountPageResult.cs
+++ b/src/IdentityServer/Endpoints/Results/CreateAccountPageResult.cs
@@ -10,27 +10,27 @@ using Duende.IdentityServer.Validation;
 namespace Duende.IdentityServer.Endpoints.Results;
 
 /// <summary>
-/// Result for consent page
+/// Result for create account page
 /// </summary>
-public class ConsentPageResult : InteractivePageResult
+public class CreateAccountPageResult : InteractivePageResult
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="ConsentPageResult"/> class.
+    /// Initializes a new instance of the <see cref="CreateAccountPageResult"/> class.
     /// </summary>
     /// <param name="request">The request.</param>
     /// <param name="options"></param>
     /// <exception cref="System.ArgumentNullException">request</exception>
-    public ConsentPageResult(ValidatedAuthorizeRequest request, IdentityServerOptions options)
-        : base(request, options.UserInteraction.ConsentUrl, options.UserInteraction.ConsentReturnUrlParameter)
+    public CreateAccountPageResult(ValidatedAuthorizeRequest request, IdentityServerOptions options) 
+        : base(request, options.UserInteraction.CreateAccountUrl, options.UserInteraction.CreateAccountReturnUrlParameter)
     {
     }
 
-    internal ConsentPageResult(
+    internal CreateAccountPageResult(
         ValidatedAuthorizeRequest request,
         IdentityServerOptions options,
         IServerUrls urls,
         IAuthorizationParametersMessageStore authorizationParametersMessageStore = null) 
-        : base(request, options.UserInteraction.ConsentUrl, options.UserInteraction.ConsentReturnUrlParameter, urls, authorizationParametersMessageStore)
+        : base(request, options.UserInteraction.CreateAccountUrl, options.UserInteraction.CreateAccountReturnUrlParameter, urls, authorizationParametersMessageStore)
     {
     }
 }

--- a/src/IdentityServer/Endpoints/Results/CreateAccountPageResult.cs
+++ b/src/IdentityServer/Endpoints/Results/CreateAccountPageResult.cs
@@ -10,7 +10,7 @@ namespace Duende.IdentityServer.Endpoints.Results;
 /// <summary>
 /// Result for create account page
 /// </summary>
-public class CreateAccountPageResult : InteractivePageResult
+public class CreateAccountPageResult : AuthorizeInteractionPageResult
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="CreateAccountPageResult"/> class.

--- a/src/IdentityServer/Endpoints/Results/CreateAccountPageResult.cs
+++ b/src/IdentityServer/Endpoints/Results/CreateAccountPageResult.cs
@@ -3,8 +3,6 @@
 
 
 using Duende.IdentityServer.Configuration;
-using Duende.IdentityServer.Services;
-using Duende.IdentityServer.Stores;
 using Duende.IdentityServer.Validation;
 
 namespace Duende.IdentityServer.Endpoints.Results;
@@ -22,15 +20,6 @@ public class CreateAccountPageResult : InteractivePageResult
     /// <exception cref="System.ArgumentNullException">request</exception>
     public CreateAccountPageResult(ValidatedAuthorizeRequest request, IdentityServerOptions options) 
         : base(request, options.UserInteraction.CreateAccountUrl, options.UserInteraction.CreateAccountReturnUrlParameter)
-    {
-    }
-
-    internal CreateAccountPageResult(
-        ValidatedAuthorizeRequest request,
-        IdentityServerOptions options,
-        IServerUrls urls,
-        IAuthorizationParametersMessageStore authorizationParametersMessageStore = null) 
-        : base(request, options.UserInteraction.CreateAccountUrl, options.UserInteraction.CreateAccountReturnUrlParameter, urls, authorizationParametersMessageStore)
     {
     }
 }

--- a/src/IdentityServer/Endpoints/Results/CustomRedirectResult.cs
+++ b/src/IdentityServer/Endpoints/Results/CustomRedirectResult.cs
@@ -3,8 +3,6 @@
 
 
 using Duende.IdentityServer.Configuration;
-using Duende.IdentityServer.Services;
-using Duende.IdentityServer.Stores;
 using Duende.IdentityServer.Validation;
 
 namespace Duende.IdentityServer.Endpoints.Results;
@@ -27,16 +25,6 @@ public class CustomRedirectResult : InteractivePageResult
     /// </exception>
     public CustomRedirectResult(ValidatedAuthorizeRequest request, string url, IdentityServerOptions options)
         : base(request, url, options.UserInteraction.CustomRedirectReturnUrlParameter)
-    {
-    }
-
-    internal CustomRedirectResult(
-        ValidatedAuthorizeRequest request,
-        string url,
-        IdentityServerOptions options,
-        IServerUrls urls,
-        IAuthorizationParametersMessageStore authorizationParametersMessageStore = null) 
-        : base(request, url, options.UserInteraction.CustomRedirectReturnUrlParameter, urls, authorizationParametersMessageStore)
     {
     }
 }

--- a/src/IdentityServer/Endpoints/Results/CustomRedirectResult.cs
+++ b/src/IdentityServer/Endpoints/Results/CustomRedirectResult.cs
@@ -2,47 +2,32 @@
 // See LICENSE in the project root for license information.
 
 
-using System;
-using System.Threading.Tasks;
 using Duende.IdentityServer.Configuration;
-using Duende.IdentityServer.Hosting;
-using Duende.IdentityServer.Validation;
-using Microsoft.AspNetCore.Http;
-using Duende.IdentityServer.Extensions;
-using Microsoft.Extensions.DependencyInjection;
-using Duende.IdentityServer.Stores;
-using Duende.IdentityServer.Models;
-using System.Collections.Generic;
 using Duende.IdentityServer.Services;
+using Duende.IdentityServer.Stores;
+using Duende.IdentityServer.Validation;
 
 namespace Duende.IdentityServer.Endpoints.Results;
 
 /// <summary>
 /// Result for a custom redirect
 /// </summary>
-/// <seealso cref="IEndpointResult" />
-public class CustomRedirectResult : IEndpointResult
+public class CustomRedirectResult : InteractivePageResult
 {
-    private readonly ValidatedAuthorizeRequest _request;
-    private readonly string _url;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="CustomRedirectResult"/> class.
     /// </summary>
     /// <param name="request">The request.</param>
     /// <param name="url">The URL.</param>
+    /// <param name="options"></param>
     /// <exception cref="System.ArgumentNullException">
     /// request
     /// or
     /// url
     /// </exception>
-    public CustomRedirectResult(ValidatedAuthorizeRequest request, string url)
+    public CustomRedirectResult(ValidatedAuthorizeRequest request, string url, IdentityServerOptions options)
+        : base(request, url, options.UserInteraction.CustomRedirectReturnUrlParameter)
     {
-        if (request == null) throw new ArgumentNullException(nameof(request));
-        if (url.IsMissing()) throw new ArgumentNullException(nameof(url));
-
-        _request = request;
-        _url = url;
     }
 
     internal CustomRedirectResult(
@@ -51,54 +36,7 @@ public class CustomRedirectResult : IEndpointResult
         IdentityServerOptions options,
         IServerUrls urls,
         IAuthorizationParametersMessageStore authorizationParametersMessageStore = null) 
-        : this(request, url)
+        : base(request, url, options.UserInteraction.CustomRedirectReturnUrlParameter, urls, authorizationParametersMessageStore)
     {
-        _options = options;
-        _urls = urls;
-        _authorizationParametersMessageStore = authorizationParametersMessageStore;
-    }
-
-    private IdentityServerOptions _options;
-    private IServerUrls _urls;
-    private IAuthorizationParametersMessageStore _authorizationParametersMessageStore;
-
-    private void Init(HttpContext context)
-    {
-        _options = _options ?? context.RequestServices.GetRequiredService<IdentityServerOptions>();
-        _urls = _urls ?? context.RequestServices.GetRequiredService<IServerUrls>();
-        _authorizationParametersMessageStore = _authorizationParametersMessageStore ?? context.RequestServices.GetService<IAuthorizationParametersMessageStore>();
-    }
-
-    /// <summary>
-    /// Executes the result.
-    /// </summary>
-    /// <param name="context">The HTTP context.</param>
-    /// <returns></returns>
-    public async Task ExecuteAsync(HttpContext context)
-    {
-        Init(context);
-
-        var returnUrl = _urls.BasePath.EnsureTrailingSlash() + Constants.ProtocolRoutePaths.AuthorizeCallback;
-
-        if (_authorizationParametersMessageStore != null)
-        {
-            var msg = new Message<IDictionary<string, string[]>>(_request.ToOptimizedFullDictionary());
-            var id = await _authorizationParametersMessageStore.WriteAsync(msg);
-            returnUrl = returnUrl.AddQueryString(Constants.AuthorizationParamsStore.MessageStoreIdParameterName, id);
-        }
-        else
-        {
-            returnUrl = returnUrl.AddQueryString(_request.ToOptimizedQueryString());
-        }
-
-        if (!_url.IsLocalUrl())
-        {
-            // this converts the relative redirect path to an absolute one if we're 
-            // redirecting to a different server
-            returnUrl = _urls.Origin + returnUrl;
-        }
-
-        var url = _url.AddQueryString(_options.UserInteraction.CustomRedirectReturnUrlParameter, returnUrl);
-        context.Response.Redirect(_urls.GetAbsoluteUrl(url));
     }
 }

--- a/src/IdentityServer/Endpoints/Results/CustomRedirectResult.cs
+++ b/src/IdentityServer/Endpoints/Results/CustomRedirectResult.cs
@@ -10,7 +10,7 @@ namespace Duende.IdentityServer.Endpoints.Results;
 /// <summary>
 /// Result for a custom redirect
 /// </summary>
-public class CustomRedirectResult : InteractivePageResult
+public class CustomRedirectResult : AuthorizeInteractionPageResult
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="CustomRedirectResult"/> class.

--- a/src/IdentityServer/Endpoints/Results/InteractivePageResult.cs
+++ b/src/IdentityServer/Endpoints/Results/InteractivePageResult.cs
@@ -23,8 +23,8 @@ namespace Duende.IdentityServer.Endpoints.Results;
 public abstract class InteractivePageResult : IEndpointResult
 {
     private readonly ValidatedAuthorizeRequest _request;
-    private string _redirectUrl { get; set; }
-    private string _returnUrlParameterName { get; set; }
+    private string _redirectUrl;
+    private string _returnUrlParameterName;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="InteractivePageResult"/> class.
@@ -40,24 +40,13 @@ public abstract class InteractivePageResult : IEndpointResult
         _returnUrlParameterName = returnUrlParameterName ?? throw new ArgumentNullException(nameof(returnUrlParameterName));
     }
 
-    internal InteractivePageResult(
-        ValidatedAuthorizeRequest request,
-        string redirectUrl, string returnUrlParameterName,
-        IServerUrls urls,
-        IAuthorizationParametersMessageStore authorizationParametersMessageStore = null) 
-        : this(request, redirectUrl, returnUrlParameterName)
-    {
-        _urls = urls;
-        _authorizationParametersMessageStore = authorizationParametersMessageStore;
-    }
-
     private IServerUrls _urls;
     private IAuthorizationParametersMessageStore _authorizationParametersMessageStore;
 
     private void Init(HttpContext context)
     {
-        _urls = _urls ?? context.RequestServices.GetRequiredService<IServerUrls>();
-        _authorizationParametersMessageStore = _authorizationParametersMessageStore ?? context.RequestServices.GetService<IAuthorizationParametersMessageStore>();
+        _urls = context.RequestServices.GetRequiredService<IServerUrls>();
+        _authorizationParametersMessageStore = context.RequestServices.GetService<IAuthorizationParametersMessageStore>();
     }
 
     /// <summary>

--- a/src/IdentityServer/Endpoints/Results/InteractivePageResult.cs
+++ b/src/IdentityServer/Endpoints/Results/InteractivePageResult.cs
@@ -1,0 +1,96 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Duende.IdentityServer.Hosting;
+using Duende.IdentityServer.Models;
+using Duende.IdentityServer.Stores;
+using Duende.IdentityServer.Validation;
+using Microsoft.AspNetCore.Http;
+using Duende.IdentityServer.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Duende.IdentityServer.Services;
+
+namespace Duende.IdentityServer.Endpoints.Results;
+
+/// <summary>
+/// Result for an interactive page
+/// </summary>
+/// <seealso cref="IEndpointResult" />
+public abstract class InteractivePageResult : IEndpointResult
+{
+    private readonly ValidatedAuthorizeRequest _request;
+    private string _redirectUrl { get; set; }
+    private string _returnUrlParameterName { get; set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InteractivePageResult"/> class.
+    /// </summary>
+    /// <param name="request">The request.</param>
+    /// <param name="redirectUrl"></param>
+    /// <param name="returnUrlParameterName"></param>
+    /// <exception cref="System.ArgumentNullException">request</exception>
+    public InteractivePageResult(ValidatedAuthorizeRequest request, string redirectUrl, string returnUrlParameterName)
+    {
+        _request = request ?? throw new ArgumentNullException(nameof(request));
+        _redirectUrl = redirectUrl ?? throw new ArgumentNullException(nameof(redirectUrl));
+        _returnUrlParameterName = returnUrlParameterName ?? throw new ArgumentNullException(nameof(returnUrlParameterName));
+    }
+
+    internal InteractivePageResult(
+        ValidatedAuthorizeRequest request,
+        string redirectUrl, string returnUrlParameterName,
+        IServerUrls urls,
+        IAuthorizationParametersMessageStore authorizationParametersMessageStore = null) 
+        : this(request, redirectUrl, returnUrlParameterName)
+    {
+        _urls = urls;
+        _authorizationParametersMessageStore = authorizationParametersMessageStore;
+    }
+
+    private IServerUrls _urls;
+    private IAuthorizationParametersMessageStore _authorizationParametersMessageStore;
+
+    private void Init(HttpContext context)
+    {
+        _urls = _urls ?? context.RequestServices.GetRequiredService<IServerUrls>();
+        _authorizationParametersMessageStore = _authorizationParametersMessageStore ?? context.RequestServices.GetService<IAuthorizationParametersMessageStore>();
+    }
+
+    /// <summary>
+    /// Executes the result.
+    /// </summary>
+    /// <param name="context">The HTTP context.</param>
+    /// <returns></returns>
+    public async Task ExecuteAsync(HttpContext context)
+    {
+        Init(context);
+
+        var returnUrl = _urls.BasePath.EnsureTrailingSlash() + Constants.ProtocolRoutePaths.AuthorizeCallback;
+
+        if (_authorizationParametersMessageStore != null)
+        {
+            var msg = new Message<IDictionary<string, string[]>>(_request.ToOptimizedFullDictionary());
+            var id = await _authorizationParametersMessageStore.WriteAsync(msg);
+            returnUrl = returnUrl.AddQueryString(Constants.AuthorizationParamsStore.MessageStoreIdParameterName, id);
+        }
+        else
+        {
+            returnUrl = returnUrl.AddQueryString(_request.ToOptimizedQueryString());
+        }
+
+        var url = _redirectUrl;
+        if (!url.IsLocalUrl())
+        {
+            // this converts the relative redirect path to an absolute one if we're 
+            // redirecting to a different server
+            returnUrl = _urls.Origin + returnUrl;
+        }
+
+        url = url.AddQueryString(_returnUrlParameterName, returnUrl);
+        context.Response.Redirect(_urls.GetAbsoluteUrl(url));
+    }
+}

--- a/src/IdentityServer/Endpoints/Results/LoginPageResult.cs
+++ b/src/IdentityServer/Endpoints/Results/LoginPageResult.cs
@@ -3,8 +3,6 @@
 
 
 using Duende.IdentityServer.Configuration;
-using Duende.IdentityServer.Services;
-using Duende.IdentityServer.Stores;
 using Duende.IdentityServer.Validation;
 
 namespace Duende.IdentityServer.Endpoints.Results;
@@ -22,15 +20,6 @@ public class LoginPageResult : InteractivePageResult
     /// <exception cref="System.ArgumentNullException">request</exception>
     public LoginPageResult(ValidatedAuthorizeRequest request, IdentityServerOptions options) 
         : base(request, options.UserInteraction.LoginUrl, options.UserInteraction.LoginReturnUrlParameter)
-    {
-    }
-
-    internal LoginPageResult(
-        ValidatedAuthorizeRequest request,
-        IdentityServerOptions options,
-        IServerUrls urls,
-        IAuthorizationParametersMessageStore authorizationParametersMessageStore = null) 
-        : base(request, options.UserInteraction.LoginUrl, options.UserInteraction.LoginReturnUrlParameter, urls, authorizationParametersMessageStore)
     {
     }
 }

--- a/src/IdentityServer/Endpoints/Results/LoginPageResult.cs
+++ b/src/IdentityServer/Endpoints/Results/LoginPageResult.cs
@@ -2,37 +2,27 @@
 // See LICENSE in the project root for license information.
 
 
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using Duende.IdentityServer.Configuration;
-using Duende.IdentityServer.Hosting;
-using Duende.IdentityServer.Models;
+using Duende.IdentityServer.Services;
 using Duende.IdentityServer.Stores;
 using Duende.IdentityServer.Validation;
-using Microsoft.AspNetCore.Http;
-using Duende.IdentityServer.Extensions;
-using Microsoft.Extensions.DependencyInjection;
-using Duende.IdentityServer.Services;
 
 namespace Duende.IdentityServer.Endpoints.Results;
 
 /// <summary>
 /// Result for login page
 /// </summary>
-/// <seealso cref="IEndpointResult" />
-public class LoginPageResult : IEndpointResult
+public class LoginPageResult : InteractivePageResult
 {
-    private readonly ValidatedAuthorizeRequest _request;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="LoginPageResult"/> class.
     /// </summary>
     /// <param name="request">The request.</param>
+    /// <param name="options"></param>
     /// <exception cref="System.ArgumentNullException">request</exception>
-    public LoginPageResult(ValidatedAuthorizeRequest request)
+    public LoginPageResult(ValidatedAuthorizeRequest request, IdentityServerOptions options) 
+        : base(request, options.UserInteraction.LoginUrl, options.UserInteraction.LoginReturnUrlParameter)
     {
-        _request = request ?? throw new ArgumentNullException(nameof(request));
     }
 
     internal LoginPageResult(
@@ -40,54 +30,7 @@ public class LoginPageResult : IEndpointResult
         IdentityServerOptions options,
         IServerUrls urls,
         IAuthorizationParametersMessageStore authorizationParametersMessageStore = null) 
-        : this(request)
+        : base(request, options.UserInteraction.LoginUrl, options.UserInteraction.LoginReturnUrlParameter, urls, authorizationParametersMessageStore)
     {
-        _options = options;
-        _urls = urls;
-        _authorizationParametersMessageStore = authorizationParametersMessageStore;
-    }
-
-    private IdentityServerOptions _options;
-    private IServerUrls _urls;
-    private IAuthorizationParametersMessageStore _authorizationParametersMessageStore;
-
-    private void Init(HttpContext context)
-    {
-        _options = _options ?? context.RequestServices.GetRequiredService<IdentityServerOptions>();
-        _urls = _urls ?? context.RequestServices.GetRequiredService<IServerUrls>();
-        _authorizationParametersMessageStore = _authorizationParametersMessageStore ?? context.RequestServices.GetService<IAuthorizationParametersMessageStore>();
-    }
-
-    /// <summary>
-    /// Executes the result.
-    /// </summary>
-    /// <param name="context">The HTTP context.</param>
-    /// <returns></returns>
-    public async Task ExecuteAsync(HttpContext context)
-    {
-        Init(context);
-
-        var returnUrl = _urls.BasePath.EnsureTrailingSlash() + Constants.ProtocolRoutePaths.AuthorizeCallback;
-        if (_authorizationParametersMessageStore != null)
-        {
-            var msg = new Message<IDictionary<string, string[]>>(_request.ToOptimizedFullDictionary());
-            var id = await _authorizationParametersMessageStore.WriteAsync(msg);
-            returnUrl = returnUrl.AddQueryString(Constants.AuthorizationParamsStore.MessageStoreIdParameterName, id);
-        }
-        else
-        {
-            returnUrl = returnUrl.AddQueryString(_request.ToOptimizedQueryString());
-        }
-
-        var loginUrl = _options.UserInteraction.LoginUrl;
-        if (!loginUrl.IsLocalUrl())
-        {
-            // this converts the relative redirect path to an absolute one if we're 
-            // redirecting to a different server
-            returnUrl = _urls.Origin + returnUrl;
-        }
-
-        var url = loginUrl.AddQueryString(_options.UserInteraction.LoginReturnUrlParameter, returnUrl);
-        context.Response.Redirect(_urls.GetAbsoluteUrl(url));
     }
 }

--- a/src/IdentityServer/Endpoints/Results/LoginPageResult.cs
+++ b/src/IdentityServer/Endpoints/Results/LoginPageResult.cs
@@ -10,7 +10,7 @@ namespace Duende.IdentityServer.Endpoints.Results;
 /// <summary>
 /// Result for login page
 /// </summary>
-public class LoginPageResult : InteractivePageResult
+public class LoginPageResult : AuthorizeInteractionPageResult
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="LoginPageResult"/> class.

--- a/src/IdentityServer/Extensions/ValidatedAuthorizeRequestExtensions.cs
+++ b/src/IdentityServer/Extensions/ValidatedAuthorizeRequestExtensions.cs
@@ -32,9 +32,21 @@ public static class ValidatedAuthorizeRequestExtensions
             }
             suppress.Append(OidcConstants.PromptModes.SelectAccount);
         }
+        if (request.PromptModes.Contains(OidcConstants.PromptModes.Create))
+        {
+            if (suppress.Length > 0)
+            {
+                suppress.Append(" ");
+            }
+            suppress.Append(OidcConstants.PromptModes.Create);
+        }
 
         request.Raw.Add(Constants.SuppressedPrompt, suppress.ToString());
-        request.PromptModes = request.PromptModes.Except(new[] { OidcConstants.PromptModes.Login, OidcConstants.PromptModes.SelectAccount }).ToArray();
+        request.PromptModes = request.PromptModes.Except(new[] { 
+            OidcConstants.PromptModes.Login, 
+            OidcConstants.PromptModes.SelectAccount,
+            OidcConstants.PromptModes.Create
+        }).ToArray();
     }
 
     public static string GetPrefixedAcrValue(this ValidatedAuthorizeRequest request, string prefix)

--- a/src/IdentityServer/ResponseHandling/Default/AuthorizeInteractionResponseGenerator.cs
+++ b/src/IdentityServer/ResponseHandling/Default/AuthorizeInteractionResponseGenerator.cs
@@ -137,7 +137,8 @@ public class AuthorizeInteractionResponseGenerator : IAuthorizeInteractionRespon
         using var activity = Tracing.BasicActivitySource.StartActivity("AuthorizeInteractionResponseGenerator.ProcessLogin");
         
         if (request.PromptModes.Contains(OidcConstants.PromptModes.Login) ||
-            request.PromptModes.Contains(OidcConstants.PromptModes.SelectAccount))
+            request.PromptModes.Contains(OidcConstants.PromptModes.SelectAccount) ||
+            request.PromptModes.Contains(OidcConstants.PromptModes.Create))
         {
             Logger.LogInformation("Showing login: request contains prompt={0}", request.PromptModes.ToSpaceSeparatedString());
 

--- a/src/IdentityServer/ResponseHandling/Default/DiscoveryResponseGenerator.cs
+++ b/src/IdentityServer/ResponseHandling/Default/DiscoveryResponseGenerator.cs
@@ -362,8 +362,7 @@ public class DiscoveryResponseGenerator : IDiscoveryResponseGenerator
 
             if (Options.UserInteraction.PromptValuesSupported?.Any() == true)
             {
-                // TODO: update to constant once IdentityModel updated
-                entries.Add("prompt_values_supported", Options.UserInteraction.PromptValuesSupported.ToArray());
+                entries.Add(OidcConstants.Discovery.PromptValuesSupported, Options.UserInteraction.PromptValuesSupported.ToArray());
             }
         }
 

--- a/src/IdentityServer/ResponseHandling/Default/DiscoveryResponseGenerator.cs
+++ b/src/IdentityServer/ResponseHandling/Default/DiscoveryResponseGenerator.cs
@@ -359,6 +359,12 @@ public class DiscoveryResponseGenerator : IDiscoveryResponseGenerator
             {
                 entries.Add(OidcConstants.Discovery.RequestUriParameterSupported, true);
             }
+
+            if (Options.UserInteraction.PromptValuesSupported?.Any() == true)
+            {
+                // TODO: update to constant once IdentityModel updated
+                entries.Add("prompt_values_supported", Options.UserInteraction.PromptValuesSupported.ToArray());
+            }
         }
 
         entries.Add(OidcConstants.Discovery.AuthorizationResponseIssParameterSupported, Options.EmitIssuerIdentificationResponseParameter);

--- a/src/IdentityServer/ResponseHandling/Models/InteractionResponse.cs
+++ b/src/IdentityServer/ResponseHandling/Models/InteractionResponse.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 
@@ -7,10 +7,42 @@ using Duende.IdentityServer.Extensions;
 namespace Duende.IdentityServer.ResponseHandling;
 
 /// <summary>
+/// Models the types of interaction results from the IAuthorizeInteractionResponseGenerator
+/// </summary>
+public enum InteractionResponseType
+{
+    /// <summary>
+    /// No interaction response, so a success result should be returned to the client
+    /// </summary>
+    None,
+    /// <summary>
+    /// Error of some sort. Depending on error, it will be shown to the user, or returned to the client.
+    /// </summary>
+    Error,
+    /// <summary>
+    /// Some sort of user interaction is required, such as login, consent, or something else.
+    /// </summary>
+    UserInteraction,
+}
+
+/// <summary>
 /// Indicates interaction outcome for user on authorization endpoint.
 /// </summary>
 public class InteractionResponse
 {
+    /// <summary>
+    /// The interaction response type.
+    /// </summary>
+    public InteractionResponseType ResponseType
+    {
+        get
+        {
+            if (IsError) return InteractionResponseType.Error;
+            if (IsLogin || IsConsent || IsCreateAccount || IsRedirect) return InteractionResponseType.UserInteraction;
+            return InteractionResponseType.None;
+        }
+    }
+
     /// <summary>
     /// Gets or sets a value indicating whether the user must login.
     /// </summary>
@@ -26,6 +58,14 @@ public class InteractionResponse
     /// <c>true</c> if this instance is consent; otherwise, <c>false</c>.
     /// </value>
     public bool IsConsent { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the user must create an account.
+    /// </summary>
+    /// <value>
+    /// <c>true</c> if this instance is create an account; otherwise, <c>false</c>.
+    /// </value>
+    public bool IsCreateAccount { get; set; }
 
     /// <summary>
     /// Gets a value indicating whether the result is an error.

--- a/src/IdentityServer/Test/TestUserStore.cs
+++ b/src/IdentityServer/Test/TestUserStore.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 
@@ -36,17 +36,17 @@ public class TestUserStore
     public bool ValidateCredentials(string username, string password)
     {
         var user = FindByUsername(username);
-            
+
         if (user != null)
         {
             if (string.IsNullOrWhiteSpace(user.Password) && string.IsNullOrWhiteSpace(password))
             {
                 return true;
             }
-                
+
             return user.Password.Equals(password);
         }
-            
+
         return false;
     }
 
@@ -152,6 +152,46 @@ public class TestUserStore
         // add user to in-memory store
         _users.Add(user);
 
+        return user;
+    }
+
+    /// <summary>
+    /// Adds a new a user.
+    /// </summary>
+    /// <returns></returns>
+    public TestUser CreateUser(string username, string password, string name = null, string email = null)
+    {
+        if (_users.Any(x => x.Username == username))
+        {
+            throw new Exception("That username already exists.");
+        }
+
+        // create a new unique subject id
+        var sub = CryptoRandom.CreateUniqueId(format: CryptoRandom.OutputFormat.Hex);
+
+        var claims = new List<Claim>();
+        if (!String.IsNullOrEmpty(name))
+        {
+            claims.Add(new Claim(ClaimTypes.Name, name));
+        }
+        if (!String.IsNullOrEmpty(email))
+        {
+            claims.Add(new Claim(ClaimTypes.Email, email));
+        }
+
+        // create new user
+        var user = new TestUser
+        {
+            SubjectId = sub,
+            Username = username,
+            Password = password,
+            Claims = claims
+        };
+
+        // add user to in-memory store
+        _users.Add(user);
+
+        // success
         return user;
     }
 }

--- a/src/IdentityServer/Validation/Default/AuthorizeRequestValidator.cs
+++ b/src/IdentityServer/Validation/Default/AuthorizeRequestValidator.cs
@@ -751,7 +751,7 @@ internal class AuthorizeRequestValidator : IAuthorizeRequestValidator
             }
             else
             {
-                // TODO: change to error in a major release
+                // TODO: change to error in a major release?
                 // https://github.com/DuendeSoftware/IdentityServer/issues/845#issuecomment-1405377531
                 // https://openid.net/specs/openid-connect-prompt-create-1_0.html#name-authorization-request
                 _logger.LogDebug("Unsupported prompt mode - ignored: " + prompt);
@@ -769,11 +769,19 @@ internal class AuthorizeRequestValidator : IAuthorizeRequestValidator
                     LogError("suppressed_prompt contains 'none' and other values. 'none' should be used by itself.", request);
                     return Invalid(request, description: "Invalid prompt");
                 }
+                if (prompts.Contains(OidcConstants.PromptModes.Create) && prompts.Length > 1)
+                {
+                    LogError("prompt contains 'create' and other values. 'create' should be used by itself.", request);
+                    return Invalid(request, description: "Invalid prompt");
+                }
 
                 request.SuppressedPromptModes = prompts;
             }
             else
             {
+                // TODO: change to error in a major release?
+                // https://github.com/DuendeSoftware/IdentityServer/issues/845#issuecomment-1405377531
+                // https://openid.net/specs/openid-connect-prompt-create-1_0.html#name-authorization-request
                 _logger.LogDebug("Unsupported suppressed_prompt mode - ignored: " + prompt);
             }
         }

--- a/src/IdentityServer/Validation/Default/AuthorizeRequestValidator.cs
+++ b/src/IdentityServer/Validation/Default/AuthorizeRequestValidator.cs
@@ -741,6 +741,11 @@ internal class AuthorizeRequestValidator : IAuthorizeRequestValidator
                     LogError("prompt contains 'none' and other values. 'none' should be used by itself.", request);
                     return Invalid(request, description: "Invalid prompt");
                 }
+                if (prompts.Contains(OidcConstants.PromptModes.Create) && prompts.Length > 1)
+                {
+                    LogError("prompt contains 'create' and other values. 'create' should be used by itself.", request);
+                    return Invalid(request, description: "Invalid prompt");
+                }
 
                 request.OriginalPromptModes = prompts;
             }

--- a/src/IdentityServer/Validation/Default/AuthorizeRequestValidator.cs
+++ b/src/IdentityServer/Validation/Default/AuthorizeRequestValidator.cs
@@ -734,7 +734,7 @@ internal class AuthorizeRequestValidator : IAuthorizeRequestValidator
         if (prompt.IsPresent())
         {
             var prompts = prompt.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-            if (prompts.All(p => Constants.SupportedPromptModes.Contains(p)))
+            if (prompts.All(p => _options.UserInteraction.PromptValuesSupported?.Contains(p) == true))
             {
                 if (prompts.Contains(OidcConstants.PromptModes.None) && prompts.Length > 1)
                 {
@@ -746,6 +746,9 @@ internal class AuthorizeRequestValidator : IAuthorizeRequestValidator
             }
             else
             {
+                // TODO: change to error in a major release
+                // https://github.com/DuendeSoftware/IdentityServer/issues/845#issuecomment-1405377531
+                // https://openid.net/specs/openid-connect-prompt-create-1_0.html#name-authorization-request
                 _logger.LogDebug("Unsupported prompt mode - ignored: " + prompt);
             }
         }
@@ -754,7 +757,7 @@ internal class AuthorizeRequestValidator : IAuthorizeRequestValidator
         if (suppressed_prompt.IsPresent())
         {
             var prompts = suppressed_prompt.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-            if (prompts.All(p => Constants.SupportedPromptModes.Contains(p)))
+            if (prompts.All(p => _options.UserInteraction.PromptValuesSupported?.Contains(p) == true))
             {
                 if (prompts.Contains(OidcConstants.PromptModes.None) && prompts.Length > 1)
                 {

--- a/test/IdentityServer.IntegrationTests/Common/IdentityServerPipeline.cs
+++ b/test/IdentityServer.IntegrationTests/Common/IdentityServerPipeline.cs
@@ -164,6 +164,10 @@ public class IdentityServerPipeline
         app.UseIdentityServer();
 
         // UI endpoints
+        app.Map("/account/create", path =>
+        {
+            path.Run(ctx => OnCreateAccount(ctx));
+        });
         app.Map(Constants.UIConstants.DefaultRoutePaths.Login.EnsureLeadingSlash(), path =>
         {
             path.Run(ctx => OnLogin(ctx));
@@ -197,6 +201,18 @@ public class IdentityServerPipeline
     {
         LoginWasCalled = true;
         await ReadLoginRequest(ctx);
+        await IssueLoginCookie(ctx);
+    }
+
+    public bool CreateAccountWasCalled { get; set; }
+    public string CreateAccountReturnUrl { get; set; }
+    public AuthorizationRequest CreateAccountRequest { get; set; }
+    private async Task OnCreateAccount(HttpContext ctx)
+    {
+        CreateAccountWasCalled = true;
+        var interaction = ctx.RequestServices.GetRequiredService<IIdentityServerInteractionService>();
+        CreateAccountReturnUrl = ctx.Request.Query[Options.UserInteraction.CreateAccountReturnUrlParameter].FirstOrDefault();
+        CreateAccountRequest = await interaction.GetAuthorizationContextAsync(CreateAccountReturnUrl);
         await IssueLoginCookie(ctx);
     }
 

--- a/test/IdentityServer.IntegrationTests/Endpoints/Authorize/AuthorizeTests.cs
+++ b/test/IdentityServer.IntegrationTests/Endpoints/Authorize/AuthorizeTests.cs
@@ -1285,6 +1285,48 @@ public class AuthorizeTests
         response.Headers.Location.ToString().Should().Contain("id_token=");
     }
 
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task prompt_create_should_show_login_page_and_preserve_prompt_values()
+    {
+        await _mockPipeline.LoginAsync("bob");
+
+        var url = _mockPipeline.CreateAuthorizeUrl(
+            clientId: "client3",
+            responseType: "id_token",
+            scope: "openid profile",
+            redirectUri: "https://client3/callback",
+            state: "123_state",
+            nonce: "123_nonce",
+            extra: new { prompt = "create" }
+        );
+        var response = await _mockPipeline.BrowserClient.GetAsync(url);
+
+        _mockPipeline.LoginWasCalled.Should().BeTrue();
+        _mockPipeline.LoginRequest.PromptModes.Should().Contain("create");
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task prompt_create_and_login_should_show_login_page_and_preserve_prompt_values()
+    {
+        await _mockPipeline.LoginAsync("bob");
+
+        var url = _mockPipeline.CreateAuthorizeUrl(
+            clientId: "client3",
+            responseType: "id_token",
+            scope: "openid profile",
+            redirectUri: "https://client3/callback",
+            state: "123_state",
+            nonce: "123_nonce",
+            extra: new { prompt = "create login" }
+        );
+        var response = await _mockPipeline.BrowserClient.GetAsync(url);
+
+        _mockPipeline.LoginWasCalled.Should().BeTrue();
+        _mockPipeline.LoginRequest.PromptModes.Should().BeEquivalentTo(new[] { "create", "login" });
+    }
+
 
     [Theory]
     [InlineData((Type) null)]

--- a/test/IdentityServer.IntegrationTests/Endpoints/Authorize/AuthorizeTests.cs
+++ b/test/IdentityServer.IntegrationTests/Endpoints/Authorize/AuthorizeTests.cs
@@ -9,6 +9,7 @@ using System.Net.Http;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Duende.IdentityServer;
+using Duende.IdentityServer.Configuration;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.ResponseHandling;
 using Duende.IdentityServer.Stores;
@@ -1287,8 +1288,36 @@ public class AuthorizeTests
 
     [Fact]
     [Trait("Category", Category)]
-    public async Task prompt_create_should_show_login_page_and_preserve_prompt_values()
+    public async Task without_config_prompt_create_should_not_show_create_account_page()
     {
+        var url = _mockPipeline.CreateAuthorizeUrl(
+            clientId: "client3",
+            responseType: "id_token",
+            scope: "openid profile",
+            redirectUri: "https://client3/callback",
+            state: "123_state",
+            nonce: "123_nonce",
+            extra: new { prompt = "create" }
+        );
+        var response = await _mockPipeline.BrowserClient.GetAsync(url);
+
+        _mockPipeline.CreateAccountWasCalled.Should().BeFalse();
+        _mockPipeline.LoginWasCalled.Should().BeTrue();
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task with_config_prompt_create_should_show_create_account_page_and_preserve_prompt_values()
+    {
+        _mockPipeline.OnPreConfigureServices += svcs => 
+        {
+            svcs.PostConfigure<IdentityServerOptions>(opts =>
+            {
+                opts.UserInteraction.CreateAccountUrl = "/account/create";
+            });
+        };
+        _mockPipeline.Initialize();
+
         await _mockPipeline.LoginAsync("bob");
 
         var url = _mockPipeline.CreateAuthorizeUrl(
@@ -1302,14 +1331,23 @@ public class AuthorizeTests
         );
         var response = await _mockPipeline.BrowserClient.GetAsync(url);
 
-        _mockPipeline.LoginWasCalled.Should().BeTrue();
-        _mockPipeline.LoginRequest.PromptModes.Should().Contain("create");
+        _mockPipeline.CreateAccountWasCalled.Should().BeTrue();
+        _mockPipeline.CreateAccountRequest.PromptModes.Should().Contain("create");
     }
 
     [Fact]
     [Trait("Category", Category)]
-    public async Task prompt_create_and_login_should_show_login_page_and_preserve_prompt_values()
+    public async Task prompt_create_and_login_should_be_an_error()
     {
+        _mockPipeline.OnPreConfigureServices += svcs =>
+        {
+            svcs.PostConfigure<IdentityServerOptions>(opts =>
+            {
+                opts.UserInteraction.CreateAccountUrl = "/account/create";
+            });
+        };
+        _mockPipeline.Initialize(); 
+        
         await _mockPipeline.LoginAsync("bob");
 
         var url = _mockPipeline.CreateAuthorizeUrl(
@@ -1323,8 +1361,7 @@ public class AuthorizeTests
         );
         var response = await _mockPipeline.BrowserClient.GetAsync(url);
 
-        _mockPipeline.LoginWasCalled.Should().BeTrue();
-        _mockPipeline.LoginRequest.PromptModes.Should().BeEquivalentTo(new[] { "create", "login" });
+        _mockPipeline.ErrorWasCalled.Should().BeTrue();
     }
 
 

--- a/test/IdentityServer.UnitTests/Endpoints/Authorize/AuthorizeEndpointBaseTests.cs
+++ b/test/IdentityServer.UnitTests/Endpoints/Authorize/AuthorizeEndpointBaseTests.cs
@@ -183,6 +183,9 @@ public class AuthorizeEndpointBaseTests
 
         _stubAuthorizeRequestValidator.Result = new AuthorizeRequestValidationResult(_validatedAuthorizeRequest);
 
+        _options.UserInteraction.LoginUrl = "/Account/Login";
+        _options.UserInteraction.LoginReturnUrlParameter = "returnUrl";
+
         _subject = new TestAuthorizeEndpoint(
             _fakeEventService,
             _fakeLogger,


### PR DESCRIPTION
This PR adds support for the OIDC prompt=create extension:

https://openid.net/specs/openid-connect-prompt-create-1_0.html

Closes: https://github.com/DuendeSoftware/IdentityServer/issues/432

Docs needed: New CreateAccountUrl property on the UserInteractionOptions, and how this affects the values in discovery and request processing.