### PR TITLE
fix non-unique names in endpoint list and add health check sample

### DIFF
--- a/hosts/main/DiscoveryHealthCheck.cs
+++ b/hosts/main/DiscoveryHealthCheck.cs
@@ -1,0 +1,42 @@
+using Duende.IdentityServer.Endpoints.Results;
+using Duende.IdentityServer.Hosting;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Duende.IdentityServer;
+
+public class DiscoveryHealthCheck : IHealthCheck
+{
+    private readonly IEnumerable<Hosting.Endpoint> _endpoints;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public DiscoveryHealthCheck(IEnumerable<Hosting.Endpoint> endpoints, IHttpContextAccessor httpContextAccessor)
+    {
+        _endpoints = endpoints;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var endpoint = _endpoints.FirstOrDefault(x => x.Name == IdentityServerConstants.EndpointNames.Discovery);
+            if (endpoint != null)
+            {
+                var handler = _httpContextAccessor.HttpContext.RequestServices.GetRequiredService(endpoint.Handler) as IEndpointHandler;
+                if (handler != null)
+                {
+                    var result = await handler.ProcessAsync(_httpContextAccessor.HttpContext);
+                    if (result is DiscoveryDocumentResult)
+                    {
+                        return HealthCheckResult.Healthy();
+                    }
+                }
+            }
+        }
+        catch
+        {
+        }
+        
+        return new HealthCheckResult(context.Registration.FailureStatus);
+    }
+}

--- a/hosts/main/DiscoveryHealthCheck.cs
+++ b/hosts/main/DiscoveryHealthCheck.cs
@@ -40,3 +40,40 @@ public class DiscoveryHealthCheck : IHealthCheck
         return new HealthCheckResult(context.Registration.FailureStatus);
     }
 }
+
+public class DiscoveryKeysHealthCheck : IHealthCheck
+{
+    private readonly IEnumerable<Hosting.Endpoint> _endpoints;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public DiscoveryKeysHealthCheck(IEnumerable<Hosting.Endpoint> endpoints, IHttpContextAccessor httpContextAccessor)
+    {
+        _endpoints = endpoints;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var endpoint = _endpoints.FirstOrDefault(x => x.Name == IdentityServerConstants.EndpointNames.Jwks);
+            if (endpoint != null)
+            {
+                var handler = _httpContextAccessor.HttpContext.RequestServices.GetRequiredService(endpoint.Handler) as IEndpointHandler;
+                if (handler != null)
+                {
+                    var result = await handler.ProcessAsync(_httpContextAccessor.HttpContext);
+                    if (result is JsonWebKeysResult)
+                    {
+                        return HealthCheckResult.Healthy();
+                    }
+                }
+            }
+        }
+        catch
+        {
+        }
+
+        return new HealthCheckResult(context.Registration.FailureStatus);
+    }
+}

--- a/hosts/main/HostingExtensions.cs
+++ b/hosts/main/HostingExtensions.cs
@@ -19,6 +19,8 @@ internal static class HostingExtensions
             .AddRazorRuntimeCompilation();
 
         builder.Services.AddControllers();
+        builder.Services.AddHealthChecks()
+                    .AddCheck<DiscoveryHealthCheck>("DiscoveryHealthCheck");
 
         // cookie policy to deal with temporary browser incompatibilities
         builder.Services.AddSameSiteCookiePolicy();
@@ -151,6 +153,9 @@ internal static class HostingExtensions
         app.UseIdentityServer();
         app.UseAuthorization();
 
+        // health checks
+        app.MapHealthChecks("/health");
+        
         // local API endpoints
         app.MapControllers()
             .RequireAuthorization(IdentityServerConstants.LocalApi.PolicyName);

--- a/hosts/main/HostingExtensions.cs
+++ b/hosts/main/HostingExtensions.cs
@@ -20,7 +20,8 @@ internal static class HostingExtensions
 
         builder.Services.AddControllers();
         builder.Services.AddHealthChecks()
-                    .AddCheck<DiscoveryHealthCheck>("DiscoveryHealthCheck");
+                    .AddCheck<DiscoveryHealthCheck>("DiscoveryHealthCheck")
+                    .AddCheck<DiscoveryKeysHealthCheck>("DiscoveryKeysHealthCheck");
 
         // cookie policy to deal with temporary browser incompatibilities
         builder.Services.AddSameSiteCookiePolicy();

--- a/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -113,7 +113,7 @@ public static class IdentityServerBuilderExtensionsCore
         builder.AddEndpoint<BackchannelAuthenticationEndpoint>(EndpointNames.BackchannelAuthentication, ProtocolRoutePaths.BackchannelAuthentication.EnsureLeadingSlash());
         builder.AddEndpoint<CheckSessionEndpoint>(EndpointNames.CheckSession, ProtocolRoutePaths.CheckSession.EnsureLeadingSlash());
         builder.AddEndpoint<DeviceAuthorizationEndpoint>(EndpointNames.DeviceAuthorization, ProtocolRoutePaths.DeviceAuthorization.EnsureLeadingSlash());
-        builder.AddEndpoint<DiscoveryKeyEndpoint>(EndpointNames.Discovery, ProtocolRoutePaths.DiscoveryWebKeys.EnsureLeadingSlash());
+        builder.AddEndpoint<DiscoveryKeyEndpoint>(EndpointNames.Jwks, ProtocolRoutePaths.DiscoveryWebKeys.EnsureLeadingSlash());
         builder.AddEndpoint<DiscoveryEndpoint>(EndpointNames.Discovery, ProtocolRoutePaths.DiscoveryConfiguration.EnsureLeadingSlash());
         builder.AddEndpoint<EndSessionCallbackEndpoint>(EndpointNames.EndSession, ProtocolRoutePaths.EndSessionCallback.EnsureLeadingSlash());
         builder.AddEndpoint<EndSessionEndpoint>(EndpointNames.EndSession, ProtocolRoutePaths.EndSession.EnsureLeadingSlash());

--- a/src/IdentityServer/IdentityServerConstants.cs
+++ b/src/IdentityServer/IdentityServerConstants.cs
@@ -197,6 +197,7 @@ public static class IdentityServerConstants
         public const string Token = "Token";
         public const string DeviceAuthorization = "DeviceAuthorization";
         public const string Discovery = "Discovery";
+        public const string Jwks = "Jwks";
         public const string Introspection = "Introspection";
         public const string Revocation = "Revocation";
         public const string EndSession = "Endsession";


### PR DESCRIPTION
This PR contains two things:
* bug fix: the JWKS Endpoint in the endpoint collection was using the same name as the discovery endpoint, so the lookup by name results in an ambiguous/non-unique result
* sample to show how to use our public APIs to create a health check for the discovery endpoint

Closes: https://github.com/DuendeSoftware/IdentityServer/issues/584