### PR TITLE
Always emit the sid claim in id tokens

### DIFF
--- a/src/IdentityServer/Validation/Default/AuthorizeRequestValidator.cs
+++ b/src/IdentityServer/Validation/Default/AuthorizeRequestValidator.cs
@@ -874,26 +874,23 @@ internal class AuthorizeRequestValidator : IAuthorizeRequestValidator
         }
 
         //////////////////////////////////////////////////////////
-        // check session cookie
+        // session id
         //////////////////////////////////////////////////////////
-        if (_options.Endpoints.EnableCheckSessionEndpoint)
+        if (request.Subject.IsAuthenticated())
         {
-            if (request.Subject.IsAuthenticated())
+            var sessionId = await _userSession.GetSessionIdAsync();
+            if (sessionId.IsPresent())
             {
-                var sessionId = await _userSession.GetSessionIdAsync();
-                if (sessionId.IsPresent())
-                {
-                    request.SessionId = sessionId;
-                }
-                else
-                {
-                    LogError("Check session endpoint enabled, but SessionId is missing", request);
-                }
+                request.SessionId = sessionId;
             }
             else
             {
-                request.SessionId = ""; // empty string for anonymous users
+                LogError("SessionId is missing", request);
             }
+        }
+        else
+        {
+            request.SessionId = ""; // empty string for anonymous users
         }
 
         return Valid(request);


### PR DESCRIPTION
In the past, we only needed the sid claim in the check session endpoint, and only included the sid claim when that endpoint was enabled check session. Now we have more cases where the sid claim is useful, so we are no longer going to make the sid claim conditional on the EnableCheckSessionEndpoint option