### PR TITLE
add LogoutTokenJwtType property for back channel logout tokens

### DIFF
--- a/src/IdentityServer/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
@@ -34,6 +34,14 @@ public class IdentityServerOptions
     public string AccessTokenJwtType { get; set; } = "at+jwt";
 
     /// <summary>
+    /// Gets or sets the value for the JWT typ header for logout tokens.
+    /// </summary>
+    /// <value>
+    /// The JWT typ value.
+    /// </value>
+    public string LogoutTokenJwtType { get; set; } = "logout+jwt";
+
+    /// <summary>
     /// Emits an aud claim with the format issuer/resources. That's needed for some older access token validation plumbing. Defaults to false.
     /// </summary>
     public bool EmitStaticAudienceClaim { get; set; } = false;

--- a/src/IdentityServer/IdentityServerConstants.cs
+++ b/src/IdentityServer/IdentityServerConstants.cs
@@ -51,6 +51,7 @@ public static class IdentityServerConstants
     {
         public const string IdentityToken = "id_token";
         public const string AccessToken = "access_token";
+        public const string LogoutToken = "logout_token";
     }
 
     public static class ClaimValueTypes

--- a/src/IdentityServer/IdentityServerTools.cs
+++ b/src/IdentityServer/IdentityServerTools.cs
@@ -47,20 +47,8 @@ public class IdentityServerTools
     /// <exception cref="System.ArgumentNullException">claims</exception>
     public virtual async Task<string> IssueJwtAsync(int lifetime, IEnumerable<Claim> claims)
     {
-        if (claims == null) throw new ArgumentNullException(nameof(claims));
-
         var issuer = await IssuerNameService.GetCurrentAsync();
-
-        var token = new Token
-        {
-            CreationTime = _clock.UtcNow.UtcDateTime,
-            Issuer = issuer,
-            Lifetime = lifetime,
-
-            Claims = new HashSet<Claim>(claims, new ClaimComparer())
-        };
-
-        return await _tokenCreation.CreateTokenAsync(token);
+        return await IssueJwtAsync(lifetime, issuer, claims);
     }
 
     /// <summary>
@@ -71,12 +59,28 @@ public class IdentityServerTools
     /// <param name="claims">The claims.</param>
     /// <returns></returns>
     /// <exception cref="System.ArgumentNullException">claims</exception>
-    public virtual async Task<string> IssueJwtAsync(int lifetime, string issuer, IEnumerable<Claim> claims)
+    public virtual Task<string> IssueJwtAsync(int lifetime, string issuer, IEnumerable<Claim> claims)
+    {
+        var tokenType = OidcConstants.TokenTypes.AccessToken;
+        return IssueJwtAsync(lifetime, issuer, tokenType, claims);
+    }
+
+    /// <summary>
+    /// Issues a JWT.
+    /// </summary>
+    /// <param name="lifetime">The lifetime.</param>
+    /// <param name="issuer">The issuer.</param>
+    /// <param name="tokenType"></param>
+    /// <param name="claims">The claims.</param>
+    /// <returns></returns>
+    /// <exception cref="System.ArgumentNullException">claims</exception>
+    public virtual async Task<string> IssueJwtAsync(int lifetime, string issuer, string tokenType, IEnumerable<Claim> claims)
     {
         if (String.IsNullOrWhiteSpace(issuer)) throw new ArgumentNullException(nameof(issuer));
+        if (String.IsNullOrWhiteSpace(tokenType)) throw new ArgumentNullException(nameof(tokenType));
         if (claims == null) throw new ArgumentNullException(nameof(claims));
 
-        var token = new Token
+        var token = new Token(tokenType)
         {
             CreationTime = _clock.UtcNow.UtcDateTime,
             Issuer = issuer,
@@ -84,7 +88,7 @@ public class IdentityServerTools
 
             Claims = new HashSet<Claim>(claims, new ClaimComparer())
         };
-
+        
         return await _tokenCreation.CreateTokenAsync(token);
     }
 }

--- a/src/IdentityServer/Services/Default/DefaultBackChannelLogoutService.cs
+++ b/src/IdentityServer/Services/Default/DefaultBackChannelLogoutService.cs
@@ -147,10 +147,10 @@ public class DefaultBackChannelLogoutService : IBackChannelLogoutService
 
         if (request.Issuer != null)
         {
-            return await Tools.IssueJwtAsync(DefaultLogoutTokenLifetime, request.Issuer, claims);
+            return await Tools.IssueJwtAsync(DefaultLogoutTokenLifetime, request.Issuer, IdentityServerConstants.TokenTypes.LogoutToken, claims);
         }
 
-        return await Tools.IssueJwtAsync(DefaultLogoutTokenLifetime, claims);
+        return await Tools.IssueJwtAsync(DefaultLogoutTokenLifetime, IdentityServerConstants.TokenTypes.LogoutToken, claims);
     }
 
     /// <summary>

--- a/src/IdentityServer/Services/Default/DefaultTokenCreationService.cs
+++ b/src/IdentityServer/Services/Default/DefaultTokenCreationService.cs
@@ -96,12 +96,19 @@ public class DefaultTokenCreationService : ITokenCreationService
     protected virtual Task<Dictionary<string, object>> CreateHeaderElementsAsync(Token token)
     {
         var additionalHeaderElements = new Dictionary<string, object>();
-            
+
         if (token.Type == IdentityServerConstants.TokenTypes.AccessToken)
         {
             if (Options.AccessTokenJwtType.IsPresent())
             {
                 additionalHeaderElements.Add("typ", Options.AccessTokenJwtType);
+            }
+        }
+        else if (token.Type == IdentityServerConstants.TokenTypes.LogoutToken)
+        {
+            if (Options.LogoutTokenJwtType.IsPresent())
+            {
+                additionalHeaderElements.Add("typ", Options.LogoutTokenJwtType);
             }
         }
 


### PR DESCRIPTION
This adds a new `LogoutTokenJwtType` option for explicitly configuring back channel logout tokens `typ` header. It defaults to `logout+jwt` to be in compliance with the recently updated and released OIDC back channel logout spec.

https://openid.net/specs/openid-connect-backchannel-1_0.html#LogoutToken

While this might be a breaking change, the current versions of the .NET JWT handler ignore the `typ` so it is a low chance of affecting customers. And if they are validating the `typ` then they should be using the value as per spec. If this does cause issues, then they can set the new `LogoutTokenJwtType` option value introduced in this PR.

Closes: https://github.com/DuendeSoftware/IdentityServer/issues/1169