### PR TITLE
requests to ~/federation with no additional segments should return not found

### DIFF
--- a/src/IdentityServer/Hosting/DynamicProviders/DynamicSchemes/DynamicSchemeAuthenticationMiddleware.cs
+++ b/src/IdentityServer/Hosting/DynamicProviders/DynamicSchemes/DynamicSchemeAuthenticationMiddleware.cs
@@ -27,20 +27,23 @@ class DynamicSchemeAuthenticationMiddleware
         if (context.Request.Path.StartsWithSegments(_options.PathPrefix))
         {
             var startIndex = _options.PathPrefix.ToString().Length;
-            var scheme = context.Request.Path.Value.Substring(startIndex + 1);
-            var idx = scheme.IndexOf('/');
-            if (idx > 0)
+            if (context.Request.Path.Value.Length > startIndex)
             {
-                // this assumes the path is: /<PathPrefix>/<scheme>/<extra>
-                // e.g.: /federation/my-oidc-provider/signin
-                scheme = scheme.Substring(0, idx);
-            }
+                var scheme = context.Request.Path.Value.Substring(startIndex + 1);
+                var idx = scheme.IndexOf('/');
+                if (idx > 0)
+                {
+                    // this assumes the path is: /<PathPrefix>/<scheme>/<extra>
+                    // e.g.: /federation/my-oidc-provider/signin
+                    scheme = scheme.Substring(0, idx);
+                }
 
-            var handlers = context.RequestServices.GetRequiredService<IAuthenticationHandlerProvider>();
-            var handler = await handlers.GetHandlerAsync(context, scheme) as IAuthenticationRequestHandler;
-            if (handler != null && await handler.HandleRequestAsync())
-            {
-                return;
+                var handlers = context.RequestServices.GetRequiredService<IAuthenticationHandlerProvider>();
+                var handler = await handlers.GetHandlerAsync(context, scheme) as IAuthenticationRequestHandler;
+                if (handler != null && await handler.HandleRequestAsync())
+                {
+                    return;
+                }
             }
         }
 

--- a/test/IdentityServer.IntegrationTests/Hosting/DynamicProvidersTests.cs
+++ b/test/IdentityServer.IntegrationTests/Hosting/DynamicProvidersTests.cs
@@ -365,4 +365,17 @@ public class DynamicProvidersTests
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
 #endif
+
+    [Fact]
+    public async Task missing_segments_in_redirect_uri_should_return_not_found()
+    {
+        var response = await _host.HttpClient.GetAsync(_host.Url("/federation/idp1"));
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+    [Fact]
+    public async Task federation_endpoint_with_no_scheme_should_return_not_found()
+    {
+        var response = await _host.HttpClient.GetAsync(_host.Url("/federation"));
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
 }


### PR DESCRIPTION
Fixes: https://github.com/DuendeSoftware/IdentityServer/issues/1171