### PR TITLE
First draft of DPoP support

### DIFF
--- a/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Additional.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Additional.cs
@@ -336,7 +336,6 @@ public static class IdentityServerBuilderExtensionsAdditional
     /// <returns></returns>
     public static IIdentityServerBuilder AddJwtBearerClientAuthentication(this IIdentityServerBuilder builder)
     {
-        builder.Services.TryAddTransient<IReplayCache, DefaultReplayCache>();
         builder.AddSecretParser<JwtBearerClientAssertionSecretParser>();
         builder.AddSecretValidator<PrivateKeyJwtSecretValidator>();
 

--- a/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -215,7 +215,6 @@ public static class IdentityServerBuilderExtensionsCore
         builder.Services.TryAddTransient<IUserCodeGenerator, NumericUserCodeGenerator>();
         builder.Services.TryAddTransient<ILogoutNotificationService, LogoutNotificationService>();
         builder.Services.TryAddTransient<IBackChannelLogoutService, DefaultBackChannelLogoutService>();
-        builder.Services.TryAddTransient<IResourceValidator, DefaultResourceValidator>();
         builder.Services.TryAddTransient<IScopeParser, DefaultScopeParser>();
         builder.Services.TryAddTransient<ISessionCoordinationService, DefaultSessionCoordinationService>();
 
@@ -297,7 +296,9 @@ public static class IdentityServerBuilderExtensionsCore
         builder.Services.TryAddTransient<IDeviceAuthorizationRequestValidator, DeviceAuthorizationRequestValidator>();
         builder.Services.TryAddTransient<IDeviceCodeValidator, DeviceCodeValidator>();
         builder.Services.TryAddTransient<IBackchannelAuthenticationRequestIdValidator, BackchannelAuthenticationRequestIdValidator>();
-            
+        builder.Services.TryAddTransient<IResourceValidator, DefaultResourceValidator>();
+        builder.Services.TryAddTransient<IDPoPProofValidator, DefaultDPoPProofValidator>();
+
         builder.Services.TryAddTransient<IBackchannelAuthenticationRequestValidator, BackchannelAuthenticationRequestValidator>();
 
         // optional

--- a/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -217,6 +217,7 @@ public static class IdentityServerBuilderExtensionsCore
         builder.Services.TryAddTransient<IBackChannelLogoutService, DefaultBackChannelLogoutService>();
         builder.Services.TryAddTransient<IScopeParser, DefaultScopeParser>();
         builder.Services.TryAddTransient<ISessionCoordinationService, DefaultSessionCoordinationService>();
+        builder.Services.TryAddTransient<IReplayCache, DefaultReplayCache>();
 
         builder.Services.TryAddTransient<IBackchannelAuthenticationThrottlingService, DistributedBackchannelAuthenticationThrottlingService>();
         builder.Services.TryAddTransient<IBackchannelAuthenticationUserNotificationService, NopBackchannelAuthenticationUserNotificationService>();

--- a/src/IdentityServer/Endpoints/Results/TokenResult.cs
+++ b/src/IdentityServer/Endpoints/Results/TokenResult.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 
@@ -33,7 +33,7 @@ internal class TokenResult : IEndpointResult
             access_token = Response.AccessToken,
             refresh_token = Response.RefreshToken,
             expires_in = Response.AccessTokenLifetime,
-            token_type = OidcConstants.TokenResponse.BearerTokenType,
+            token_type = Response.AccessTokenType,
             scope = Response.Scope,
                 
             Custom = Response.Custom

--- a/src/IdentityServer/Endpoints/TokenEndpoint.cs
+++ b/src/IdentityServer/Endpoints/TokenEndpoint.cs
@@ -95,7 +95,14 @@ internal class TokenEndpoint : IEndpointHandler
         // validate request
         var form = (await context.Request.ReadFormAsync()).AsNameValueCollection();
         _logger.LogTrace("Calling into token request validator: {type}", _requestValidator.GetType().FullName);
-        var requestResult = await _requestValidator.ValidateRequestAsync(form, clientResult);
+
+        var requestContext = new TokenRequestValidationContext
+        { 
+            RequestParameters = form, 
+            ClientValidationResult = clientResult,
+            RequestHeaders = new HeaderCollection(context.Request.Headers)
+        };
+        var requestResult = await _requestValidator.ValidateRequestAsync(requestContext);
 
         if (requestResult.IsError)
         {

--- a/src/IdentityServer/IdentityServerConstants.cs
+++ b/src/IdentityServer/IdentityServerConstants.cs
@@ -113,6 +113,21 @@ public static class IdentityServerConstants
         SecurityAlgorithms.EcdsaSha512
     };
 
+    public readonly static IEnumerable<string> SupportedDPoPSigningAlgorithms = new[] 
+    {
+        SecurityAlgorithms.RsaSha256,
+        SecurityAlgorithms.RsaSha384,
+        SecurityAlgorithms.RsaSha512,
+
+        SecurityAlgorithms.RsaSsaPssSha256,
+        SecurityAlgorithms.RsaSsaPssSha384,
+        SecurityAlgorithms.RsaSsaPssSha512,
+
+        SecurityAlgorithms.EcdsaSha256,
+        SecurityAlgorithms.EcdsaSha384,
+        SecurityAlgorithms.EcdsaSha512
+    };
+
     public enum RsaSigningAlgorithm
     {
         RS256,

--- a/src/IdentityServer/Models/RefreshTokenCreationRequest.cs
+++ b/src/IdentityServer/Models/RefreshTokenCreationRequest.cs
@@ -49,6 +49,11 @@ public class RefreshTokenCreationRequest
     public Token AccessToken { get; set; }
 
     /// <summary>
+    /// The thumbprint of the associated DPoP proof key, if one was used.
+    /// </summary>
+    public string DPoPKeyThumbprint { get; set; }
+
+    /// <summary>
     /// Called to validate the <see cref="RefreshTokenCreationRequest"/> before it is processed.
     /// </summary>
     public void Validate()

--- a/src/IdentityServer/ResponseHandling/Default/AuthorizeResponseGenerator.cs
+++ b/src/IdentityServer/ResponseHandling/Default/AuthorizeResponseGenerator.cs
@@ -261,6 +261,7 @@ public class AuthorizeResponseGenerator : IAuthorizeResponseGenerator
             Description = request.Description,
             CodeChallenge = request.CodeChallenge.Sha256(),
             CodeChallengeMethod = request.CodeChallengeMethod,
+            DPoPKeyThumbprint = request.DPoPKeyThumbprint,
 
             IsOpenId = request.IsOpenIdRequest,
             RequestedScopes = request.ValidatedResources.RawScopeValues,

--- a/src/IdentityServer/ResponseHandling/Default/DiscoveryResponseGenerator.cs
+++ b/src/IdentityServer/ResponseHandling/Default/DiscoveryResponseGenerator.cs
@@ -380,6 +380,12 @@ public class DiscoveryResponseGenerator : IDiscoveryResponseGenerator
             entries.Add(OidcConstants.Discovery.BackchannelUserCodeParameterSupported, true);
         }
 
+        if (Options.Endpoints.EnableTokenEndpoint)
+        {
+            // TODO: IdentityModel
+            entries.Add("dpop_signing_alg_values_supported", new[] { IdentityServerConstants.SupportedDPoPSigningAlgorithms });
+        }
+
         // custom entries
         if (!IEnumerableExtensions.IsNullOrEmpty(Options.Discovery.CustomEntries))
         {

--- a/src/IdentityServer/ResponseHandling/Default/TokenResponseGenerator.cs
+++ b/src/IdentityServer/ResponseHandling/Default/TokenResponseGenerator.cs
@@ -509,6 +509,7 @@ public class TokenResponseGenerator : ITokenResponseGenerator
                 AuthorizedResourceIndicators = authorizedResourceIndicators,
                 AccessToken = at,
                 RequestedResourceIndicator = request.RequestedResourceIndicator,
+                DPoPKeyThumbprint = request.DPoPKeyThumbprint
             };
             var refreshToken = await RefreshTokenService.CreateRefreshTokenAsync(rtRequest);
             return (accessToken, refreshToken);

--- a/src/IdentityServer/ResponseHandling/Default/TokenResponseGenerator.cs
+++ b/src/IdentityServer/ResponseHandling/Default/TokenResponseGenerator.cs
@@ -150,6 +150,7 @@ public class TokenResponseGenerator : ITokenResponseGenerator
         var response = new TokenResponse
         {
             AccessToken = accessToken,
+            AccessTokenType = request.ValidatedRequest.ContainsDPoPProofToken ? "DPoP" : OidcConstants.TokenResponse.BearerTokenType,
             AccessTokenLifetime = request.ValidatedRequest.AccessTokenLifetime,
             Custom = request.CustomResponse,
             Scope = request.ValidatedRequest.ValidatedResources.RawScopeValues.ToSpaceSeparatedString()
@@ -242,6 +243,7 @@ public class TokenResponseGenerator : ITokenResponseGenerator
         {
             IdentityToken = await CreateIdTokenFromRefreshTokenRequestAsync(request.ValidatedRequest, accessTokenString),
             AccessToken = accessTokenString,
+            AccessTokenType = request.ValidatedRequest.ContainsDPoPProofToken ? "DPoP" : OidcConstants.TokenResponse.BearerTokenType, 
             AccessTokenLifetime = request.ValidatedRequest.AccessTokenLifetime,
             RefreshToken = handle,
             Custom = request.CustomResponse,
@@ -265,6 +267,7 @@ public class TokenResponseGenerator : ITokenResponseGenerator
         var response = new TokenResponse
         {
             AccessToken = accessToken,
+            AccessTokenType = request.ValidatedRequest.ContainsDPoPProofToken ? "DPoP" : OidcConstants.TokenResponse.BearerTokenType,
             AccessTokenLifetime = request.ValidatedRequest.AccessTokenLifetime,
             Custom = request.CustomResponse,
             Scope = request.ValidatedRequest.ValidatedResources.RawScopeValues.ToSpaceSeparatedString()
@@ -327,6 +330,7 @@ public class TokenResponseGenerator : ITokenResponseGenerator
         var response = new TokenResponse
         {
             AccessToken = accessToken,
+            AccessTokenType = request.ValidatedRequest.ContainsDPoPProofToken ? "DPoP" : OidcConstants.TokenResponse.BearerTokenType,
             AccessTokenLifetime = request.ValidatedRequest.AccessTokenLifetime,
             Custom = request.CustomResponse,
             Scope = request.ValidatedRequest.ValidatedResources.RawScopeValues.ToSpaceSeparatedString()
@@ -394,6 +398,7 @@ public class TokenResponseGenerator : ITokenResponseGenerator
         var response = new TokenResponse
         {
             AccessToken = accessToken,
+            AccessTokenType = validationResult.ValidatedRequest.ContainsDPoPProofToken ? "DPoP" : OidcConstants.TokenResponse.BearerTokenType,
             AccessTokenLifetime = validationResult.ValidatedRequest.AccessTokenLifetime,
             Custom = validationResult.CustomResponse,
             Scope = validationResult.ValidatedRequest.ValidatedResources.RawScopeValues.ToSpaceSeparatedString()

--- a/src/IdentityServer/ResponseHandling/Default/TokenResponseGenerator.cs
+++ b/src/IdentityServer/ResponseHandling/Default/TokenResponseGenerator.cs
@@ -150,7 +150,7 @@ public class TokenResponseGenerator : ITokenResponseGenerator
         var response = new TokenResponse
         {
             AccessToken = accessToken,
-            AccessTokenType = request.ValidatedRequest.ContainsDPoPProofToken ? "DPoP" : OidcConstants.TokenResponse.BearerTokenType,
+            AccessTokenType = request.ValidatedRequest.DPoPKeyThumbprint.IsPresent() ? "DPoP" : OidcConstants.TokenResponse.BearerTokenType,
             AccessTokenLifetime = request.ValidatedRequest.AccessTokenLifetime,
             Custom = request.CustomResponse,
             Scope = request.ValidatedRequest.ValidatedResources.RawScopeValues.ToSpaceSeparatedString()
@@ -243,7 +243,7 @@ public class TokenResponseGenerator : ITokenResponseGenerator
         {
             IdentityToken = await CreateIdTokenFromRefreshTokenRequestAsync(request.ValidatedRequest, accessTokenString),
             AccessToken = accessTokenString,
-            AccessTokenType = request.ValidatedRequest.ContainsDPoPProofToken ? "DPoP" : OidcConstants.TokenResponse.BearerTokenType, 
+            AccessTokenType = request.ValidatedRequest.DPoPKeyThumbprint.IsPresent() ? "DPoP" : OidcConstants.TokenResponse.BearerTokenType, 
             AccessTokenLifetime = request.ValidatedRequest.AccessTokenLifetime,
             RefreshToken = handle,
             Custom = request.CustomResponse,
@@ -267,7 +267,7 @@ public class TokenResponseGenerator : ITokenResponseGenerator
         var response = new TokenResponse
         {
             AccessToken = accessToken,
-            AccessTokenType = request.ValidatedRequest.ContainsDPoPProofToken ? "DPoP" : OidcConstants.TokenResponse.BearerTokenType,
+            AccessTokenType = request.ValidatedRequest.DPoPKeyThumbprint.IsPresent() ? "DPoP" : OidcConstants.TokenResponse.BearerTokenType,
             AccessTokenLifetime = request.ValidatedRequest.AccessTokenLifetime,
             Custom = request.CustomResponse,
             Scope = request.ValidatedRequest.ValidatedResources.RawScopeValues.ToSpaceSeparatedString()
@@ -330,7 +330,7 @@ public class TokenResponseGenerator : ITokenResponseGenerator
         var response = new TokenResponse
         {
             AccessToken = accessToken,
-            AccessTokenType = request.ValidatedRequest.ContainsDPoPProofToken ? "DPoP" : OidcConstants.TokenResponse.BearerTokenType,
+            AccessTokenType = request.ValidatedRequest.DPoPKeyThumbprint.IsPresent() ? "DPoP" : OidcConstants.TokenResponse.BearerTokenType,
             AccessTokenLifetime = request.ValidatedRequest.AccessTokenLifetime,
             Custom = request.CustomResponse,
             Scope = request.ValidatedRequest.ValidatedResources.RawScopeValues.ToSpaceSeparatedString()
@@ -398,7 +398,7 @@ public class TokenResponseGenerator : ITokenResponseGenerator
         var response = new TokenResponse
         {
             AccessToken = accessToken,
-            AccessTokenType = validationResult.ValidatedRequest.ContainsDPoPProofToken ? "DPoP" : OidcConstants.TokenResponse.BearerTokenType,
+            AccessTokenType = validationResult.ValidatedRequest.DPoPKeyThumbprint.IsPresent() ? "DPoP" : OidcConstants.TokenResponse.BearerTokenType,
             AccessTokenLifetime = validationResult.ValidatedRequest.AccessTokenLifetime,
             Custom = validationResult.CustomResponse,
             Scope = validationResult.ValidatedRequest.ValidatedResources.RawScopeValues.ToSpaceSeparatedString()

--- a/src/IdentityServer/ResponseHandling/Models/TokenResponse.cs
+++ b/src/IdentityServer/ResponseHandling/Models/TokenResponse.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 
+using IdentityModel;
 using System.Collections.Generic;
 
 namespace Duende.IdentityServer.ResponseHandling;
@@ -11,6 +12,11 @@ namespace Duende.IdentityServer.ResponseHandling;
 /// </summary>
 public class TokenResponse
 {
+    /// <summary>
+    /// The type of access token, used to populate the token_type response parameter.
+    /// </summary>
+    public string AccessTokenType { get; set; }
+
     /// <summary>
     /// Gets or sets the identity token.
     /// </summary>

--- a/src/IdentityServer/Services/Default/DefaultRefreshTokenService.cs
+++ b/src/IdentityServer/Services/Default/DefaultRefreshTokenService.cs
@@ -213,6 +213,7 @@ public class DefaultRefreshTokenService : IRefreshTokenService
             Description = request.Description,
             AuthorizedScopes = request.AuthorizedScopes,
             AuthorizedResourceIndicators = request.AuthorizedResourceIndicators,
+            DPoPKeyThumbprint = request.DPoPKeyThumbprint,
 
             CreationTime = Clock.UtcNow.UtcDateTime,
             Lifetime = lifetime,

--- a/src/IdentityServer/Validation/Contexts/CustomTokenRequestValidationContext.cs
+++ b/src/IdentityServer/Validation/Contexts/CustomTokenRequestValidationContext.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/src/IdentityServer/Validation/Contexts/DPoPProofValidatonContext.cs
+++ b/src/IdentityServer/Validation/Contexts/DPoPProofValidatonContext.cs
@@ -1,18 +1,15 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
-
-using System.Threading.Tasks;
-
 namespace Duende.IdentityServer.Validation;
 
 /// <summary>
-/// Validator for handling DPoP proofs.
+/// Models the context for validaing DPoP proof tokens.
 /// </summary>
-public interface IDPoPProofValidator
+public class DPoPProofValidatonContext
 {
     /// <summary>
-    /// Validates the DPoP proof.
+    /// The DPoP proof token to validate.
     /// </summary>
-    Task<DPoPProofValidatonResult> ValidateAsync(DPoPProofValidatonContext context);
+    public string ProofToken { get; internal set; }
 }

--- a/src/IdentityServer/Validation/Contexts/DPoPProofValidatonContext.cs
+++ b/src/IdentityServer/Validation/Contexts/DPoPProofValidatonContext.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
+using Duende.IdentityServer.Models;
+
 namespace Duende.IdentityServer.Validation;
 
 /// <summary>
@@ -9,7 +11,12 @@ namespace Duende.IdentityServer.Validation;
 public class DPoPProofValidatonContext
 {
     /// <summary>
-    /// The DPoP proof token to validate.
+    /// The client presenting the DPoP proof
     /// </summary>
-    public string ProofToken { get; internal set; }
+    public Client Client { get; set; }
+
+    /// <summary>
+    /// The DPoP proof token to validate
+    /// </summary>
+    public string ProofToken { get; set; }
 }

--- a/src/IdentityServer/Validation/Contexts/TokenRequestValidationContext.cs
+++ b/src/IdentityServer/Validation/Contexts/TokenRequestValidationContext.cs
@@ -2,13 +2,10 @@
 // See LICENSE in the project root for license information.
 
 
-using Microsoft.AspNetCore.DataProtection.KeyManagement;
 using Microsoft.AspNetCore.Http;
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 
 namespace Duende.IdentityServer.Validation;
 
@@ -45,7 +42,7 @@ public interface IHeaderCollection
     ///     This parameter is passed uninitialized.
     /// Returns true if the collection contains an element with the specified key; otherwise, false.
     /// </summary>
-    bool TryGetValue(string key, out string value);
+    bool TryGetValues(string key, out string[] values);
 }
 
 internal class HeaderCollection : IHeaderCollection
@@ -57,19 +54,19 @@ internal class HeaderCollection : IHeaderCollection
         _headers = headers ?? throw new ArgumentNullException(nameof(headers));
     }
 
-    public bool TryGetValue(string key, out string value)
+    public bool TryGetValues(string key, out string[] values)
     {
-        var result = _headers.TryGetValue(key, out var values);
-        value = values;
+        var result = _headers.TryGetValue(key, out var value);
+        values = value.ToArray();
         return result;
     }
 }
 
 internal class EmptyHeaderCollection : IHeaderCollection
 {
-    public bool TryGetValue(string key, out string value)
+    public bool TryGetValues(string key, out string[] values)
     {
-        value = null;
+        values = Enumerable.Empty<string>().ToArray();
         return false;
     }
 }

--- a/src/IdentityServer/Validation/Contexts/TokenRequestValidationContext.cs
+++ b/src/IdentityServer/Validation/Contexts/TokenRequestValidationContext.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+using Microsoft.AspNetCore.DataProtection.KeyManagement;
+using Microsoft.AspNetCore.Http;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Duende.IdentityServer.Validation;
+
+/// <summary>
+/// Class describing the token endpoint request validation context
+/// </summary>
+public class TokenRequestValidationContext
+{
+    /// <summary>
+    /// The request form parameters.
+    /// </summary>
+    public NameValueCollection RequestParameters { get; set; }
+
+    /// <summary>
+    /// The validaiton result of client authentication.
+    /// </summary>
+    public ClientSecretValidationResult ClientValidationResult { get; set; }
+
+    /// <summary>
+    /// The request headers.
+    /// </summary>
+    public IHeaderCollection RequestHeaders { get; set; } = new EmptyHeaderCollection();
+}
+
+/// <summary>
+/// Abstracts accessing the HTTP request headers.
+/// </summary>
+public interface IHeaderCollection
+{
+    /// <summary>
+    /// Gets the value associated with the specified key.
+    ///     When this method returns, the value associated with the specified key, if the
+    ///     key is found; otherwise, the default value for the type of the value parameter.
+    ///     This parameter is passed uninitialized.
+    /// Returns true if the collection contains an element with the specified key; otherwise, false.
+    /// </summary>
+    bool TryGetValue(string key, out string value);
+}
+
+internal class HeaderCollection : IHeaderCollection
+{
+    readonly IHeaderDictionary _headers;
+
+    public HeaderCollection(IHeaderDictionary headers)
+    {
+        _headers = headers ?? throw new ArgumentNullException(nameof(headers));
+    }
+
+    public bool TryGetValue(string key, out string value)
+    {
+        var result = _headers.TryGetValue(key, out var values);
+        value = values;
+        return result;
+    }
+}
+
+internal class EmptyHeaderCollection : IHeaderCollection
+{
+    public bool TryGetValue(string key, out string value)
+    {
+        value = null;
+        return false;
+    }
+}

--- a/src/IdentityServer/Validation/Default/AuthorizeRequestValidator.cs
+++ b/src/IdentityServer/Validation/Default/AuthorizeRequestValidator.cs
@@ -909,6 +909,22 @@ internal class AuthorizeRequestValidator : IAuthorizeRequestValidator
             request.SessionId = ""; // empty string for anonymous users
         }
 
+        //////////////////////////////////////////////////////////
+        // DPoP
+        //////////////////////////////////////////////////////////
+        // TODO: IdentityModel
+        var dpop_jwk = request.Raw.Get("dpop_jkt");
+        if (dpop_jwk.IsPresent())
+        {
+            request.DPoPKeyThumbprint = dpop_jwk;
+        }
+        // TODO: this is OPTIONAL in spec, but do we want to do this check here if client is required?
+        //else if (request.Client.RequireDPoP)
+        //{
+        //    LogError("Client is configured to require DPoP and the 'dpop_jkt' parameter is missing.", request);
+        //    return Invalid(request, description: "Missing dpop_jkt");
+        //}
+
         return Valid(request);
     }
 

--- a/src/IdentityServer/Validation/Default/DefaultDPoPProofValidator.cs
+++ b/src/IdentityServer/Validation/Default/DefaultDPoPProofValidator.cs
@@ -1,0 +1,108 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Duende.IdentityServer.Configuration;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.IdentityModel.JsonWebTokens;
+using System;
+
+namespace Duende.IdentityServer.Validation;
+
+/// <summary>
+/// Default implementation of IDPoPProofValidator
+/// </summary>
+public class DefaultDPoPProofValidator : IDPoPProofValidator
+{
+    private readonly ISystemClock _clock;
+    private readonly ILogger _logger;
+
+    /// <summary>
+    /// ctor
+    /// </summary>
+    public DefaultDPoPProofValidator(
+        IdentityServerOptions options,
+        ISystemClock clock, 
+        ILogger<DefaultDPoPProofValidator> logger)
+    {
+        _logger = logger;
+        _clock = clock;
+    }
+
+    /// <inheritdoc/>
+    public async Task<DPoPProofValidatonResult> ValidateAsync(DPoPProofValidatonContext context)
+    {
+        var result = new DPoPProofValidatonResult();
+
+        if (String.IsNullOrEmpty(context?.ProofTooken))
+        {
+            // TODO: IdentityModel
+            result.Error = "invalid_dpop_proof";
+            result.ErrorDescription = "Missing DPoP proof value.";
+        }
+        else
+        {
+            await ValidateHeaderAsync(context, result);
+            if (!result.IsError)
+            {
+                await ValidateSignatureAsync(context, result);
+                if (!result.IsError)
+                {
+                    await ValidatePayloadAsync(context, result);
+                    if (!result.IsError)
+                    {
+                        await ValidateFreshnessAsync(context, result);
+                        if (result.IsError)
+                        {
+                            _logger.LogDebug("Failed to validate DPoP token freshness");
+                        }
+                    }
+                    else
+                    {
+                        _logger.LogDebug("Failed to validate DPoP payload");
+                    }
+                }
+                else
+                {
+                    _logger.LogDebug("Failed to validate DPoP signature");
+                }
+            }
+            else
+            {
+                _logger.LogDebug("Failed to validate DPoP header");
+            }
+        }
+
+        return result;
+    }
+
+    private Task ValidateHeaderAsync(DPoPProofValidatonContext context, DPoPProofValidatonResult result)
+    {
+        var handler = new JsonWebTokenHandler();
+        var token = handler.ReadJsonWebToken(context.ProofTooken);
+
+        var typ = token.GetHeaderValue<string>("typ");
+        var alg = token.GetHeaderValue<string>("alg");
+        var jwk = token.GetHeaderValue<IDictionary<string, object>>("jwk");
+        
+        return Task.CompletedTask;
+    }
+
+    private Task ValidateSignatureAsync(DPoPProofValidatonContext context, DPoPProofValidatonResult result)
+    {
+        return Task.CompletedTask;
+    }
+
+    private Task ValidatePayloadAsync(DPoPProofValidatonContext context, DPoPProofValidatonResult result)
+    {
+        return Task.CompletedTask;
+    }
+
+    private Task ValidateFreshnessAsync(DPoPProofValidatonContext context, DPoPProofValidatonResult result)
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/src/IdentityServer/Validation/Default/DefaultDPoPProofValidator.cs
+++ b/src/IdentityServer/Validation/Default/DefaultDPoPProofValidator.cs
@@ -9,6 +9,12 @@ using Duende.IdentityServer.Configuration;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.IdentityModel.JsonWebTokens;
 using System;
+using Duende.IdentityServer.Extensions;
+using System.Text.Json;
+using IdentityModel;
+using System.Linq;
+using Duende.IdentityServer.Services;
+using static Duende.IdentityServer.Constants;
 
 namespace Duende.IdentityServer.Validation;
 
@@ -17,91 +23,235 @@ namespace Duende.IdentityServer.Validation;
 /// </summary>
 public class DefaultDPoPProofValidator : IDPoPProofValidator
 {
-    private readonly ISystemClock _clock;
-    private readonly ILogger _logger;
+    /// <summary>
+    /// The clock
+    /// </summary>
+    protected readonly ISystemClock Clock;
+
+    /// <summary>
+    /// The server urls service
+    /// </summary>
+    protected readonly IServerUrls ServerUrls;
+
+    /// <summary>
+    /// The logger
+    /// </summary>
+    protected readonly ILogger Logger;
 
     /// <summary>
     /// ctor
     /// </summary>
     public DefaultDPoPProofValidator(
-        IdentityServerOptions options,
-        ISystemClock clock, 
+        IServerUrls server,
+        ISystemClock clock,
         ILogger<DefaultDPoPProofValidator> logger)
     {
-        _logger = logger;
-        _clock = clock;
+        Clock = clock;
+        ServerUrls = server;
+        Logger = logger;
     }
 
     /// <inheritdoc/>
     public async Task<DPoPProofValidatonResult> ValidateAsync(DPoPProofValidatonContext context)
     {
-        var result = new DPoPProofValidatonResult();
+        var result = new DPoPProofValidatonResult() { IsError = false };
 
-        if (String.IsNullOrEmpty(context?.ProofTooken))
+        try
         {
-            // TODO: IdentityModel
-            result.Error = "invalid_dpop_proof";
-            result.ErrorDescription = "Missing DPoP proof value.";
-        }
-        else
-        {
-            await ValidateHeaderAsync(context, result);
-            if (!result.IsError)
+            if (String.IsNullOrEmpty(context?.ProofToken))
             {
-                await ValidateSignatureAsync(context, result);
-                if (!result.IsError)
-                {
-                    await ValidatePayloadAsync(context, result);
-                    if (!result.IsError)
-                    {
-                        await ValidateFreshnessAsync(context, result);
-                        if (result.IsError)
-                        {
-                            _logger.LogDebug("Failed to validate DPoP token freshness");
-                        }
-                    }
-                    else
-                    {
-                        _logger.LogDebug("Failed to validate DPoP payload");
-                    }
-                }
-                else
-                {
-                    _logger.LogDebug("Failed to validate DPoP signature");
-                }
+                result.IsError = true;
+                result.ErrorDescription = "Missing DPoP proof value.";
+                return result;
             }
-            else
+
+            await ValidateHeaderAsync(context, result);
+            if (result.IsError)
             {
-                _logger.LogDebug("Failed to validate DPoP header");
+                Logger.LogDebug("Failed to validate DPoP header");
+                return result;
+            }
+
+            await ValidateSignatureAsync(context, result);
+            if (result.IsError)
+            {
+                Logger.LogDebug("Failed to validate DPoP signature");
+                return result;
+            }
+
+            await ValidatePayloadAsync(context, result);
+            if (result.IsError)
+            {
+                Logger.LogDebug("Failed to validate DPoP payload");
+                return result;
+            }
+
+            await ValidateFreshnessAsync(context, result);
+            if (result.IsError)
+            {
+                Logger.LogDebug("Failed to validate DPoP token freshness");
+                return result;
+
+            }
+
+            Logger.LogDebug("Successfully validated DPoP proof token with thumbprint: {jkt}", result.JsonWebKeyThumbprint);
+            result.IsError = false;
+        }
+        finally
+        {
+            if (result.IsError && result.Error.IsMissing())
+            {
+                // TODO: IdentityModel
+                result.Error = "invalid_dpop_proof";
             }
         }
 
         return result;
     }
 
-    private Task ValidateHeaderAsync(DPoPProofValidatonContext context, DPoPProofValidatonResult result)
+    /// <summary>
+    /// Validates the header.
+    /// </summary>
+    protected virtual Task ValidateHeaderAsync(DPoPProofValidatonContext context, DPoPProofValidatonResult result)
     {
-        var handler = new JsonWebTokenHandler();
-        var token = handler.ReadJsonWebToken(context.ProofTooken);
+        JsonWebToken token;
 
-        var typ = token.GetHeaderValue<string>("typ");
-        var alg = token.GetHeaderValue<string>("alg");
-        var jwk = token.GetHeaderValue<IDictionary<string, object>>("jwk");
-        
+        try
+        {
+            var handler = new JsonWebTokenHandler();
+            token = handler.ReadJsonWebToken(context.ProofToken);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug("Error parsing DPoP token: {error}", ex.Message);
+            result.IsError = true;
+            result.ErrorDescription = "Malformed DPoP token.";
+            return Task.CompletedTask;
+        }
+
+        if (!token.TryGetHeaderValue<string>("typ", out var typ) || typ != "dpop+jwk")
+        {
+            result.IsError = true;
+            result.ErrorDescription = "Invalid 'typ' value.";
+            return Task.CompletedTask;
+        }
+
+        if (!token.TryGetHeaderValue<string>("alg", out var alg) || !IdentityServerConstants.SupportedDPoPSigningAlgorithms.Contains(alg))
+        {
+            result.IsError = true;
+            result.ErrorDescription = "Invalid 'alg' value.";
+            return Task.CompletedTask;
+        }
+
+        if (!token.TryGetHeaderValue<IDictionary<string, object>>("jwk", out var jwkValues))
+        {
+            result.IsError = true;
+            result.ErrorDescription = "Invalid 'jwk' value.";
+            return Task.CompletedTask;
+        }
+
+        result.JsonWebKey = JsonSerializer.Serialize(jwkValues);
+
+        Microsoft.IdentityModel.Tokens.JsonWebKey jwt;
+        try
+        {
+            jwt = new Microsoft.IdentityModel.Tokens.JsonWebKey(result.JsonWebKey);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug("Error parsing DPoP jwk value: {error}", ex.Message);
+            result.IsError = true;
+            result.ErrorDescription = "Invalid 'jwk' value.";
+            return Task.CompletedTask;
+        }
+
+        if (jwt.HasPrivateKey)
+        {
+            result.IsError = true;
+            result.ErrorDescription = "'jwk' value contains a private key.";
+            return Task.CompletedTask;
+        }
+
+        result.JsonWebKeyThumbprint = Base64Url.Encode(jwt.ComputeJwkThumbprint());
+
         return Task.CompletedTask;
     }
 
-    private Task ValidateSignatureAsync(DPoPProofValidatonContext context, DPoPProofValidatonResult result)
+    /// <summary>
+    /// Validates the signature.
+    /// </summary>
+    protected virtual Task ValidateSignatureAsync(DPoPProofValidatonContext context, DPoPProofValidatonResult result)
     {
+        Microsoft.IdentityModel.Tokens.TokenValidationResult tokenValidationResult;
+
+        try
+        {
+            var key = new Microsoft.IdentityModel.Tokens.JsonWebKey(result.JsonWebKey);
+            var tvp = new Microsoft.IdentityModel.Tokens.TokenValidationParameters 
+            {
+                ValidateAudience = false,
+                ValidateIssuer = false,
+                ValidateLifetime = false,
+                IssuerSigningKey = key,
+            };
+            
+            var handler = new JsonWebTokenHandler();
+            tokenValidationResult = handler.ValidateToken(context.ProofToken, tvp);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug("Error parsing DPoP token: {error}", ex.Message);
+            result.IsError = true;
+            result.ErrorDescription = "Invalid signature on DPoP token.";
+            return Task.CompletedTask;
+        }
+
+        if (tokenValidationResult.Exception != null)
+        {
+            Logger.LogDebug("Error parsing DPoP token: {error}", tokenValidationResult.Exception.Message);
+            result.IsError = true;
+            result.ErrorDescription = "Invalid signature on DPoP token.";
+            return Task.CompletedTask;
+        }
+
+        result.ProofPayload = tokenValidationResult.Claims;
+
         return Task.CompletedTask;
     }
 
-    private Task ValidatePayloadAsync(DPoPProofValidatonContext context, DPoPProofValidatonResult result)
+    /// <summary>
+    /// Validates the payload.
+    /// </summary>
+    protected virtual Task ValidatePayloadAsync(DPoPProofValidatonContext context, DPoPProofValidatonResult result)
     {
+        if (!result.ProofPayload.TryGetValue(JwtClaimTypes.JwtId, out var jti) || jti is not string)
+        {
+            result.IsError = true;
+            result.ErrorDescription = "Invalid 'jti' value.";
+        }
+
+        // TODO: validate jti against replay cache
+
+        if (!result.ProofPayload.TryGetValue("htm", out var htm) || !"POST".Equals(htm))
+        {
+            result.IsError = true;
+            result.ErrorDescription = "Invalid 'htm' value.";
+        }
+
+        var tokenUrl = ServerUrls.BaseUrl.EnsureTrailingSlash() + ProtocolRoutePaths.Token;
+        if (!result.ProofPayload.TryGetValue("htu", out var htu) || !tokenUrl.Equals(htu))
+        {
+            result.IsError = true;
+            result.ErrorDescription = "Invalid 'htu' value.";
+        }
+
         return Task.CompletedTask;
     }
 
-    private Task ValidateFreshnessAsync(DPoPProofValidatonContext context, DPoPProofValidatonResult result)
+    /// <summary>
+    /// Validates the freshness.
+    /// </summary>
+    protected virtual Task ValidateFreshnessAsync(DPoPProofValidatonContext context, DPoPProofValidatonResult result)
     {
         return Task.CompletedTask;
     }

--- a/src/IdentityServer/Validation/Default/TokenRequestValidator.cs
+++ b/src/IdentityServer/Validation/Default/TokenRequestValidator.cs
@@ -182,7 +182,7 @@ internal class TokenRequestValidator : ITokenRequestValidator
 
             var dpopContext = new DPoPProofValidatonContext
             {
-                ProofTooken = dpopHeader.Single(),
+                ProofToken = dpopHeader.Single(),
             };
             var dpopResult = await _dPoPProofValidator.ValidateAsync(dpopContext);
             if (dpopResult.IsError)

--- a/src/IdentityServer/Validation/Default/TokenRequestValidator.cs
+++ b/src/IdentityServer/Validation/Default/TokenRequestValidator.cs
@@ -320,7 +320,7 @@ internal class TokenRequestValidator : ITokenRequestValidator
         //////////////////////////////////////////////////////////
         // DPoP
         //////////////////////////////////////////////////////////
-        if (authZcode.DPoPKeyThumbprint != null && _validatedRequest.DPoPKeyThumbprint != authZcode.DPoPKeyThumbprint)
+        if (authZcode.DPoPKeyThumbprint.IsPresent() && _validatedRequest.DPoPKeyThumbprint != authZcode.DPoPKeyThumbprint)
         {
             LogError("The DPoP proof token thumbprint in code exchange request does not match the original used on the authorize endpoint.");
             return Invalid("invalid_dpop_proof", "The DPoP proof token thumbprint in code exchange request does not match the original used on the authorize endpoint.");
@@ -646,7 +646,7 @@ internal class TokenRequestValidator : ITokenRequestValidator
         //////////////////////////////////////////////////////////
         // DPoP
         //////////////////////////////////////////////////////////
-        if (_validatedRequest.ContainsDPoPProofToken)
+        if (_validatedRequest.DPoPKeyThumbprint.IsPresent())
         {
             if (_validatedRequest.DPoPKeyThumbprint != result.RefreshToken.DPoPKeyThumbprint)
             {
@@ -656,7 +656,7 @@ internal class TokenRequestValidator : ITokenRequestValidator
         }
         else
         {
-            if (result.RefreshToken.DPoPKeyThumbprint != null && !_validatedRequest.Client.RequireClientSecret)
+            if (result.RefreshToken.DPoPKeyThumbprint.IsPresent() && !_validatedRequest.Client.RequireClientSecret)
             {
                 LogError("DPoP proof token required.");
                 return Invalid("invalid_dpop_proof", "DPoP proof token required.");

--- a/src/IdentityServer/Validation/Default/TokenRequestValidator.cs
+++ b/src/IdentityServer/Validation/Default/TokenRequestValidator.cs
@@ -182,6 +182,7 @@ internal class TokenRequestValidator : ITokenRequestValidator
 
             var dpopContext = new DPoPProofValidatonContext
             {
+                Client = _validatedRequest.Client,
                 ProofToken = dpopHeader.Single(),
             };
             var dpopResult = await _dPoPProofValidator.ValidateAsync(dpopContext);

--- a/src/IdentityServer/Validation/Default/TokenRequestValidator.cs
+++ b/src/IdentityServer/Validation/Default/TokenRequestValidator.cs
@@ -192,6 +192,7 @@ internal class TokenRequestValidator : ITokenRequestValidator
                 return Invalid(dpopResult.Error, dpopResult.ErrorDescription);
             }
 
+            _validatedRequest.ContainsDPoPProofToken = true;
             _validatedRequest.Confirmation = dpopResult.CreateThumbprintCnf();
         }
         else if (_validatedRequest.Client.RequireDPoP)

--- a/src/IdentityServer/Validation/Default/TokenValidator.cs
+++ b/src/IdentityServer/Validation/Default/TokenValidator.cs
@@ -430,6 +430,11 @@ internal class TokenValidator : ITokenValidator
                 ClaimValueTypes.Integer64)
         };
 
+        if (!String.IsNullOrEmpty(token.Confirmation))
+        {
+            claims.Add(new Claim(JwtClaimTypes.Confirmation, token.Confirmation, IdentityServerConstants.ClaimValueTypes.Json));
+        }
+
         foreach (var aud in token.Audiences)
         {
             claims.Add(new Claim(JwtClaimTypes.Audience, aud));

--- a/src/IdentityServer/Validation/IDPoPProofValidator.cs
+++ b/src/IdentityServer/Validation/IDPoPProofValidator.cs
@@ -28,7 +28,7 @@ public class DPoPProofValidatonContext
     /// <summary>
     /// The DPoP proof token to validate.
     /// </summary>
-    public string ProofTooken { get; internal set; }
+    public string ProofToken { get; internal set; }
 }
 
 /// <summary>
@@ -40,6 +40,16 @@ public class DPoPProofValidatonResult : ValidationResult
     /// The JWK thumbprint from the validated DPoP proof token.
     /// </summary>
     public string JsonWebKeyThumbprint { get; set; }
+
+    /// <summary>
+    /// The payload of the DPoP proof token.
+    /// </summary>
+    public IDictionary<string, object> ProofPayload { get; internal set; }
+
+    /// <summary>
+    /// The serialized JWK from the validated DPoP proof token.
+    /// </summary>
+    public string JsonWebKey { get; set; }
 
     /// <summary>
     /// Create the "cnf" value from the JsonWebKeyThumbprint value;

--- a/src/IdentityServer/Validation/IDPoPProofValidator.cs
+++ b/src/IdentityServer/Validation/IDPoPProofValidator.cs
@@ -37,19 +37,39 @@ public class DPoPProofValidatonContext
 public class DPoPProofValidatonResult : ValidationResult
 {
     /// <summary>
+    /// The serialized JWK from the validated DPoP proof token.
+    /// </summary>
+    public string JsonWebKey { get; set; }
+
+    /// <summary>
     /// The JWK thumbprint from the validated DPoP proof token.
     /// </summary>
     public string JsonWebKeyThumbprint { get; set; }
 
     /// <summary>
-    /// The payload of the DPoP proof token.
+    /// The payload value of the DPoP proof token.
     /// </summary>
-    public IDictionary<string, object> ProofPayload { get; internal set; }
+    public IDictionary<string, object> Payload { get; internal set; }
 
     /// <summary>
-    /// The serialized JWK from the validated DPoP proof token.
+    /// The jti value read from the payload.
     /// </summary>
-    public string JsonWebKey { get; set; }
+    public string TokenId { get; set; }
+    
+    /// <summary>
+    /// The nonce value read from the payload.
+    /// </summary>
+    public string Nonce { get; set; }
+
+    /// <summary>
+    /// The iat value read from the payload.
+    /// </summary>
+    public long? IssuedAt{ get; set; }
+
+    /// <summary>
+    /// The nonce value issued by the server.
+    /// </summary>
+    public string ServerIssuedNonce { get; set; }
 
     /// <summary>
     /// Create the "cnf" value from the JsonWebKeyThumbprint value;

--- a/src/IdentityServer/Validation/IDPoPProofValidator.cs
+++ b/src/IdentityServer/Validation/IDPoPProofValidator.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace Duende.IdentityServer.Validation;
+
+/// <summary>
+/// Validator for handling DPoP proofs.
+/// </summary>
+public interface IDPoPProofValidator
+{
+    /// <summary>
+    /// Validates the DPoP proof.
+    /// </summary>
+    Task<DPoPProofValidatonResult> ValidateAsync(DPoPProofValidatonContext context);
+}
+
+/// <summary>
+/// 
+/// </summary>
+public class DPoPProofValidatonContext
+{
+    /// <summary>
+    /// The DPoP proof token to validate.
+    /// </summary>
+    public string ProofTooken { get; internal set; }
+}
+
+/// <summary>
+/// Models the result of DPoP proof validation.
+/// </summary>
+public class DPoPProofValidatonResult : ValidationResult
+{
+    /// <summary>
+    /// The JWK thumbprint from the validated DPoP proof token.
+    /// </summary>
+    public string JsonWebKeyThumbprint { get; set; }
+
+    /// <summary>
+    /// Create the "cnf" value from the JsonWebKeyThumbprint value;
+    /// </summary>
+    public string CreateThumbprintCnf()
+    {
+        if (String.IsNullOrWhiteSpace(JsonWebKeyThumbprint)) return String.Empty;
+
+        var values = new Dictionary<string, string>
+        {
+            // TODO: IdentityModel
+            { "jkt", JsonWebKeyThumbprint }
+        };
+        return JsonSerializer.Serialize(values);
+    }
+}

--- a/src/IdentityServer/Validation/ITokenRequestValidator.cs
+++ b/src/IdentityServer/Validation/ITokenRequestValidator.cs
@@ -12,11 +12,14 @@ namespace Duende.IdentityServer.Validation;
 /// </summary>
 public interface ITokenRequestValidator
 {
+    // TODO: can we remove? this was not designed to be replaced. can mark with obsolete and remove in v7.0?
     /// <summary>
     /// Validates the request.
     /// </summary>
-    /// <param name="parameters">The parameters.</param>
-    /// <param name="clientValidationResult">The client validation result.</param>
-    /// <returns></returns>
     Task<TokenRequestValidationResult> ValidateRequestAsync(NameValueCollection parameters, ClientSecretValidationResult clientValidationResult);
+
+    /// <summary>
+    /// Validates the request.
+    /// </summary>
+    Task<TokenRequestValidationResult> ValidateRequestAsync(TokenRequestValidationContext context) => ValidateRequestAsync(context.RequestParameters, context.ClientValidationResult);
 }

--- a/src/IdentityServer/Validation/Models/DPoPProofValidatonResult.cs
+++ b/src/IdentityServer/Validation/Models/DPoPProofValidatonResult.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace Duende.IdentityServer.Validation;
+
+/// <summary>
+/// Models the result of DPoP proof validation.
+/// </summary>
+public class DPoPProofValidatonResult : ValidationResult
+{
+    /// <summary>
+    /// The serialized JWK from the validated DPoP proof token.
+    /// </summary>
+    public string JsonWebKey { get; set; }
+
+    /// <summary>
+    /// The JWK thumbprint from the validated DPoP proof token.
+    /// </summary>
+    public string JsonWebKeyThumbprint { get; set; }
+
+    /// <summary>
+    /// The payload value of the DPoP proof token.
+    /// </summary>
+    public IDictionary<string, object> Payload { get; internal set; }
+
+    /// <summary>
+    /// The jti value read from the payload.
+    /// </summary>
+    public string TokenId { get; set; }
+    
+    /// <summary>
+    /// The nonce value read from the payload.
+    /// </summary>
+    public string Nonce { get; set; }
+
+    /// <summary>
+    /// The iat value read from the payload.
+    /// </summary>
+    public long? IssuedAt{ get; set; }
+
+    /// <summary>
+    /// The nonce value issued by the server.
+    /// </summary>
+    public string ServerIssuedNonce { get; set; }
+
+    /// <summary>
+    /// Create the "cnf" value from the JsonWebKeyThumbprint value;
+    /// </summary>
+    public string CreateThumbprintCnf()
+    {
+        if (String.IsNullOrWhiteSpace(JsonWebKeyThumbprint)) return String.Empty;
+
+        var values = new Dictionary<string, string>
+        {
+            // TODO: IdentityModel
+            { "jkt", JsonWebKeyThumbprint }
+        };
+        return JsonSerializer.Serialize(values);
+    }
+}

--- a/src/IdentityServer/Validation/Models/DPoPProofValidatonResult.cs
+++ b/src/IdentityServer/Validation/Models/DPoPProofValidatonResult.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 
@@ -47,19 +47,4 @@ public class DPoPProofValidatonResult : ValidationResult
     /// The nonce value issued by the server.
     /// </summary>
     public string ServerIssuedNonce { get; set; }
-
-    /// <summary>
-    /// Create the "cnf" value from the JsonWebKeyThumbprint value;
-    /// </summary>
-    public string CreateThumbprintCnf()
-    {
-        if (String.IsNullOrWhiteSpace(JsonWebKeyThumbprint)) return String.Empty;
-
-        var values = new Dictionary<string, string>
-        {
-            // TODO: IdentityModel
-            { "jkt", JsonWebKeyThumbprint }
-        };
-        return JsonSerializer.Serialize(values);
-    }
 }

--- a/src/IdentityServer/Validation/Models/ValidatedAuthorizeRequest.cs
+++ b/src/IdentityServer/Validation/Models/ValidatedAuthorizeRequest.cs
@@ -3,6 +3,7 @@
 
 
 using IdentityModel;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
@@ -204,7 +205,17 @@ public class ValidatedAuthorizeRequest : ValidatedRequest
     /// The request object
     /// </value>
     public string RequestObject { get; set; }
-        
+
+    /// <summary>
+    /// Flag to indicate if this request was made using a DPoP proof token.
+    /// </summary>
+    public bool ContainsDPoPProofToken => !String.IsNullOrEmpty(DPoPKeyThumbprint);
+
+    /// <summary>
+    /// The thumbprint of the associated DPoP proof key, if one was used.
+    /// </summary>
+    public string DPoPKeyThumbprint { get; set; }
+    
     /// <summary>
     /// Gets a value indicating whether an access token was requested.
     /// </summary>

--- a/src/IdentityServer/Validation/Models/ValidatedRequest.cs
+++ b/src/IdentityServer/Validation/Models/ValidatedRequest.cs
@@ -106,16 +106,6 @@ public class ValidatedRequest
     public string Confirmation { get; set; }
 
     /// <summary>
-    /// Flag to indicate if this request was made using a DPoP proof token.
-    /// </summary>
-    public bool ContainsDPoPProofToken => !String.IsNullOrEmpty(DPoPKeyThumbprint);
-
-    /// <summary>
-    /// The thumbprint of the associated DPoP proof key, if one was used.
-    /// </summary>
-    public string DPoPKeyThumbprint { get; set; }
-
-    /// <summary>
     /// Gets or sets the client ID that should be used for the current request (this is useful for token exchange scenarios)
     /// </summary>
     /// <value>

--- a/src/IdentityServer/Validation/Models/ValidatedRequest.cs
+++ b/src/IdentityServer/Validation/Models/ValidatedRequest.cs
@@ -108,7 +108,12 @@ public class ValidatedRequest
     /// <summary>
     /// Flag to indicate if this request was made using a DPoP proof token.
     /// </summary>
-    public bool ContainsDPoPProofToken { get; set; }
+    public bool ContainsDPoPProofToken => !String.IsNullOrEmpty(DPoPKeyThumbprint);
+
+    /// <summary>
+    /// The thumbprint of the associated DPoP proof key, if one was used.
+    /// </summary>
+    public string DPoPKeyThumbprint { get; set; }
 
     /// <summary>
     /// Gets or sets the client ID that should be used for the current request (this is useful for token exchange scenarios)

--- a/src/IdentityServer/Validation/Models/ValidatedRequest.cs
+++ b/src/IdentityServer/Validation/Models/ValidatedRequest.cs
@@ -106,6 +106,11 @@ public class ValidatedRequest
     public string Confirmation { get; set; }
 
     /// <summary>
+    /// Flag to indicate if this request was made using a DPoP proof token.
+    /// </summary>
+    public bool ContainsDPoPProofToken { get; set; }
+
+    /// <summary>
     /// Gets or sets the client ID that should be used for the current request (this is useful for token exchange scenarios)
     /// </summary>
     /// <value>

--- a/src/IdentityServer/Validation/Models/ValidatedTokenRequest.cs
+++ b/src/IdentityServer/Validation/Models/ValidatedTokenRequest.cs
@@ -3,6 +3,7 @@
 
 
 using Duende.IdentityServer.Models;
+using System;
 using System.Collections.Generic;
 
 namespace Duende.IdentityServer.Validation;
@@ -96,4 +97,14 @@ public class ValidatedTokenRequest : ValidatedRequest
     /// The backchannel authentication request.
     /// </value>
     public BackChannelAuthenticationRequest BackChannelAuthenticationRequest { get; set; }
+
+    /// <summary>
+    /// Flag to indicate if this request was made using a DPoP proof token.
+    /// </summary>
+    public bool ContainsDPoPProofToken => !String.IsNullOrEmpty(DPoPKeyThumbprint);
+
+    /// <summary>
+    /// The thumbprint of the associated DPoP proof key, if one was used.
+    /// </summary>
+    public string DPoPKeyThumbprint { get; set; }
 }

--- a/src/IdentityServer/Validation/Models/ValidatedTokenRequest.cs
+++ b/src/IdentityServer/Validation/Models/ValidatedTokenRequest.cs
@@ -99,11 +99,6 @@ public class ValidatedTokenRequest : ValidatedRequest
     public BackChannelAuthenticationRequest BackChannelAuthenticationRequest { get; set; }
 
     /// <summary>
-    /// Flag to indicate if this request was made using a DPoP proof token.
-    /// </summary>
-    public bool ContainsDPoPProofToken => !String.IsNullOrEmpty(DPoPKeyThumbprint);
-
-    /// <summary>
     /// The thumbprint of the associated DPoP proof key, if one was used.
     /// </summary>
     public string DPoPKeyThumbprint { get; set; }

--- a/src/Storage/Models/AuthorizationCode.cs
+++ b/src/Storage/Models/AuthorizationCode.cs
@@ -124,6 +124,11 @@ public class AuthorizationCode
     public string CodeChallengeMethod { get; set; }
 
     /// <summary>
+    /// The thumbprint of the associated DPoP proof key, if one was used.
+    /// </summary>
+    public string DPoPKeyThumbprint { get; set; }
+
+    /// <summary>
     /// Gets the description the user assigned to the device being authorized.
     /// </summary>
     /// <value>

--- a/src/Storage/Models/Client.cs
+++ b/src/Storage/Models/Client.cs
@@ -117,6 +117,11 @@ public class Client
     public bool AllowAccessTokensViaBrowser { get; set; } = false;
 
     /// <summary>
+    /// Specifies whether a DPoP (Demonstrating Proof-of-Possession) token is requied to be used by this client (defaults to <c>false</c>).
+    /// </summary>
+    public bool RequireDPoP { get; set; }
+
+    /// <summary>
     /// Specifies allowed URIs to return tokens or authorization codes to
     /// </summary>
     public ICollection<string> RedirectUris { get; set; } = new HashSet<string>();

--- a/src/Storage/Models/RefreshToken.cs
+++ b/src/Storage/Models/RefreshToken.cs
@@ -138,4 +138,9 @@ public class RefreshToken
     /// Non-null means there was an authorization step, and subsequent requested resource indicators must be in the original list.
     /// </summary>
     public IEnumerable<string> AuthorizedResourceIndicators { get; set; }
+
+    /// <summary>
+    /// The thumbprint of the associated DPoP proof key, if one was used.
+    /// </summary>
+    public string DPoPKeyThumbprint { get; set; }
 }

--- a/test/IdentityServer.IntegrationTests/Endpoints/Token/DPoPTokenEndpointTests.cs
+++ b/test/IdentityServer.IntegrationTests/Endpoints/Token/DPoPTokenEndpointTests.cs
@@ -1,0 +1,247 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+using FluentAssertions;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Duende.IdentityServer.Models;
+using Duende.IdentityServer.Test;
+using IntegrationTests.Common;
+using Xunit;
+using IdentityModel.Client;
+using System;
+using Microsoft.AspNetCore.Authentication;
+using System.IdentityModel.Tokens.Jwt;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+using System.Linq;
+
+namespace IntegrationTests.Endpoints.Token;
+
+public class DPoPTokenEndpointTests
+{
+    private const string Category = "DPoP Token endpoint";
+
+    IdentityServerPipeline _mockPipeline = new IdentityServerPipeline();
+
+    Client _dpopClient;
+
+    private DateTime _now = new DateTime(2020, 3, 10, 9, 0, 0, DateTimeKind.Utc);
+    public DateTime UtcNow
+    {
+        get
+        {
+            if (_now > DateTime.MinValue) return _now;
+            return DateTime.UtcNow;
+        }
+    }
+
+    Dictionary<string, object> _header;
+    Dictionary<string, object> _payload;
+    string _privateJWK = "{\"Crv\":null,\"D\":\"QeBWodq0hSYjfAxxo0VZleXLqwwZZeNWvvFfES4WyItao_-OJv1wKA7zfkZxbWkpK5iRbKrl2AMJ52AtUo5JJ6QZ7IjAQlgM0lBg3ltjb1aA0gBsK5XbiXcsV8DiAnRuy6-XgjAKPR8Lo-wZl_fdPbVoAmpSdmfn_6QXXPBai5i7FiyDbQa16pI6DL-5SCj7F78QDTRiJOqn5ElNvtoJEfJBm13giRdqeriFi3pCWo7H3QBgTEWtDNk509z4w4t64B2HTXnM0xj9zLnS42l7YplJC7MRibD4nVBMtzfwtGRKLj8beuDgtW9pDlQqf7RVWX5pHQgiHAZmUi85TEbYdQ\",\"DP\":\"h2F54OMaC9qq1yqR2b55QNNaChyGtvmTHSdqZJ8lJFqvUorlz-Uocj2BTowWQnaMd8zRKMdKlSeUuSv4Z6WmjSxSsNbonI6_II5XlZLWYqFdmqDS-xCmJY32voT5Wn7OwB9xj1msDqrFPg-PqSBOh5OppjCqXqDFcNvSkQSajXc\",\"DQ\":\"VABdS20Nxkmq6JWLQj7OjRxVJuYsHrfmWJmDA7_SYtlXaPUcg-GiHGQtzdDWEeEi0dlJjv9I3FdjKGC7CGwqtVygW38DzVYJsV2EmRNJc1-j-1dRs_pK9GWR4NYm0mVz_IhS8etIf9cfRJk90xU3AL3_J6p5WNF7I5ctkLpnt8M\",\"E\":\"AQAB\",\"K\":null,\"KeyOps\":[],\"Kty\":\"RSA\",\"N\":\"yWWAOSV3Z_BW9rJEFvbZyeU-q2mJWC0l8WiHNqwVVf7qXYgm9hJC0j1aPHku_Wpl38DpK3Xu3LjWOFG9OrCqga5Pzce3DDJKI903GNqz5wphJFqweoBFKOjj1wegymvySsLoPqqDNVYTKp4nVnECZS4axZJoNt2l1S1bC8JryaNze2stjW60QT-mIAGq9konKKN3URQ12dr478m0Oh-4WWOiY4HrXoSOklFmzK-aQx1JV_SZ04eIGfSw1pZZyqTaB1BwBotiy-QA03IRxwIXQ7BSx5EaxC5uMCMbzmbvJqjt-q8Y1wyl-UQjRucgp7hkfHSE1QT3zEex2Q3NFux7SQ\",\"Oth\":null,\"P\":\"_T7MTkeOh5QyqlYCtLQ2RWf2dAJ9i3wrCx4nEDm1c1biijhtVTL7uJTLxwQIM9O2PvOi5Dq-UiGy6rhHZqf5akWTeHtaNyI-2XslQfaS3ctRgmGtRQL_VihK-R9AQtDx4eWL4h-bDJxPaxby_cVo_j2MX5AeoC1kNmcCdDf_X0M\",\"Q\":\"y5ZSThaGLjaPj8Mk2nuD8TiC-sb4aAZVh9K-W4kwaWKfDNoPcNb_dephBNMnOp9M1br6rDbyG7P-Sy_LOOsKg3Q0wHqv4hnzGaOQFeMJH4HkXYdENC7B5JG9PefbC6zwcgZWiBnsxgKpScNWuzGF8x2CC-MdsQ1bkQeTPbJklIM\",\"QI\":\"i716Vt9II_Rt6qnjsEhfE4bej52QFG9a1hSnx5PDNvRrNqR_RpTA0lO9qeXSZYGHTW_b6ZXdh_0EUwRDEDHmaxjkIcTADq6JLuDltOhZuhLUSc5NCKLAVCZlPcaSzv8-bZm57mVcIpx0KyFHxvk50___Jgx1qyzwLX03mPGUbDQ\",\"Use\":null,\"X\":null,\"X5c\":[],\"X5t\":null,\"X5tS256\":null,\"X5u\":null,\"Y\":null,\"KeySize\":2048,\"HasPrivateKey\":true,\"CryptoProviderFactory\":{\"CryptoProviderCache\":{},\"CustomCryptoProvider\":null,\"CacheSignatureProviders\":true,\"SignatureProviderObjectPoolCacheSize\":80}}";
+    string _publicJWK = "{\"kty\":\"RSA\",\"use\":\"sig\",\"x5t\":null,\"e\":\"AQAB\",\"n\":\"yWWAOSV3Z_BW9rJEFvbZyeU-q2mJWC0l8WiHNqwVVf7qXYgm9hJC0j1aPHku_Wpl38DpK3Xu3LjWOFG9OrCqga5Pzce3DDJKI903GNqz5wphJFqweoBFKOjj1wegymvySsLoPqqDNVYTKp4nVnECZS4axZJoNt2l1S1bC8JryaNze2stjW60QT-mIAGq9konKKN3URQ12dr478m0Oh-4WWOiY4HrXoSOklFmzK-aQx1JV_SZ04eIGfSw1pZZyqTaB1BwBotiy-QA03IRxwIXQ7BSx5EaxC5uMCMbzmbvJqjt-q8Y1wyl-UQjRucgp7hkfHSE1QT3zEex2Q3NFux7SQ\",\"x5c\":null,\"x\":null,\"y\":null,\"crv\":null}";
+    string _JKT = "JGSVlE73oKtQQI1dypYg8_JNat0xJjsQNyOI5oxaZf4";
+
+    public DPoPTokenEndpointTests()
+    {
+        _mockPipeline.OnPostConfigureServices += services =>
+        {
+        };
+
+        _mockPipeline.Clients.AddRange(new Client[] {
+            _dpopClient = new Client
+            {
+                ClientId = "client1",
+                AllowedGrantTypes = GrantTypes.CodeAndClientCredentials,
+                ClientSecrets =
+                {
+                    new Secret("secret".Sha256()),
+                },
+                RedirectUris = { "https://client1/callback" },
+                AllowOfflineAccess = true,
+                AllowedScopes = new List<string> { "openid", "profile", "scope1" },
+            },
+        });
+
+        _mockPipeline.Users.Add(new TestUser
+        {
+            SubjectId = "123",
+            Username = "bob",
+            Password = "bob",
+            Claims = new Claim[]
+            {
+                new Claim("name", "Bob Loblaw"),
+                new Claim("email", "bob@loblaw.com"),
+                new Claim("role", "Attorney")
+            }
+        });
+
+        _mockPipeline.IdentityScopes.AddRange(new IdentityResource[] {
+            new IdentityResources.OpenId(),
+            new IdentityResources.Profile(),
+            new IdentityResources.Email()
+        });
+        _mockPipeline.ApiScopes.AddRange(new ApiScope[] {
+            new ApiScope
+            {
+                Name = "scope1"
+            },
+        });
+
+        _mockPipeline.Initialize();
+
+        _payload = new Dictionary<string, object>
+        {
+            { "jti", "random" },
+            { "htm", "POST" },
+            { "htu", IdentityServerPipeline.TokenEndpoint },
+            { "iat", DateTimeOffset.UtcNow.ToUnixTimeSeconds() },
+        };
+
+        CreateHeaderValuesFromPublicKey();
+    }
+
+    void CreateHeaderValuesFromPublicKey()
+    {
+        var jwk = JsonSerializer.Deserialize<JsonElement>(_publicJWK);
+        var jwkValues = new Dictionary<string, object>();
+        foreach (var item in jwk.EnumerateObject())
+        {
+            if (item.Value.ValueKind == JsonValueKind.String)
+            {
+                var val = item.Value.GetString();
+                if (!String.IsNullOrEmpty(val))
+                {
+                    jwkValues.Add(item.Name, val);
+                }
+            }
+            if (item.Value.ValueKind == JsonValueKind.False)
+            {
+                jwkValues.Add(item.Name, false);
+            }
+            if (item.Value.ValueKind == JsonValueKind.True)
+            {
+                jwkValues.Add(item.Name, true);
+            }
+            if (item.Value.ValueKind == JsonValueKind.Number)
+            {
+                jwkValues.Add(item.Name, item.Value.GetInt64());
+            }
+        }
+        _header = new Dictionary<string, object>()
+        {
+            //{ "alg", "RS265" }, // JsonWebTokenHandler requires adding this itself
+            { "typ", "dpop+jwk" },
+            { "jwk", jwkValues },
+        };
+    }
+
+    string CreateDPoPProofToken(string alg = "RS256", SecurityKey key = null)
+    {
+        key ??= new Microsoft.IdentityModel.Tokens.JsonWebKey(_privateJWK);
+        var handler = new JsonWebTokenHandler() { SetDefaultTimesOnTokenCreation = false };
+        var token = handler.CreateToken(JsonSerializer.Serialize(_payload), new SigningCredentials(key, alg), _header);
+        return token;
+    }
+
+    private IEnumerable<Claim> ParseAccessTokenClaims(TokenResponse tokenResponse)
+    {
+        tokenResponse.IsError.Should().BeFalse(tokenResponse.Error);
+
+        var handler = new JwtSecurityTokenHandler();
+        var token = handler.ReadJwtToken(tokenResponse.AccessToken);
+        return token.Claims;
+    }
+    private string GetJKT(TokenResponse tokenResponse)
+    {
+        var claims = ParseAccessTokenClaims(tokenResponse);
+        var cnf = claims.SingleOrDefault(x => x.Type == "cnf")?.Value;
+        if (cnf != null)
+        {
+            var json = JsonSerializer.Deserialize<JsonElement>(cnf);
+            return json.GetString("jkt");
+        }
+        return null;
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task valid_dpop_request_should_return_bound_access_token()
+    {
+        var dpopToken = CreateDPoPProofToken();
+        var request = new ClientCredentialsTokenRequest
+        {
+            Address = IdentityServerPipeline.TokenEndpoint,
+            ClientId = "client1",
+            ClientSecret = "secret",
+            Scope = "scope1",
+        };
+        request.Headers.Add("DPoP", dpopToken);
+
+        var response = await _mockPipeline.BackChannelClient.RequestClientCredentialsTokenAsync(request);
+        response.IsError.Should().BeFalse();
+        response.TokenType.Should().Be("DPoP");
+        var jkt = GetJKT(response);
+        jkt.Should().Be(_JKT);
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task invalid_dpop_request_should_fail()
+    {
+        var request = new ClientCredentialsTokenRequest
+        {
+            Address = IdentityServerPipeline.TokenEndpoint,
+            ClientId = "client1",
+            ClientSecret = "secret",
+            Scope = "scope1",
+        };
+        request.Headers.Add("DPoP", "malformed");
+
+        var response = await _mockPipeline.BackChannelClient.RequestClientCredentialsTokenAsync(request);
+        response.IsError.Should().BeTrue();
+        response.Error.Should().Be("invalid_dpop_proof");
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task missing_dpop_token_when_required_should_fail()
+    {
+        _dpopClient.RequireDPoP = true;
+
+        var request = new ClientCredentialsTokenRequest
+        {
+            Address = IdentityServerPipeline.TokenEndpoint,
+            ClientId = "client1",
+            ClientSecret = "secret",
+            Scope = "scope1",
+        };
+
+        var response = await _mockPipeline.BackChannelClient.RequestClientCredentialsTokenAsync(request);
+        response.IsError.Should().BeTrue();
+        response.Error.Should().Be("invalid_dpop_proof");
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task multiple_dpop_tokens_should_fail()
+    {
+        var dpopToken = CreateDPoPProofToken();
+        var request = new ClientCredentialsTokenRequest
+        {
+            Address = IdentityServerPipeline.TokenEndpoint,
+            ClientId = "client1",
+            ClientSecret = "secret",
+            Scope = "scope1",
+        };
+        request.Headers.Add("DPoP", dpopToken);
+        request.Headers.Add("DPoP", dpopToken);
+
+        var response = await _mockPipeline.BackChannelClient.RequestClientCredentialsTokenAsync(request);
+        response.IsError.Should().BeTrue();
+        response.Error.Should().Be("invalid_dpop_proof");
+    }
+}

--- a/test/IdentityServer.IntegrationTests/Endpoints/Token/DPoPTokenEndpointTests.cs
+++ b/test/IdentityServer.IntegrationTests/Endpoints/Token/DPoPTokenEndpointTests.cs
@@ -645,4 +645,86 @@ public class DPoPTokenEndpointTests
         introspectionResponse.IsError.Should().BeFalse();
         GetJKTFromCnfClaim(introspectionResponse.Claims).Should().Be(_JKT);
     }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task matching_dpop_key_thumbprint_on_authorize_endpoint_and_token_endpoint_should_succeed()
+    {
+        await _mockPipeline.LoginAsync("bob");
+
+        _mockPipeline.BrowserClient.AllowAutoRedirect = false;
+
+        var url = _mockPipeline.CreateAuthorizeUrl(
+            clientId: "client1",
+            responseType: "code",
+            responseMode: "query",
+            scope: "openid scope1 offline_access",
+            redirectUri: "https://client1/callback",
+            extra: new
+            {
+                dpop_jkt = _JKT
+            });
+        var response = await _mockPipeline.BrowserClient.GetAsync(url);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        response.Headers.Location.ToString().Should().StartWith("https://client1/callback");
+
+        var authorization = new AuthorizeResponse(response.Headers.Location.ToString());
+        authorization.IsError.Should().BeFalse();
+
+        var codeRequest = new AuthorizationCodeTokenRequest
+        {
+            Address = IdentityServerPipeline.TokenEndpoint,
+            ClientId = "client1",
+            ClientSecret = "secret",
+            Code = authorization.Code,
+            RedirectUri = "https://client1/callback",
+        };
+        codeRequest.Headers.Add("DPoP", CreateDPoPProofToken());
+
+        var codeResponse = await _mockPipeline.BackChannelClient.RequestAuthorizationCodeTokenAsync(codeRequest);
+        codeResponse.IsError.Should().BeFalse();
+        GetJKTFromAccessToken(codeResponse).Should().Be(_JKT);
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task mismatched_dpop_key_thumbprint_on_authorize_endpoint_and_token_endpoint_should_fail()
+    {
+        await _mockPipeline.LoginAsync("bob");
+
+        _mockPipeline.BrowserClient.AllowAutoRedirect = false;
+
+        var url = _mockPipeline.CreateAuthorizeUrl(
+            clientId: "client1",
+            responseType: "code",
+            responseMode: "query",
+            scope: "openid scope1 offline_access",
+            redirectUri: "https://client1/callback",
+            extra: new
+            {
+                dpop_jkt = "invalid"
+            });
+        var response = await _mockPipeline.BrowserClient.GetAsync(url);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        response.Headers.Location.ToString().Should().StartWith("https://client1/callback");
+
+        var authorization = new AuthorizeResponse(response.Headers.Location.ToString());
+        authorization.IsError.Should().BeFalse();
+
+        var codeRequest = new AuthorizationCodeTokenRequest
+        {
+            Address = IdentityServerPipeline.TokenEndpoint,
+            ClientId = "client1",
+            ClientSecret = "secret",
+            Code = authorization.Code,
+            RedirectUri = "https://client1/callback",
+        };
+        codeRequest.Headers.Add("DPoP", CreateDPoPProofToken());
+
+        var codeResponse = await _mockPipeline.BackChannelClient.RequestAuthorizationCodeTokenAsync(codeRequest);
+        codeResponse.IsError.Should().BeTrue();
+        codeResponse.Error.Should().Be("invalid_dpop_proof");
+    }
 }

--- a/test/IdentityServer.IntegrationTests/Endpoints/Token/DPoPTokenEndpointTests.cs
+++ b/test/IdentityServer.IntegrationTests/Endpoints/Token/DPoPTokenEndpointTests.cs
@@ -340,7 +340,7 @@ public class DPoPTokenEndpointTests
 
     [Fact]
     [Trait("Category", Category)]
-    public async Task when_client_authenticates_then_dpop_proof_should_be_optional_on_token_renewal()
+    public async Task when_client_requires_authentication_then_dpop_proof_should_be_optional_on_token_renewal()
     {
         await _mockPipeline.LoginAsync("bob");
 
@@ -392,7 +392,7 @@ public class DPoPTokenEndpointTests
 
     [Fact]
     [Trait("Category", Category)]
-    public async Task when_client_does_not_authenticate_then_dpop_proof_should_be_required_on_token_renewal()
+    public async Task when_client_does_not_require_authentication_then_dpop_proof_should_be_required_on_token_renewal()
     {
         _dpopClient.RequireClientSecret = false;
 

--- a/test/IdentityServer.UnitTests/Common/MockReplayCache.cs
+++ b/test/IdentityServer.UnitTests/Common/MockReplayCache.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+
+using Duende.IdentityServer.Services;
+using System;
+using System.Threading.Tasks;
+
+namespace UnitTests.Common;
+
+public class MockReplayCache : IReplayCache
+{
+    public bool Exists { get; set; }
+
+    public Task AddAsync(string purpose, string handle, DateTimeOffset expiration)
+    {
+        return Task.CompletedTask;
+    }
+
+    public Task<bool> ExistsAsync(string purpose, string handle)
+    {
+        return Task.FromResult(Exists);
+    }
+}

--- a/test/IdentityServer.UnitTests/Common/StubClock.cs
+++ b/test/IdentityServer.UnitTests/Common/StubClock.cs
@@ -9,6 +9,6 @@ namespace UnitTests.Common;
 
 internal class StubClock : ISystemClock
 {
-    public Func<DateTime> UtcNowFunc = () => DateTime.UtcNow;
+    public Func<DateTime> UtcNowFunc { get; set; } = () => DateTime.UtcNow;
     public DateTimeOffset UtcNow => new DateTimeOffset(UtcNowFunc());
 }

--- a/test/IdentityServer.UnitTests/Validation/DPoPProofValidatorTests.cs
+++ b/test/IdentityServer.UnitTests/Validation/DPoPProofValidatorTests.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Threading.Tasks;
+using Duende.IdentityServer.Configuration;
+using Duende.IdentityServer.Models;
+using Duende.IdentityServer.Stores;
+using Duende.IdentityServer.Validation;
+using FluentAssertions;
+using IdentityModel;
+using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.Tokens;
+using UnitTests.Common;
+using UnitTests.Validation.Setup;
+using UnitTests.Validation.TokenRequest_Validation;
+using Xunit;
+
+namespace UnitTests.Validation;
+
+public class DPoPProofValidatorTests
+{
+    private const string Category = "DPoP validator";
+
+    private IdentityServerOptions _options = new IdentityServerOptions();
+    private StubClock _clock = new StubClock();
+    
+    private DateTime _now = new DateTime(2020, 3, 10, 9, 0, 0, DateTimeKind.Utc);
+    public DateTime UtcNow
+    {
+        get
+        {
+            if (_now > DateTime.MinValue) return _now;
+            return DateTime.UtcNow;
+        }
+    }
+
+    DefaultDPoPProofValidator _subject;
+
+    public DPoPProofValidatorTests()
+    {
+        _clock.UtcNowFunc = () => UtcNow;
+        _subject = new DefaultDPoPProofValidator(_options, _clock, new LoggerFactory().CreateLogger<DefaultDPoPProofValidator>());
+    }
+
+    string CreateDPoPToken()
+    {
+        //var key = CryptoHelper.CreateRsaSecurityKey();
+        //var jwk = JsonWebKeyConverter.ConvertFromRSASecurityKey(key);
+        //jwk.Alg = "RS256";
+
+        //var header = new Dictionary<string, object>()
+        //{
+        //    { "typ", "dpop+jwt" },
+        //    { "alg", "RS256" },
+        //    { "jwk", jwk },
+        //};
+
+        return null;
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task empty_string_should_fail_validation()
+    {
+        var popToken = "";
+        var ctx = new DPoPProofValidatonContext { ProofTooken = popToken };
+        var result = await _subject.ValidateAsync(ctx);
+        result.IsError.Should().BeTrue();
+        result.Error.Should().Be("invalid_dpop_proof");
+    }
+    
+    //[Fact]
+    //[Trait("Category", Category)]
+    //public async Task valid_dpop_jwt_should_pass_validation()
+    //{
+    //    var popToken = CreateDPoPToken();
+    //    var ctx = new DPoPProofValidatonContext { ProofTooken = popToken };
+    //    var result = await _subject.ValidateAsync(ctx);
+    //    result.IsError.Should().BeTrue();
+    //    result.Error.Should().Be("invalid_dpop_proof");
+    //}
+}

--- a/test/IdentityServer.UnitTests/Validation/DPoPProofValidatorTests.cs
+++ b/test/IdentityServer.UnitTests/Validation/DPoPProofValidatorTests.cs
@@ -4,20 +4,16 @@
 
 using System;
 using System.Collections.Generic;
-using System.IdentityModel.Tokens.Jwt;
-using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Duende.IdentityServer.Configuration;
-using Duende.IdentityServer.Models;
-using Duende.IdentityServer.Stores;
 using Duende.IdentityServer.Validation;
 using FluentAssertions;
-using IdentityModel;
 using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;
 using UnitTests.Common;
 using UnitTests.Validation.Setup;
-using UnitTests.Validation.TokenRequest_Validation;
 using Xunit;
 
 namespace UnitTests.Validation;
@@ -39,28 +35,71 @@ public class DPoPProofValidatorTests
         }
     }
 
+    Dictionary<string, object> _header;
+    Dictionary<string, object> _payload;
+    string _privateJWK = "{\"Crv\":null,\"D\":\"QeBWodq0hSYjfAxxo0VZleXLqwwZZeNWvvFfES4WyItao_-OJv1wKA7zfkZxbWkpK5iRbKrl2AMJ52AtUo5JJ6QZ7IjAQlgM0lBg3ltjb1aA0gBsK5XbiXcsV8DiAnRuy6-XgjAKPR8Lo-wZl_fdPbVoAmpSdmfn_6QXXPBai5i7FiyDbQa16pI6DL-5SCj7F78QDTRiJOqn5ElNvtoJEfJBm13giRdqeriFi3pCWo7H3QBgTEWtDNk509z4w4t64B2HTXnM0xj9zLnS42l7YplJC7MRibD4nVBMtzfwtGRKLj8beuDgtW9pDlQqf7RVWX5pHQgiHAZmUi85TEbYdQ\",\"DP\":\"h2F54OMaC9qq1yqR2b55QNNaChyGtvmTHSdqZJ8lJFqvUorlz-Uocj2BTowWQnaMd8zRKMdKlSeUuSv4Z6WmjSxSsNbonI6_II5XlZLWYqFdmqDS-xCmJY32voT5Wn7OwB9xj1msDqrFPg-PqSBOh5OppjCqXqDFcNvSkQSajXc\",\"DQ\":\"VABdS20Nxkmq6JWLQj7OjRxVJuYsHrfmWJmDA7_SYtlXaPUcg-GiHGQtzdDWEeEi0dlJjv9I3FdjKGC7CGwqtVygW38DzVYJsV2EmRNJc1-j-1dRs_pK9GWR4NYm0mVz_IhS8etIf9cfRJk90xU3AL3_J6p5WNF7I5ctkLpnt8M\",\"E\":\"AQAB\",\"K\":null,\"KeyOps\":[],\"Kty\":\"RSA\",\"N\":\"yWWAOSV3Z_BW9rJEFvbZyeU-q2mJWC0l8WiHNqwVVf7qXYgm9hJC0j1aPHku_Wpl38DpK3Xu3LjWOFG9OrCqga5Pzce3DDJKI903GNqz5wphJFqweoBFKOjj1wegymvySsLoPqqDNVYTKp4nVnECZS4axZJoNt2l1S1bC8JryaNze2stjW60QT-mIAGq9konKKN3URQ12dr478m0Oh-4WWOiY4HrXoSOklFmzK-aQx1JV_SZ04eIGfSw1pZZyqTaB1BwBotiy-QA03IRxwIXQ7BSx5EaxC5uMCMbzmbvJqjt-q8Y1wyl-UQjRucgp7hkfHSE1QT3zEex2Q3NFux7SQ\",\"Oth\":null,\"P\":\"_T7MTkeOh5QyqlYCtLQ2RWf2dAJ9i3wrCx4nEDm1c1biijhtVTL7uJTLxwQIM9O2PvOi5Dq-UiGy6rhHZqf5akWTeHtaNyI-2XslQfaS3ctRgmGtRQL_VihK-R9AQtDx4eWL4h-bDJxPaxby_cVo_j2MX5AeoC1kNmcCdDf_X0M\",\"Q\":\"y5ZSThaGLjaPj8Mk2nuD8TiC-sb4aAZVh9K-W4kwaWKfDNoPcNb_dephBNMnOp9M1br6rDbyG7P-Sy_LOOsKg3Q0wHqv4hnzGaOQFeMJH4HkXYdENC7B5JG9PefbC6zwcgZWiBnsxgKpScNWuzGF8x2CC-MdsQ1bkQeTPbJklIM\",\"QI\":\"i716Vt9II_Rt6qnjsEhfE4bej52QFG9a1hSnx5PDNvRrNqR_RpTA0lO9qeXSZYGHTW_b6ZXdh_0EUwRDEDHmaxjkIcTADq6JLuDltOhZuhLUSc5NCKLAVCZlPcaSzv8-bZm57mVcIpx0KyFHxvk50___Jgx1qyzwLX03mPGUbDQ\",\"Use\":null,\"X\":null,\"X5c\":[],\"X5t\":null,\"X5tS256\":null,\"X5u\":null,\"Y\":null,\"KeySize\":2048,\"HasPrivateKey\":true,\"CryptoProviderFactory\":{\"CryptoProviderCache\":{},\"CustomCryptoProvider\":null,\"CacheSignatureProviders\":true,\"SignatureProviderObjectPoolCacheSize\":80}}";
+    string _publicJWK = "{\"kty\":\"RSA\",\"use\":\"sig\",\"x5t\":null,\"e\":\"AQAB\",\"n\":\"yWWAOSV3Z_BW9rJEFvbZyeU-q2mJWC0l8WiHNqwVVf7qXYgm9hJC0j1aPHku_Wpl38DpK3Xu3LjWOFG9OrCqga5Pzce3DDJKI903GNqz5wphJFqweoBFKOjj1wegymvySsLoPqqDNVYTKp4nVnECZS4axZJoNt2l1S1bC8JryaNze2stjW60QT-mIAGq9konKKN3URQ12dr478m0Oh-4WWOiY4HrXoSOklFmzK-aQx1JV_SZ04eIGfSw1pZZyqTaB1BwBotiy-QA03IRxwIXQ7BSx5EaxC5uMCMbzmbvJqjt-q8Y1wyl-UQjRucgp7hkfHSE1QT3zEex2Q3NFux7SQ\",\"x5c\":null,\"x\":null,\"y\":null,\"crv\":null}";
+    string _JKT = "JGSVlE73oKtQQI1dypYg8_JNat0xJjsQNyOI5oxaZf4";
+
     DefaultDPoPProofValidator _subject;
 
     public DPoPProofValidatorTests()
     {
         _clock.UtcNowFunc = () => UtcNow;
-        _subject = new DefaultDPoPProofValidator(_options, _clock, new LoggerFactory().CreateLogger<DefaultDPoPProofValidator>());
+        _subject = new DefaultDPoPProofValidator(new MockServerUrls() { BasePath = "/", Origin = "https://identityserver" }, _clock, new LoggerFactory().CreateLogger<DefaultDPoPProofValidator>());
+
+        _payload = new Dictionary<string, object>
+        {
+            { "jti", "random" },
+            { "htm", "POST" },
+            { "htu", "https://identityserver/connect/token" },
+            { "iat", _clock.UtcNow.UtcTicks },
+        };
+
+        CreateHeaderValuesFromPublicKey();
     }
 
-    string CreateDPoPToken()
+    void CreateHeaderValuesFromPublicKey()
     {
-        //var key = CryptoHelper.CreateRsaSecurityKey();
-        //var jwk = JsonWebKeyConverter.ConvertFromRSASecurityKey(key);
-        //jwk.Alg = "RS256";
+        var jwk = JsonSerializer.Deserialize<JsonElement>(_publicJWK);
+        var jwkValues = new Dictionary<string, object>();
+        foreach (var item in jwk.EnumerateObject())
+        {
+            if (item.Value.ValueKind == JsonValueKind.String)
+            {
+                var val = item.Value.GetString();
+                if (!String.IsNullOrEmpty(val))
+                {
+                    jwkValues.Add(item.Name, val);
+                }
+            }
+            if (item.Value.ValueKind == JsonValueKind.False)
+            {
+                jwkValues.Add(item.Name, false);
+            }
+            if (item.Value.ValueKind == JsonValueKind.True)
+            {
+                jwkValues.Add(item.Name, true);
+            }
+            if (item.Value.ValueKind == JsonValueKind.Number)
+            {
+                jwkValues.Add(item.Name, item.Value.GetInt64());
+            }
+        }
+        _header = new Dictionary<string, object>()
+        {
+            //{ "alg", "RS265" }, // JsonWebTokenHandler requires adding this itself
+            { "typ", "dpop+jwk" },
+            { "jwk", jwkValues },
+        };
+    }
 
-        //var header = new Dictionary<string, object>()
-        //{
-        //    { "typ", "dpop+jwt" },
-        //    { "alg", "RS256" },
-        //    { "jwk", jwk },
-        //};
-
-        return null;
+    string CreateDPoPProofToken(string alg = "RS256", SecurityKey key = null)
+    {
+        key ??= new JsonWebKey(_privateJWK);
+        var handler = new JsonWebTokenHandler() { SetDefaultTimesOnTokenCreation = false };
+        var token = handler.CreateToken(JsonSerializer.Serialize(_payload), new SigningCredentials(key, alg), _header);
+        return token;
     }
 
     [Fact]
@@ -68,20 +107,136 @@ public class DPoPProofValidatorTests
     public async Task empty_string_should_fail_validation()
     {
         var popToken = "";
-        var ctx = new DPoPProofValidatonContext { ProofTooken = popToken };
+        var ctx = new DPoPProofValidatonContext { ProofToken = popToken };
         var result = await _subject.ValidateAsync(ctx);
         result.IsError.Should().BeTrue();
         result.Error.Should().Be("invalid_dpop_proof");
     }
-    
-    //[Fact]
-    //[Trait("Category", Category)]
-    //public async Task valid_dpop_jwt_should_pass_validation()
-    //{
-    //    var popToken = CreateDPoPToken();
-    //    var ctx = new DPoPProofValidatonContext { ProofTooken = popToken };
-    //    var result = await _subject.ValidateAsync(ctx);
-    //    result.IsError.Should().BeTrue();
-    //    result.Error.Should().Be("invalid_dpop_proof");
-    //}
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task malformed_dpop_jwt_should_fail_validation()
+    {
+        var token = "malformed";
+        var ctx = new DPoPProofValidatonContext { ProofToken = token };
+        var result = await _subject.ValidateAsync(ctx);
+
+        result.IsError.Should().BeTrue();
+        result.Error.Should().Be("invalid_dpop_proof");
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task valid_dpop_jwt_should_pass_validation()
+    {
+        var token = CreateDPoPProofToken();
+        var ctx = new DPoPProofValidatonContext { ProofToken = token };
+        var result = await _subject.ValidateAsync(ctx);
+
+        result.IsError.Should().BeFalse();
+        result.JsonWebKeyThumbprint.Should().Be(_JKT);
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task invalid_typ_dpop_jwt_should_fail_validation()
+    {
+        _header["typ"] = "JWT";
+
+        var token = CreateDPoPProofToken();
+        var ctx = new DPoPProofValidatonContext { ProofToken = token };
+        var result = await _subject.ValidateAsync(ctx);
+
+        result.IsError.Should().BeTrue();
+        result.Error.Should().Be("invalid_dpop_proof");
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task invalid_alg_dpop_jwt_should_fail_validation()
+    {
+        var key = new SymmetricSecurityKey(IdentityModel.CryptoRandom.CreateRandomKey(32));
+        _publicJWK = JsonSerializer.Serialize(key);
+        CreateHeaderValuesFromPublicKey();
+        var token = CreateDPoPProofToken("HS256", key);
+
+        var ctx = new DPoPProofValidatonContext { ProofToken = token };
+        var result = await _subject.ValidateAsync(ctx);
+        
+        result.IsError.Should().BeTrue();
+        result.Error.Should().Be("invalid_dpop_proof");
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task jwk_with_private_key_dpop_jwt_should_fail_validation()
+    {
+        _publicJWK = _privateJWK;
+        CreateHeaderValuesFromPublicKey();
+
+        var token = CreateDPoPProofToken();
+        var ctx = new DPoPProofValidatonContext { ProofToken = token };
+        var result = await _subject.ValidateAsync(ctx);
+
+        result.IsError.Should().BeTrue();
+        result.Error.Should().Be("invalid_dpop_proof");
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task jwk_with_malformed_typ_dpop_jwt_should_fail_validation()
+    {
+        _header["typ"] = true;
+
+        var token = CreateDPoPProofToken();
+        var ctx = new DPoPProofValidatonContext { ProofToken = token };
+        var result = await _subject.ValidateAsync(ctx);
+
+        result.IsError.Should().BeTrue();
+        result.Error.Should().Be("invalid_dpop_proof");
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task jwk_with_missing_jwk_dpop_jwt_should_fail_validation()
+    {
+        _header.Remove("jwk");
+
+        var token = CreateDPoPProofToken();
+        var ctx = new DPoPProofValidatonContext { ProofToken = token };
+        var result = await _subject.ValidateAsync(ctx);
+
+        result.IsError.Should().BeTrue();
+        result.Error.Should().Be("invalid_dpop_proof");
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task jwk_with_malformed_key_dpop_jwt_should_fail_validation()
+    {
+        _header["jwk"] = "malformed";
+        
+        var token = CreateDPoPProofToken();
+        var ctx = new DPoPProofValidatonContext { ProofToken = token };
+        var result = await _subject.ValidateAsync(ctx);
+
+        result.IsError.Should().BeTrue();
+        result.Error.Should().Be("invalid_dpop_proof");
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task mismatched_key_dpop_jwt_should_fail_validation()
+    {
+        var key = CryptoHelper.CreateRsaSecurityKey();
+        var jwk = JsonWebKeyConverter.ConvertFromRSASecurityKey(key);
+        _privateJWK = JsonSerializer.Serialize(jwk);
+
+        var token = CreateDPoPProofToken();
+        var ctx = new DPoPProofValidatonContext { ProofToken = token };
+        var result = await _subject.ValidateAsync(ctx);
+        
+        result.IsError.Should().BeTrue();
+        result.Error.Should().Be("invalid_dpop_proof");
+    }
 }

--- a/test/IdentityServer.UnitTests/Validation/DPoPProofValidatorTests.cs
+++ b/test/IdentityServer.UnitTests/Validation/DPoPProofValidatorTests.cs
@@ -13,14 +13,13 @@ using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;
 using UnitTests.Common;
-using UnitTests.Validation.Setup;
 using Xunit;
 
 namespace UnitTests.Validation;
 
 public class DPoPProofValidatorTests
 {
-    private const string Category = "DPoP validator";
+    private const string Category = "DPoP validator tests";
 
     private IdentityServerOptions _options = new IdentityServerOptions();
     private StubClock _clock = new StubClock();
@@ -158,7 +157,7 @@ public class DPoPProofValidatorTests
 
     [Fact]
     [Trait("Category", Category)]
-    public async Task invalid_typ_dpop_jwt_should_fail_validation()
+    public async Task invalid_typ_should_fail_validation()
     {
         _header["typ"] = "JWT";
 
@@ -172,7 +171,7 @@ public class DPoPProofValidatorTests
 
     [Fact]
     [Trait("Category", Category)]
-    public async Task invalid_alg_dpop_jwt_should_fail_validation()
+    public async Task invalid_alg_should_fail_validation()
     {
         var key = new SymmetricSecurityKey(IdentityModel.CryptoRandom.CreateRandomKey(32));
         _publicJWK = JsonSerializer.Serialize(key);
@@ -188,7 +187,7 @@ public class DPoPProofValidatorTests
 
     [Fact]
     [Trait("Category", Category)]
-    public async Task private_key_dpop_jwt_should_fail_validation()
+    public async Task private_key_should_fail_validation()
     {
         _publicJWK = _privateJWK;
         CreateHeaderValuesFromPublicKey();
@@ -203,7 +202,7 @@ public class DPoPProofValidatorTests
 
     [Fact]
     [Trait("Category", Category)]
-    public async Task malformed_typ_dpop_jwt_should_fail_validation()
+    public async Task malformed_typ_should_fail_validation()
     {
         _header["typ"] = true;
 
@@ -217,7 +216,7 @@ public class DPoPProofValidatorTests
 
     [Fact]
     [Trait("Category", Category)]
-    public async Task missing_jwk_dpop_jwt_should_fail_validation()
+    public async Task missing_jwk_should_fail_validation()
     {
         _header.Remove("jwk");
 
@@ -231,7 +230,7 @@ public class DPoPProofValidatorTests
 
     [Fact]
     [Trait("Category", Category)]
-    public async Task jwk_with_malformed_key_dpop_jwt_should_fail_validation()
+    public async Task jwk_with_malformed_key_should_fail_validation()
     {
         _header["jwk"] = "malformed";
         
@@ -245,7 +244,7 @@ public class DPoPProofValidatorTests
 
     [Fact]
     [Trait("Category", Category)]
-    public async Task mismatched_key_dpop_jwt_should_fail_validation()
+    public async Task mismatched_key_should_fail_validation()
     {
         var key = CryptoHelper.CreateRsaSecurityKey();
         var jwk = JsonWebKeyConverter.ConvertFromRSASecurityKey(key);
@@ -261,7 +260,7 @@ public class DPoPProofValidatorTests
 
     [Fact]
     [Trait("Category", Category)]
-    public async Task missing_jti_dpop_jwt_should_fail_validation()
+    public async Task missing_jti_should_fail_validation()
     {
         _payload.Remove("jti");
 
@@ -275,7 +274,7 @@ public class DPoPProofValidatorTests
 
     [Fact]
     [Trait("Category", Category)]
-    public async Task missing_htm_dpop_jwt_should_fail_validation()
+    public async Task missing_htm_should_fail_validation()
     {
         _payload.Remove("htm");
 
@@ -289,7 +288,7 @@ public class DPoPProofValidatorTests
 
     [Fact]
     [Trait("Category", Category)]
-    public async Task missing_htu_dpop_jwt_should_fail_validation()
+    public async Task missing_htu_should_fail_validation()
     {
         _payload.Remove("htu");
 
@@ -303,7 +302,7 @@ public class DPoPProofValidatorTests
 
     [Fact]
     [Trait("Category", Category)]
-    public async Task invalid_htu_dpop_jwt_should_fail_validation()
+    public async Task invalid_htu_should_fail_validation()
     {
         _payload["htu"] = "https://identityserver";
 
@@ -317,7 +316,7 @@ public class DPoPProofValidatorTests
 
     [Fact]
     [Trait("Category", Category)]
-    public async Task missing_iat_dpop_jwt_should_fail_validation()
+    public async Task missing_iat_should_fail_validation()
     {
         _payload.Remove("iat");
 
@@ -331,7 +330,7 @@ public class DPoPProofValidatorTests
 
     [Fact]
     [Trait("Category", Category)]
-    public async Task malformed_iat_dpop_jwt_should_fail_validation()
+    public async Task malformed_iat_should_fail_validation()
     {
         _payload["iat"] = "invalid";
 
@@ -345,7 +344,7 @@ public class DPoPProofValidatorTests
 
     [Fact]
     [Trait("Category", Category)]
-    public async Task too_old_iat_dpop_jwt_should_fail_validation()
+    public async Task too_old_iat_should_fail_validation()
     {
         _payload["iat"] = _clock.UtcNow.Subtract(TimeSpan.FromSeconds(121)).ToUnixTimeSeconds();
 
@@ -359,7 +358,7 @@ public class DPoPProofValidatorTests
 
     [Fact]
     [Trait("Category", Category)]
-    public async Task too_new_iat_dpop_jwt_should_fail_validation()
+    public async Task too_new_iat_should_fail_validation()
     {
         _payload["iat"] = _clock.UtcNow.Add(TimeSpan.FromSeconds(121)).ToUnixTimeSeconds();
 
@@ -373,7 +372,7 @@ public class DPoPProofValidatorTests
 
     [Fact]
     [Trait("Category", Category)]
-    public async Task missing_iat_but_nonce_provided_dpop_jwt_should_still_fail_validation()
+    public async Task missing_iat_but_nonce_provided_should_still_fail_validation()
     {
         _payload.Remove("iat");
         _payload["nonce"] = "nonce";

--- a/test/IdentityServer.UnitTests/Validation/DPoPProofValidatorTests.cs
+++ b/test/IdentityServer.UnitTests/Validation/DPoPProofValidatorTests.cs
@@ -371,9 +371,9 @@ public class DPoPProofValidatorTests
         result.Error.Should().Be("invalid_dpop_proof");
     }
 
-    [Fact(Skip = "no nonce support yet")]
+    [Fact]
     [Trait("Category", Category)]
-    public async Task missing_iat_but_nonce_provided_dpop_jwt_should_pass_validation()
+    public async Task missing_iat_but_nonce_provided_dpop_jwt_should_still_fail_validation()
     {
         _payload.Remove("iat");
         _payload["nonce"] = "nonce";
@@ -382,6 +382,7 @@ public class DPoPProofValidatorTests
         var ctx = new DPoPProofValidatonContext { ProofToken = token };
         var result = await _subject.ValidateAsync(ctx);
 
-        result.IsError.Should().BeFalse();
+        result.IsError.Should().BeTrue();
+        result.Error.Should().Be("invalid_dpop_proof");
     }
 }

--- a/test/IdentityServer.UnitTests/Validation/Setup/Factory.cs
+++ b/test/IdentityServer.UnitTests/Validation/Setup/Factory.cs
@@ -127,7 +127,7 @@ internal static class Factory
             resourceValidator,
             resourceStore,
             refreshTokenService,
-            new DefaultDPoPProofValidator(options, new StubClock(), new LoggerFactory().CreateLogger< DefaultDPoPProofValidator >()),
+            new DefaultDPoPProofValidator(new MockServerUrls(), new StubClock(), new LoggerFactory().CreateLogger< DefaultDPoPProofValidator >()),
             new TestEventService(),
             new StubClock(),
             TestLogger.Create<TokenRequestValidator>());

--- a/test/IdentityServer.UnitTests/Validation/Setup/Factory.cs
+++ b/test/IdentityServer.UnitTests/Validation/Setup/Factory.cs
@@ -127,6 +127,7 @@ internal static class Factory
             resourceValidator,
             resourceStore,
             refreshTokenService,
+            new DefaultDPoPProofValidator(options, new StubClock(), new LoggerFactory().CreateLogger< DefaultDPoPProofValidator >()),
             new TestEventService(),
             new StubClock(),
             TestLogger.Create<TokenRequestValidator>());

--- a/test/IdentityServer.UnitTests/Validation/Setup/Factory.cs
+++ b/test/IdentityServer.UnitTests/Validation/Setup/Factory.cs
@@ -127,7 +127,7 @@ internal static class Factory
             resourceValidator,
             resourceStore,
             refreshTokenService,
-            new DefaultDPoPProofValidator(new MockServerUrls(), new StubClock(), new LoggerFactory().CreateLogger< DefaultDPoPProofValidator >()),
+            new DefaultDPoPProofValidator(options, new MockServerUrls(), new MockReplayCache(), new StubClock(), new LoggerFactory().CreateLogger< DefaultDPoPProofValidator >()),
             new TestEventService(),
             new StubClock(),
             TestLogger.Create<TokenRequestValidator>());


### PR DESCRIPTION
First cut of DPoP support (without a built-in nonce implementation).

Open issues:
* Need an update for the IdentityModel constants
* For clients that are configured to requite DPoP do we require the dpop_jkt param on the authorize endpoint? The spec says OPTIONAL, and that flag will still[ require the client to provide one on the token endpoint.
* We need to think thru the options for replay duration and where those live. Also, this will require the replay cache by default now in DI, which requires an IDistributedCache. (probably related: https://github.com/DuendeSoftware/IdentityServer/issues/1059)
* We need to think thru the options for proof token iat duration validation and where those live. Related: do we want iat vs nonce validation to be a per-client setting?
* Still need a design for nonce validation and/or extensibility. 
* Should we support dpop_jkt with CIBA on the back channel authentication request?
* Needs docs and samples.

Closes: https://github.com/DuendeSoftware/IdentityServer/issues/1116