### PR TITLE
Make ConfigurationDbContext overridable

### DIFF
--- a/src/EntityFramework.Storage/DbContexts/ConfigurationDbContext.cs
+++ b/src/EntityFramework.Storage/DbContexts/ConfigurationDbContext.cs
@@ -50,7 +50,7 @@ public class ConfigurationDbContext<TContext> : DbContext, IConfigurationDbConte
     /// </summary>
     /// <param name="options">The options.</param>
     /// <exception cref="ArgumentNullException">storeOptions</exception>
-    public ConfigurationDbContext(DbContextOptions<TContext> options)
+    public ConfigurationDbContext(DbContextOptions options)
         : base(options)
     {
     }


### PR DESCRIPTION
**What issue does this PR address?**
To inherit from ConfigurationContext it is easier to use the base class of DbContextOptions without generic like already done in the PersistedGrantDbContext. This makes it easier to add additional DbSets<>, overrides to the context. Without you'll probably need to register the generic overload by yourself to make it injectable to the constructor or use the interface and write an own database context inherited from IConfigurationDbContext


**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
