### PR TITLE
Add ITokenCleanupService Interface

### DIFF
--- a/src/EntityFramework.Storage/Configuration/ServiceCollectionExtensions.cs
+++ b/src/EntityFramework.Storage/Configuration/ServiceCollectionExtensions.cs
@@ -162,7 +162,7 @@ public static class IdentityServerEntityFrameworkBuilderExtensions
         }
 
         services.AddScoped<IPersistedGrantDbContext>(svcs => svcs.GetRequiredService<TContext>());
-        services.AddTransient<TokenCleanupService>();
+        services.AddTransient<ITokenCleanupService, TokenCleanupService>();
 
         return services;
     }

--- a/src/EntityFramework.Storage/TokenCleanup/ITokenCleanupService.cs
+++ b/src/EntityFramework.Storage/TokenCleanup/ITokenCleanupService.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Duende.IdentityServer.EntityFramework;
+
+/// <summary>
+/// Service that cleans up stale persisted grants and device codes.
+/// </summary>
+public interface ITokenCleanupService
+{
+    /// <summary>
+    /// Removes expired persisted grants, expired device codes, and optionally
+    /// consumed persisted grants from the stores.
+    /// </summary>
+    /// <param name="cancellationToken">A token that propagates notification
+    /// that the cleanup operation should be canceled.</param>
+    /// <returns></returns>
+    Task RemoveExpiredGrantsAsync(CancellationToken cancellationToken = default);
+}

--- a/src/EntityFramework.Storage/TokenCleanup/ITokenCleanupService.cs
+++ b/src/EntityFramework.Storage/TokenCleanup/ITokenCleanupService.cs
@@ -8,7 +8,8 @@ using System.Threading.Tasks;
 namespace Duende.IdentityServer.EntityFramework;
 
 /// <summary>
-/// Service that cleans up stale persisted grants and device codes.
+/// Service that cleans up persisted grants and device codes that are no longer
+/// needed.
 /// </summary>
 public interface ITokenCleanupService
 {
@@ -19,5 +20,5 @@ public interface ITokenCleanupService
     /// <param name="cancellationToken">A token that propagates notification
     /// that the cleanup operation should be canceled.</param>
     /// <returns></returns>
-    Task RemoveExpiredGrantsAsync(CancellationToken cancellationToken = default);
+    Task CleanupGrantsAsync(CancellationToken cancellationToken = default);
 }

--- a/src/EntityFramework.Storage/TokenCleanup/TokenCleanupService.cs
+++ b/src/EntityFramework.Storage/TokenCleanup/TokenCleanupService.cs
@@ -45,7 +45,7 @@ public class TokenCleanupService : ITokenCleanupService
     }
 
     /// <inheritdoc/>
-    public async Task RemoveExpiredGrantsAsync(CancellationToken cancellationToken = default)
+    public async Task CleanupGrantsAsync(CancellationToken cancellationToken = default)
     {
         try
         {

--- a/src/EntityFramework.Storage/TokenCleanup/TokenCleanupService.cs
+++ b/src/EntityFramework.Storage/TokenCleanup/TokenCleanupService.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using Duende.IdentityServer.EntityFramework.Extensions;
 using Duende.IdentityServer.EntityFramework.Interfaces;
 using Duende.IdentityServer.EntityFramework.Options;
-using Duende.IdentityServer.Stores;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
@@ -23,7 +22,6 @@ public class TokenCleanupService
     private readonly OperationalStoreOptions _options;
     private readonly IPersistedGrantDbContext _persistedGrantDbContext;
     private readonly IOperationalStoreNotification _operationalStoreNotification;
-    private readonly IServerSideSessionsMarker _sideSessionsMarker;
     private readonly ILogger<TokenCleanupService> _logger;
 
     /// <summary>
@@ -33,12 +31,10 @@ public class TokenCleanupService
     /// <param name="persistedGrantDbContext"></param>
     /// <param name="operationalStoreNotification"></param>
     /// <param name="logger"></param>
-    /// <param name="serverSideSessionsMarker"></param>
     public TokenCleanupService(
         OperationalStoreOptions options,
         IPersistedGrantDbContext persistedGrantDbContext, 
         ILogger<TokenCleanupService> logger,
-        IServerSideSessionsMarker serverSideSessionsMarker = null,
         IOperationalStoreNotification operationalStoreNotification = null)
     {
         _options = options ?? throw new ArgumentNullException(nameof(options));
@@ -48,7 +44,6 @@ public class TokenCleanupService
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
         _operationalStoreNotification = operationalStoreNotification;
-        _sideSessionsMarker = serverSideSessionsMarker;
     }
 
     /// <summary>

--- a/src/EntityFramework.Storage/TokenCleanup/TokenCleanupService.cs
+++ b/src/EntityFramework.Storage/TokenCleanup/TokenCleanupService.cs
@@ -14,10 +14,8 @@ using Microsoft.Extensions.Logging;
 
 namespace Duende.IdentityServer.EntityFramework;
 
-/// <summary>
-/// Helper to cleanup stale persisted grants and device codes.
-/// </summary>
-public class TokenCleanupService
+/// <inheritdoc/>
+public class TokenCleanupService : ITokenCleanupService
 {
     private readonly OperationalStoreOptions _options;
     private readonly IPersistedGrantDbContext _persistedGrantDbContext;
@@ -33,7 +31,7 @@ public class TokenCleanupService
     /// <param name="logger"></param>
     public TokenCleanupService(
         OperationalStoreOptions options,
-        IPersistedGrantDbContext persistedGrantDbContext, 
+        IPersistedGrantDbContext persistedGrantDbContext,
         ILogger<TokenCleanupService> logger,
         IOperationalStoreNotification operationalStoreNotification = null)
     {
@@ -46,10 +44,7 @@ public class TokenCleanupService
         _operationalStoreNotification = operationalStoreNotification;
     }
 
-    /// <summary>
-    /// Method to clear expired persisted grants.
-    /// </summary>
-    /// <returns></returns>
+    /// <inheritdoc/>
     public async Task RemoveExpiredGrantsAsync(CancellationToken cancellationToken = default)
     {
         try
@@ -175,7 +170,7 @@ public class TokenCleanupService
                 _logger.LogInformation("Removing {deviceCodeCount} device flow codes", found);
 
                 _persistedGrantDbContext.DeviceFlowCodes.RemoveRange(expiredCodes);
-                
+
                 var list = await _persistedGrantDbContext.SaveChangesWithConcurrencyCheckAsync<Entities.DeviceFlowCodes>(_logger, cancellationToken);
                 expiredCodes = expiredCodes.Except(list).ToArray();
 

--- a/src/EntityFramework/TokenCleanupHost.cs
+++ b/src/EntityFramework/TokenCleanupHost.cs
@@ -117,7 +117,7 @@ public class TokenCleanupHost : IHostedService
             using (var serviceScope = _serviceProvider.GetRequiredService<IServiceScopeFactory>().CreateScope())
             {
                 var tokenCleanupService = serviceScope.ServiceProvider.GetRequiredService<ITokenCleanupService>();
-                await tokenCleanupService.RemoveExpiredGrantsAsync(cancellationToken);
+                await tokenCleanupService.CleanupGrantsAsync(cancellationToken);
             }
         }
         catch (Exception ex)

--- a/src/EntityFramework/TokenCleanupHost.cs
+++ b/src/EntityFramework/TokenCleanupHost.cs
@@ -116,7 +116,7 @@ public class TokenCleanupHost : IHostedService
         {
             using (var serviceScope = _serviceProvider.GetRequiredService<IServiceScopeFactory>().CreateScope())
             {
-                var tokenCleanupService = serviceScope.ServiceProvider.GetRequiredService<TokenCleanupService>();
+                var tokenCleanupService = serviceScope.ServiceProvider.GetRequiredService<ITokenCleanupService>();
                 await tokenCleanupService.RemoveExpiredGrantsAsync(cancellationToken);
             }
         }

--- a/test/EntityFramework.Storage.IntegrationTests/TokenCleanup/TokenCleanupTests.cs
+++ b/test/EntityFramework.Storage.IntegrationTests/TokenCleanup/TokenCleanupTests.cs
@@ -37,7 +37,7 @@ public class TokenCleanupTests : IntegrationTest<TokenCleanupTests, PersistedGra
     }
 
     [Theory, MemberData(nameof(TestDatabaseProviders))]
-    public async Task RemoveExpiredGrantsAsync_WhenExpiredGrantsExist_ExpectExpiredGrantsRemoved(DbContextOptions<PersistedGrantDbContext> options)
+    public async Task CleanupGrantsAsync_WhenExpiredGrantsExist_ExpectExpiredGrantsRemoved(DbContextOptions<PersistedGrantDbContext> options)
     {
         var expiredGrant = new PersistedGrant
         {
@@ -55,7 +55,7 @@ public class TokenCleanupTests : IntegrationTest<TokenCleanupTests, PersistedGra
             context.SaveChanges();
         }
 
-        await CreateSut(options).RemoveExpiredGrantsAsync();
+        await CreateSut(options).CleanupGrantsAsync();
 
         using (var context = new PersistedGrantDbContext(options))
         {
@@ -64,7 +64,7 @@ public class TokenCleanupTests : IntegrationTest<TokenCleanupTests, PersistedGra
     }
 
     [Theory, MemberData(nameof(TestDatabaseProviders))]
-    public async Task RemoveExpiredGrantsAsync_WhenValidGrantsExist_ExpectValidGrantsInDb(DbContextOptions<PersistedGrantDbContext> options)
+    public async Task CleanupGrantsAsync_WhenValidGrantsExist_ExpectValidGrantsInDb(DbContextOptions<PersistedGrantDbContext> options)
     {
         var validGrant = new PersistedGrant
         {
@@ -82,7 +82,7 @@ public class TokenCleanupTests : IntegrationTest<TokenCleanupTests, PersistedGra
             context.SaveChanges();
         }
 
-        await CreateSut(options).RemoveExpiredGrantsAsync();
+        await CreateSut(options).CleanupGrantsAsync();
 
         using (var context = new PersistedGrantDbContext(options))
         {
@@ -91,7 +91,7 @@ public class TokenCleanupTests : IntegrationTest<TokenCleanupTests, PersistedGra
     }
 
     [Theory, MemberData(nameof(TestDatabaseProviders))]
-    public async Task RemoveExpiredGrantsAsync_WhenExpiredDeviceGrantsExist_ExpectExpiredDeviceGrantsRemoved(DbContextOptions<PersistedGrantDbContext> options)
+    public async Task CleanupGrantsAsync_WhenExpiredDeviceGrantsExist_ExpectExpiredDeviceGrantsRemoved(DbContextOptions<PersistedGrantDbContext> options)
     {
         var expiredGrant = new DeviceFlowCodes
         {
@@ -110,7 +110,7 @@ public class TokenCleanupTests : IntegrationTest<TokenCleanupTests, PersistedGra
             context.SaveChanges();
         }
 
-        await CreateSut(options).RemoveExpiredGrantsAsync();
+        await CreateSut(options).CleanupGrantsAsync();
 
         using (var context = new PersistedGrantDbContext(options))
         {
@@ -119,7 +119,7 @@ public class TokenCleanupTests : IntegrationTest<TokenCleanupTests, PersistedGra
     }
 
     [Theory, MemberData(nameof(TestDatabaseProviders))]
-    public async Task RemoveExpiredGrantsAsync_WhenValidDeviceGrantsExist_ExpectValidDeviceGrantsInDb(DbContextOptions<PersistedGrantDbContext> options)
+    public async Task CleanupGrantsAsync_WhenValidDeviceGrantsExist_ExpectValidDeviceGrantsInDb(DbContextOptions<PersistedGrantDbContext> options)
     {
         var validGrant = new DeviceFlowCodes
         {
@@ -138,7 +138,7 @@ public class TokenCleanupTests : IntegrationTest<TokenCleanupTests, PersistedGra
             context.SaveChanges();
         }
 
-        await CreateSut(options).RemoveExpiredGrantsAsync();
+        await CreateSut(options).CleanupGrantsAsync();
 
         using (var context = new PersistedGrantDbContext(options))
         {
@@ -148,7 +148,7 @@ public class TokenCleanupTests : IntegrationTest<TokenCleanupTests, PersistedGra
 
 
     [Theory, MemberData(nameof(TestDatabaseProviders))]
-    public async Task RemoveExpireGrantsAsync_WhenFlagIsOnAndConsumedGrantsExist_ExpectConsumedGrantsRemoved(DbContextOptions<PersistedGrantDbContext> options)
+    public async Task CleanupGrantsAsync_WhenFlagIsOnAndConsumedGrantsExist_ExpectConsumedGrantsRemoved(DbContextOptions<PersistedGrantDbContext> options)
     {
         var consumedGrant = new PersistedGrant
         {
@@ -167,7 +167,7 @@ public class TokenCleanupTests : IntegrationTest<TokenCleanupTests, PersistedGra
             context.SaveChanges();
         }
 
-        await CreateSut(options, removeConsumedTokens: true).RemoveExpiredGrantsAsync();
+        await CreateSut(options, removeConsumedTokens: true).CleanupGrantsAsync();
 
         using (var context = new PersistedGrantDbContext(options))
         {
@@ -176,7 +176,7 @@ public class TokenCleanupTests : IntegrationTest<TokenCleanupTests, PersistedGra
     }
 
     [Theory, MemberData(nameof(TestDatabaseProviders))]
-    public async Task RemoveExpireGrantsAsync_WhenFlagIsOffAndConsumedGrantsExist_ExpectConsumedGrantsNotRemoved(DbContextOptions<PersistedGrantDbContext> options)
+    public async Task CleanupGrantsAsync_WhenFlagIsOffAndConsumedGrantsExist_ExpectConsumedGrantsNotRemoved(DbContextOptions<PersistedGrantDbContext> options)
     {
         var consumedGrant = new PersistedGrant
         {
@@ -195,7 +195,7 @@ public class TokenCleanupTests : IntegrationTest<TokenCleanupTests, PersistedGra
             context.SaveChanges();
         }
 
-        await CreateSut(options, removeConsumedTokens: false).RemoveExpiredGrantsAsync();
+        await CreateSut(options, removeConsumedTokens: false).CleanupGrantsAsync();
 
         using (var context = new PersistedGrantDbContext(options))
         {
@@ -205,7 +205,7 @@ public class TokenCleanupTests : IntegrationTest<TokenCleanupTests, PersistedGra
 
 
     [Theory, MemberData(nameof(TestDatabaseProviders))]
-    public async Task RemoveExpireGrantsAsync_WhenFlagIsOnAndConsumedGrantsExistAndDelayIsSet_ExpectConsumedGrantsRemovedRespectsDelay(DbContextOptions<PersistedGrantDbContext> options)
+    public async Task CleanupGrantsAsync_WhenFlagIsOnAndConsumedGrantsExistAndDelayIsSet_ExpectConsumedGrantsRemovedRespectsDelay(DbContextOptions<PersistedGrantDbContext> options)
     {
         var delay = 100;
 
@@ -240,7 +240,7 @@ public class TokenCleanupTests : IntegrationTest<TokenCleanupTests, PersistedGra
             context.SaveChanges();
         }
 
-        await CreateSut(options, removeConsumedTokens: true, delay).RemoveExpiredGrantsAsync();
+        await CreateSut(options, removeConsumedTokens: true, delay).CleanupGrantsAsync();
 
         using (var context = new PersistedGrantDbContext(options))
         {
@@ -278,6 +278,6 @@ public class TokenCleanupTests : IntegrationTest<TokenCleanupTests, PersistedGra
         services.AddTransient<ITokenCleanupService, TokenCleanupService>();
         services.AddSingleton(StoreOptions);
 
-        return services.BuildServiceProvider().GetRequiredService<TokenCleanupService>();
+        return services.BuildServiceProvider().GetRequiredService<ITokenCleanupService>() as TokenCleanupService;
     }
 }

--- a/test/EntityFramework.Storage.IntegrationTests/TokenCleanup/TokenCleanupTests.cs
+++ b/test/EntityFramework.Storage.IntegrationTests/TokenCleanup/TokenCleanupTests.cs
@@ -213,7 +213,7 @@ public class TokenCleanupTests : IntegrationTest<TokenCleanupTests, PersistedGra
         var oldConsumedGrant = new PersistedGrant
         {
             Expiration = DateTime.UtcNow.AddDays(3),                    // Token not yet expired
-            ConsumedTime = DateTime.UtcNow.AddSeconds(-(delay + 1)),    // But was consumed MORE than the delay in the past
+            ConsumedTime = DateTime.UtcNow.AddSeconds(-(delay + 100)),  // But was consumed MORE than the delay in the past
 
             Key = Guid.NewGuid().ToString(),
             Type = IdentityServerConstants.PersistedGrantTypes.RefreshToken,
@@ -225,7 +225,7 @@ public class TokenCleanupTests : IntegrationTest<TokenCleanupTests, PersistedGra
         var newConsumedGrant = new PersistedGrant
         {
             Expiration = DateTime.UtcNow.AddDays(3),                    // Token not yet expired
-            ConsumedTime = DateTime.UtcNow.AddSeconds(-(delay - 1)),    // But was consumed LESS than the delay in the past
+            ConsumedTime = DateTime.UtcNow.AddSeconds(-(delay - 100)),  // But was consumed LESS than the delay in the past
 
             Key = Guid.NewGuid().ToString(),
             Type = IdentityServerConstants.PersistedGrantTypes.RefreshToken,

--- a/test/EntityFramework.Storage.IntegrationTests/TokenCleanup/TokenCleanupTests.cs
+++ b/test/EntityFramework.Storage.IntegrationTests/TokenCleanup/TokenCleanupTests.cs
@@ -275,7 +275,7 @@ public class TokenCleanupTests : IntegrationTest<TokenCleanupTests, PersistedGra
         services.AddTransient<IPersistedGrantStore, PersistedGrantStore>();
         services.AddTransient<IDeviceFlowStore, DeviceFlowStore>();
             
-        services.AddTransient<TokenCleanupService>();
+        services.AddTransient<ITokenCleanupService, TokenCleanupService>();
         services.AddSingleton(StoreOptions);
 
         return services.BuildServiceProvider().GetRequiredService<TokenCleanupService>();


### PR DESCRIPTION
## Changes
- Add ITokenCleanupService interface
- Remove unused IServerSideSessionsMarker from TokenCleanupService
- Rename RemoveExpiredGrantsAsync to CleanupGrantsAsync. This is more accurate, because we are performing all grant cleanup tasks within this method, which might include removing consumed grants and expired device codes in addition to expired grants.

Resolves #981 

### Minor Breaking Changes
The rename is strictly speaking a breaking change, but it a safe one to make because even though this method is public, it is not virtual. The assumption is that the only users of this class are 
- IdentityServer itself, which we change during the rename
- Classes that derive from TokenCleanupService, which can't override this non-virtual method

Removing the IServerSideSessionsMarker is also technically a breaking change, but the marker itself is stored privately, so no derived class can ever make use of it. Customizations that previously were implemented by deriving from TokenCleanupService will need to simplify how they invoke the base constructor.

Also, the TokenCleanupHost now depends on an ITokenCleanupService interface instead of the TokenCleanupService class. Customizations of the TokenCleanupService that previously registered a class that derived from TokenCleanupService in the DI system will need to register that service as an ITokenCleanupService instead.