### PR TITLE
Fix dpop_signing_alg_values_supported

### DIFF
--- a/src/IdentityServer/ResponseHandling/Default/DiscoveryResponseGenerator.cs
+++ b/src/IdentityServer/ResponseHandling/Default/DiscoveryResponseGenerator.cs
@@ -383,7 +383,7 @@ public class DiscoveryResponseGenerator : IDiscoveryResponseGenerator
 
         if (Options.Endpoints.EnableTokenEndpoint)
         {
-            entries.Add(OidcConstants.Discovery.DPoPSigningAlgorithmsSupported, new[] { SupportedDPoPSigningAlgorithms });
+            entries.Add(OidcConstants.Discovery.DPoPSigningAlgorithmsSupported, SupportedDPoPSigningAlgorithms );
         }
 
         // custom entries


### PR DESCRIPTION
dpop_signing_alg_values_supported should be an [] and not  an [[]]

