### PR TITLE
Remove IServiceProvider from CorsPolicyService

### DIFF
--- a/src/EntityFramework/Services/CorsPolicyService.cs
+++ b/src/EntityFramework/Services/CorsPolicyService.cs
@@ -20,9 +20,9 @@ namespace Duende.IdentityServer.EntityFramework.Services;
 public class CorsPolicyService : ICorsPolicyService
 {
     /// <summary>
-    /// The IServiceProvider.
+    /// The DbContext.
     /// </summary>
-    protected readonly IServiceProvider Provider;
+    protected readonly IConfigurationDbContext DbContext;
 
     /// <summary>
     /// The CancellationToken provider.
@@ -33,17 +33,18 @@ public class CorsPolicyService : ICorsPolicyService
     /// The logger.
     /// </summary>
     protected readonly ILogger<CorsPolicyService> Logger;
+    
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CorsPolicyService"/> class.
     /// </summary>
-    /// <param name="provider">The provider.</param>
+    /// <param name="dbContext">The DbContext</param>
     /// <param name="logger">The logger.</param>
     /// <param name="cancellationTokenProvider"></param>
     /// <exception cref="ArgumentNullException">context</exception>
-    public CorsPolicyService(IServiceProvider provider, ILogger<CorsPolicyService> logger, ICancellationTokenProvider cancellationTokenProvider)
+    public CorsPolicyService(IConfigurationDbContext dbContext, ILogger<CorsPolicyService> logger, ICancellationTokenProvider cancellationTokenProvider)
     {
-        Provider = provider;
+        DbContext = dbContext;
         Logger = logger;
         CancellationTokenProvider = cancellationTokenProvider;
     }
@@ -57,10 +58,7 @@ public class CorsPolicyService : ICorsPolicyService
     {
         origin = origin.ToLowerInvariant();
 
-        // doing this here and not in the ctor because: https://github.com/aspnet/CORS/issues/105
-        var dbContext = Provider.GetRequiredService<IConfigurationDbContext>();
-
-        var query = from o in dbContext.ClientCorsOrigins
+        var query = from o in DbContext.ClientCorsOrigins
             where o.Origin == origin
             select o;
 

--- a/test/EntityFramework.Tests/Services/CorsPolicyServiceTests.cs
+++ b/test/EntityFramework.Tests/Services/CorsPolicyServiceTests.cs
@@ -54,11 +54,7 @@ public class CorsPolicyServiceTests : IntegrationTest<CorsPolicyServiceTests, Co
         bool result;
         using (var context = new ConfigurationDbContext(options))
         {
-            var svcs = new ServiceCollection();
-            svcs.AddSingleton<IConfigurationDbContext>(context);
-            var provider = svcs.BuildServiceProvider();
-
-            var service = new CorsPolicyService(provider, FakeLogger<CorsPolicyService>.Create(), new NoneCancellationTokenProvider());
+            var service = new CorsPolicyService(context, FakeLogger<CorsPolicyService>.Create(), new NoneCancellationTokenProvider());
             result = service.IsOriginAllowedAsync(testCorsOrigin).Result;
         }
 
@@ -82,11 +78,7 @@ public class CorsPolicyServiceTests : IntegrationTest<CorsPolicyServiceTests, Co
         bool result;
         using (var context = new ConfigurationDbContext(options))
         {
-            var svcs = new ServiceCollection();
-            svcs.AddSingleton<IConfigurationDbContext>(context);
-            var provider = svcs.BuildServiceProvider();
-
-            var service = new CorsPolicyService(provider, FakeLogger<CorsPolicyService>.Create(), new NoneCancellationTokenProvider());
+            var service = new CorsPolicyService(context, FakeLogger<CorsPolicyService>.Create(), new NoneCancellationTokenProvider());
             result = service.IsOriginAllowedAsync("InvalidOrigin").Result;
         }
 


### PR DESCRIPTION
The CorsPolicyService originally took a dependency on the IServiceProvider because the CorsMiddleware didn't resolve dependencies dynamically. As of .NET 3.0, that is now fixed, so we can remove this dependency.

See https://github.com/dotnet/aspnetcore/issues/2377 for more detail.

Marking this for 7.0 to avoid a breaking change in 6.3.