### PR TITLE
Filter authorization codes from token request logs

### DIFF
--- a/src/IdentityServer/Configuration/DependencyInjection/Options/LoggingOptions.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/Options/LoggingOptions.cs
@@ -38,7 +38,8 @@ public class LoggingOptions
             OidcConstants.TokenRequest.Password,
             OidcConstants.TokenRequest.ClientAssertion,
             OidcConstants.TokenRequest.RefreshToken,
-            OidcConstants.TokenRequest.DeviceCode
+            OidcConstants.TokenRequest.DeviceCode,
+            OidcConstants.TokenRequest.Code
         };
 
     /// <summary>


### PR DESCRIPTION
This changes the default TokenRequestSensitiveValuesFilter to include the code parameter. This is for consistency with the parsed value, which is already being obfuscated. Previous logs that included codes are not really a concern, since codes are one time use only - by the time they are logged, they are not likely to be useful anymore.

Closes: #1240 