### PR TITLE
Noop instead of trying to use missing HttpContext

### DIFF
--- a/src/IdentityServer/Hosting/DynamicProviders/Configuration/ConfigureAuthenticationOptions.cs
+++ b/src/IdentityServer/Hosting/DynamicProviders/Configuration/ConfigureAuthenticationOptions.cs
@@ -6,6 +6,7 @@ using Duende.IdentityServer.Models;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Duende.IdentityServer.Hosting.DynamicProviders;
@@ -20,19 +21,28 @@ public abstract class ConfigureAuthenticationOptions<TAuthenticationOptions, TId
     where TIdentityProvider : IdentityProvider
 {
     private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly ILogger<ConfigureAuthenticationOptions<TAuthenticationOptions, TIdentityProvider>> _logger;
 
     /// <summary>
     /// Ctor
     /// </summary>
     /// <param name="httpContextAccessor"></param>
-    public ConfigureAuthenticationOptions(IHttpContextAccessor httpContextAccessor)
+    /// <param name="logger"></param>
+    public ConfigureAuthenticationOptions(IHttpContextAccessor httpContextAccessor, ILogger<ConfigureAuthenticationOptions<TAuthenticationOptions, TIdentityProvider>> logger)
     {
         _httpContextAccessor = httpContextAccessor;
+        _logger = logger;
     }
 
     /// <inheritdoc/>
     public void Configure(string name, TAuthenticationOptions options)
     {
+        if (_httpContextAccessor.HttpContext == null)
+        {
+            _logger.LogDebug("Failed to configure the dynamic authentication scheme \"{scheme}\" because there is no current HTTP request.", name);
+            return;
+        }
+
         // we have to resolve these here due to DI lifetime issues
         var providerOptions = _httpContextAccessor.HttpContext.RequestServices.GetRequiredService<DynamicProviderOptions>();
         var cache = _httpContextAccessor.HttpContext.RequestServices.GetRequiredService<DynamicAuthenticationSchemeCache>();

--- a/src/IdentityServer/Hosting/DynamicProviders/Oidc/OidcConfigureOptions.cs
+++ b/src/IdentityServer/Hosting/DynamicProviders/Oidc/OidcConfigureOptions.cs
@@ -5,12 +5,13 @@ using Duende.IdentityServer.Models;
 using IdentityModel;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
 
 namespace Duende.IdentityServer.Hosting.DynamicProviders;
 
 class OidcConfigureOptions : ConfigureAuthenticationOptions<OpenIdConnectOptions, OidcProvider>
 {
-    public OidcConfigureOptions(IHttpContextAccessor httpContextAccessor) : base(httpContextAccessor)
+    public OidcConfigureOptions(IHttpContextAccessor httpContextAccessor, ILogger<OidcConfigureOptions> logger) : base(httpContextAccessor, logger)
     {
     }
 


### PR DESCRIPTION
When the HttpContext is not available and we would attempt to use it, instead log a debug message explaining what is happening.

Resolves #874