### PR TITLE
add input length restrictions for dpop

### DIFF
--- a/src/IdentityServer/Configuration/DependencyInjection/Options/InputLengthRestrictions.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/Options/InputLengthRestrictions.cs
@@ -155,6 +155,15 @@ public class InputLengthRestrictions
     /// </summary>
     public int AuthenticationRequestId { get; set; } = Default;
 
+    /// <summary>
+    /// Max length for dpop_jkt
+    /// </summary>
+    public int DPoPKeyThumbprint { get; set; } = Default;
+
+    /// <summary>
+    /// Max length for DPoP proof token
+    /// </summary>
+    public int DPoPProofToken { get; set; } = 4000;
 
     //// todo: review this default
     ///// <summary>

--- a/src/IdentityServer/Validation/Default/AuthorizeRequestValidator.cs
+++ b/src/IdentityServer/Validation/Default/AuthorizeRequestValidator.cs
@@ -912,10 +912,16 @@ internal class AuthorizeRequestValidator : IAuthorizeRequestValidator
         //////////////////////////////////////////////////////////
         // DPoP
         //////////////////////////////////////////////////////////
-        var dpop_jwk = request.Raw.Get(OidcConstants.AuthorizeRequest.DPoPKeyThumbprint);
-        if (dpop_jwk.IsPresent())
+        var dpop_jwt = request.Raw.Get(OidcConstants.AuthorizeRequest.DPoPKeyThumbprint);
+        if (dpop_jwt.IsPresent())
         {
-            request.DPoPKeyThumbprint = dpop_jwk;
+            if (dpop_jwt.Length > _options.InputLengthRestrictions.DPoPKeyThumbprint)
+            {
+                LogError("dpop_jwt value too long", request);
+                return Invalid(request, description: "Invalid dpop_jwt");
+            }
+
+            request.DPoPKeyThumbprint = dpop_jwt;
         }
 
         return Valid(request);

--- a/src/IdentityServer/Validation/Default/TokenRequestValidator.cs
+++ b/src/IdentityServer/Validation/Default/TokenRequestValidator.cs
@@ -227,6 +227,12 @@ internal class TokenRequestValidator : ITokenRequestValidator
         {
             LicenseValidator.ValidateDPoP();
 
+            if (context.DPoPProofToken.Length > _options.InputLengthRestrictions.DPoPProofToken)
+            {
+                LogError("DPoP proof token is too long");
+                return Invalid(OidcConstants.TokenErrors.InvalidDPoPProof);
+            }
+
             var dpopContext = new DPoPProofValidatonContext
             {
                 Client = _validatedRequest.Client,


### PR DESCRIPTION
These were overlooked in the first cut implementation. 