### PR TITLE
Add post configuration of identity server options

### DIFF
--- a/src/AspNetIdentity/IdentityServerBuilderExtensions.cs
+++ b/src/AspNetIdentity/IdentityServerBuilderExtensions.cs
@@ -83,7 +83,7 @@ public static class IdentityServerBuilderExtensions
         builder.AddResourceOwnerValidator<ResourceOwnerPasswordValidator<TUser>>();
         builder.AddProfileService<ProfileService<TUser>>();
 
-        builder.Services.AddSingleton<IPostConfigureOptions<IdentityServerOptions>, PostConfigureIdentityServerOptions>();
+        builder.Services.AddSingleton<IPostConfigureOptions<IdentityServerOptions>, UseAspNetIdentityCookieScheme>();
 
         return builder;
     }

--- a/src/AspNetIdentity/IdentityServerBuilderExtensions.cs
+++ b/src/AspNetIdentity/IdentityServerBuilderExtensions.cs
@@ -10,6 +10,8 @@ using IdentityModel;
 using Duende.IdentityServer.AspNetIdentity;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+using Duende.IdentityServer.Configuration;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -80,6 +82,8 @@ public static class IdentityServerBuilderExtensions
 
         builder.AddResourceOwnerValidator<ResourceOwnerPasswordValidator<TUser>>();
         builder.AddProfileService<ProfileService<TUser>>();
+
+        builder.Services.AddSingleton<IPostConfigureOptions<IdentityServerOptions>, PostConfigureIdentityServerOptions>();
 
         return builder;
     }

--- a/src/AspNetIdentity/PostConfigureIdentityServerOptions.cs
+++ b/src/AspNetIdentity/PostConfigureIdentityServerOptions.cs
@@ -1,0 +1,31 @@
+using Duende.IdentityServer.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Duende.IdentityServer.AspNetIdentity;
+
+/// <summary>
+/// Identity server options configuration
+/// </summary>
+public class PostConfigureIdentityServerOptions : IPostConfigureOptions<IdentityServerOptions>
+{
+    private readonly IOptions<Microsoft.AspNetCore.Authentication.AuthenticationOptions> _authOptions;
+
+    /// <summary>
+    /// ctor
+    /// </summary>
+    /// <param name="authOptions"></param>
+    public PostConfigureIdentityServerOptions(IOptions<Microsoft.AspNetCore.Authentication.AuthenticationOptions> authOptions)
+    {
+        _authOptions = authOptions;
+    }
+
+    /// <inheritdoc />
+    public void PostConfigure(string name, IdentityServerOptions options)
+    {
+        if (_authOptions.Value.DefaultAuthenticateScheme != null
+            && _authOptions.Value.DefaultAuthenticateScheme != options.DynamicProviders.SignOutScheme)
+        {
+            options.DynamicProviders.SignOutScheme = _authOptions.Value.DefaultAuthenticateScheme;
+        }
+    }
+}

--- a/src/AspNetIdentity/PostConfigureIdentityServerOptions.cs
+++ b/src/AspNetIdentity/PostConfigureIdentityServerOptions.cs
@@ -1,4 +1,5 @@
 using Duende.IdentityServer.Configuration;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Options;
 
 namespace Duende.IdentityServer.AspNetIdentity;
@@ -6,7 +7,7 @@ namespace Duende.IdentityServer.AspNetIdentity;
 /// <summary>
 /// Identity server options configuration
 /// </summary>
-public class PostConfigureIdentityServerOptions : IPostConfigureOptions<IdentityServerOptions>
+public class UseAspNetIdentityCookieScheme : IPostConfigureOptions<IdentityServerOptions>
 {
     private readonly IOptions<Microsoft.AspNetCore.Authentication.AuthenticationOptions> _authOptions;
 
@@ -14,18 +15,26 @@ public class PostConfigureIdentityServerOptions : IPostConfigureOptions<Identity
     /// ctor
     /// </summary>
     /// <param name="authOptions"></param>
-    public PostConfigureIdentityServerOptions(IOptions<Microsoft.AspNetCore.Authentication.AuthenticationOptions> authOptions)
+    public UseAspNetIdentityCookieScheme(IOptions<Microsoft.AspNetCore.Authentication.AuthenticationOptions> authOptions)
     {
         _authOptions = authOptions;
     }
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     public void PostConfigure(string name, IdentityServerOptions options)
     {
-        if (_authOptions.Value.DefaultAuthenticateScheme != null
-            && _authOptions.Value.DefaultAuthenticateScheme != options.DynamicProviders.SignOutScheme)
+        // If we are using ASP.NET Identity and the dynamic providers don't have a
+        // sign out scheme set, then we need the dynamic providers to use ASP.NET
+        // Identity's cookie at sign out time. If the sign out scheme is explicitly
+        // set, then we don't override that though.
+
+        if (DefaultAuthSchemeIsAspNetIdentity() &&
+            !options.DynamicProviders.SignOutSchemeSetExplicitly)
         {
-            options.DynamicProviders.SignOutScheme = _authOptions.Value.DefaultAuthenticateScheme;
+            options.DynamicProviders.SignOutScheme = IdentityConstants.ApplicationScheme;
         }
+
+        bool DefaultAuthSchemeIsAspNetIdentity() => 
+            _authOptions.Value.DefaultAuthenticateScheme == IdentityConstants.ApplicationScheme;
     }
 }

--- a/src/IdentityServer/Configuration/DependencyInjection/Options/DynamicProviderOptions.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/Options/DynamicProviderOptions.cs
@@ -31,7 +31,24 @@ public class DynamicProviderOptions
     /// <summary>
     /// Scheme for signout. Defaults to the constant IdentityServerConstants.DefaultCookieAuthenticationScheme.
     /// </summary>
-    public string SignOutScheme { get; set; } = IdentityServerConstants.DefaultCookieAuthenticationScheme;
+    public string SignOutScheme 
+    { 
+        get 
+        {
+            return _signOutScheme ?? IdentityServerConstants.DefaultCookieAuthenticationScheme;
+        } 
+        set 
+        {
+            _signOutScheme = value;
+        }
+    }
+    
+    private string? _signOutScheme;
+
+    /// <summary>
+    /// Gets a value indicating if the SignOutScheme was set explicitly, either by application logic or by options binding.
+    /// </summary>
+    public bool SignOutSchemeSetExplicitly { get => _signOutScheme != null; }
 
     /// <summary>
     /// Registers a provider configuration model and authentication handler for the protocol type being used.


### PR DESCRIPTION
**Redirecting back to client application after logging out from the external identity provider**

User is not redirected back to the client application from external identity provider, when identity server is configured for asp.net identity.

[Link to the Issue](https://github.com/DuendeSoftware/IdentityServer/issues/1404)

After some debugging of the duende and Microsoft sources, I've discovered that the reason for the redirection problem is the absence of id token. SignOutScheme which is used to retrieve id token from the user is set to default value, but default authentication scheme after configuring identity server for asp.net identity is changed to Application.Identity.
