### PR TITLE
Filter out expected ef migration exception

### DIFF
--- a/hosts/AspNetIdentity/Program.cs
+++ b/hosts/AspNetIdentity/Program.cs
@@ -34,7 +34,12 @@ try
 
     app.Run();
 }
-catch (Exception ex)
+catch (Exception ex) when (
+    // https://github.com/dotnet/runtime/issues/60600
+    ex.GetType().Name is not "StopTheHostException"
+    // HostAbortedException was added in .NET 7, but since we target .NET 6 we
+    // need to do it this way until we target .NET 8
+    && ex.GetType().Name is not "HostAbortedException")
 {
     Log.Fatal(ex, "Unhandled exception");
 }

--- a/hosts/EntityFramework/Program.cs
+++ b/hosts/EntityFramework/Program.cs
@@ -34,7 +34,12 @@ try
 
     app.Run();
 }
-catch (Exception ex)
+catch (Exception ex) when (
+    // https://github.com/dotnet/runtime/issues/60600
+    ex.GetType().Name is not "StopTheHostException"
+    // HostAbortedException was added in .NET 7, but since we target .NET 6 we
+    // need to do it this way until we target .NET 8
+    && ex.GetType().Name is not "HostAbortedException")
 {
     Log.Fatal(ex, "Unhandled exception");
     Console.ReadLine();


### PR DESCRIPTION
Filter out exceptions that we expect to see during migrations in the asp.net identity and EF hosts. We already do this in the quickstart tutorial samples.

Should help folks who encounter problems like this: https://github.com/DuendeSoftware/Support/issues/678