### PR TITLE
Add ath validation in the API for DPoP

### DIFF
--- a/clients/src/APIs/DPoPApi/DPoP/DPoPJwtBearerEvents.cs
+++ b/clients/src/APIs/DPoPApi/DPoP/DPoPJwtBearerEvents.cs
@@ -41,14 +41,14 @@ public class DPoPJwtBearerEvents : JwtBearerEvents
     {
         var dpopOptions = _optionsMonitor.Get(context.Scheme.Name);
 
-        if (context.HttpContext.Request.IsDPoPAuthorizationScheme())
+        if (context.HttpContext.Request.TryGetDPoPAccessToken(out var at))
         {
             var proofToken = context.HttpContext.Request.GetDPoPProofToken();
             var result = await _validator.ValidateAsync(new DPoPProofValidatonContext
             {
                 Scheme = context.Scheme.Name,
                 ProofToken = proofToken,
-                AccessTokenClaims = context.Principal.Claims,
+                AccessToken = at,
                 Method = context.HttpContext.Request.Method,
                 Url = context.HttpContext.Request.Scheme + "://" + context.HttpContext.Request.Host + context.HttpContext.Request.PathBase + context.HttpContext.Request.Path
             });

--- a/clients/src/APIs/DPoPApi/DPoP/DPoPProofValidatonContext.cs
+++ b/clients/src/APIs/DPoPApi/DPoP/DPoPProofValidatonContext.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-using System.Security.Claims;
 
 namespace DPoPApi;
 
@@ -26,7 +24,7 @@ public class DPoPProofValidatonContext
     public string ProofToken { get; set; }
 
     /// <summary>
-    /// The validated claims from the access token
+    /// The access token
     /// </summary>
-    public IEnumerable<Claim> AccessTokenClaims { get; set; }
+    public string AccessToken { get; set; }
 }

--- a/clients/src/APIs/DPoPApi/DPoP/DPoPProofValidatonResult.cs
+++ b/clients/src/APIs/DPoPApi/DPoP/DPoPProofValidatonResult.cs
@@ -45,6 +45,11 @@ public class DPoPProofValidatonResult
     /// The jti value read from the payload.
     /// </summary>
     public string TokenId { get; set; }
+    
+    /// <summary>
+    /// The ath value read from the payload.
+    /// </summary>
+    public string AccessTokenHash { get; set; }
 
     /// <summary>
     /// The nonce value read from the payload.


### PR DESCRIPTION
This was missing when we copied over the proof token validation logic from what was in IdentityServer itself.