### PR TITLE
use session id when revoking reference tokens for refresh token

### DIFF
--- a/src/IdentityServer/ResponseHandling/Default/TokenRevocationResponseGenerator.cs
+++ b/src/IdentityServer/ResponseHandling/Default/TokenRevocationResponseGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 
@@ -136,7 +136,7 @@ public class TokenRevocationResponseGenerator : ITokenRevocationResponseGenerato
             {
                 Logger.LogDebug("Refresh token revoked");
                 await RefreshTokenStore.RemoveRefreshTokenAsync(validationResult.Token);
-                await ReferenceTokenStore.RemoveReferenceTokensAsync(token.SubjectId, token.ClientId);
+                await ReferenceTokenStore.RemoveReferenceTokensAsync(token.SubjectId, token.ClientId, token.SessionId);
             }
             else
             {

--- a/src/IdentityServer/Stores/Default/DefaultGrantStore.cs
+++ b/src/IdentityServer/Stores/Default/DefaultGrantStore.cs
@@ -253,13 +253,15 @@ public class DefaultGrantStore<T>
     /// </summary>
     /// <param name="subjectId">The subject identifier.</param>
     /// <param name="clientId">The client identifier.</param>
+    /// <param name="sessionId">The optional session identifier.</param>
     /// <returns></returns>
-    protected virtual async Task RemoveAllAsync(string subjectId, string clientId)
+    protected virtual async Task RemoveAllAsync(string subjectId, string clientId, string sessionId = null)
     {
         await Store.RemoveAllAsync(new PersistedGrantFilter
         {
             SubjectId = subjectId,
             ClientId = clientId,
+            SessionId = sessionId,
             Type = GrantType
         });
     }

--- a/src/IdentityServer/Stores/Default/DefaultReferenceTokenStore.cs
+++ b/src/IdentityServer/Stores/Default/DefaultReferenceTokenStore.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 
@@ -31,11 +31,7 @@ public class DefaultReferenceTokenStore : DefaultGrantStore<Token>, IReferenceTo
     {
     }
 
-    /// <summary>
-    /// Stores the reference token asynchronous.
-    /// </summary>
-    /// <param name="token">The token.</param>
-    /// <returns></returns>
+    /// <inheritdoc/>
     public Task<string> StoreReferenceTokenAsync(Token token)
     {
         using var activity = Tracing.StoreActivitySource.StartActivity("DefaultReferenceTokenStore.StoreReferenceToken");
@@ -43,11 +39,7 @@ public class DefaultReferenceTokenStore : DefaultGrantStore<Token>, IReferenceTo
         return CreateItemAsync(token, token.ClientId, token.SubjectId, token.SessionId, token.Description, token.CreationTime, token.Lifetime);
     }
 
-    /// <summary>
-    /// Gets the reference token asynchronous.
-    /// </summary>
-    /// <param name="handle">The handle.</param>
-    /// <returns></returns>
+    /// <inheritdoc/>
     public Task<Token> GetReferenceTokenAsync(string handle)
     {
         using var activity = Tracing.StoreActivitySource.StartActivity("DefaultReferenceTokenStore.GetReferenceToken");
@@ -55,11 +47,7 @@ public class DefaultReferenceTokenStore : DefaultGrantStore<Token>, IReferenceTo
         return GetItemAsync(handle);
     }
 
-    /// <summary>
-    /// Removes the reference token asynchronous.
-    /// </summary>
-    /// <param name="handle">The handle.</param>
-    /// <returns></returns>
+    /// <inheritdoc/>
     public Task RemoveReferenceTokenAsync(string handle)
     {
         using var activity = Tracing.StoreActivitySource.StartActivity("DefaultReferenceTokenStore.RemoveReferenceToken");
@@ -67,16 +55,11 @@ public class DefaultReferenceTokenStore : DefaultGrantStore<Token>, IReferenceTo
         return RemoveItemAsync(handle);
     }
 
-    /// <summary>
-    /// Removes the reference tokens asynchronous.
-    /// </summary>
-    /// <param name="subjectId">The subject identifier.</param>
-    /// <param name="clientId">The client identifier.</param>
-    /// <returns></returns>
-    public Task RemoveReferenceTokensAsync(string subjectId, string clientId)
+    /// <inheritdoc/>
+    public Task RemoveReferenceTokensAsync(string subjectId, string clientId, string sessionId = null)
     {
         using var activity = Tracing.StoreActivitySource.StartActivity("DefaultReferenceTokenStore.RemoveReferenceTokens");
         
-        return RemoveAllAsync(subjectId, clientId);
+        return RemoveAllAsync(subjectId, clientId, sessionId);
     }
 }

--- a/src/Storage/Stores/IReferenceTokenStore.cs
+++ b/src/Storage/Stores/IReferenceTokenStore.cs
@@ -39,6 +39,7 @@ public interface IReferenceTokenStore
     /// </summary>
     /// <param name="subjectId">The subject identifier.</param>
     /// <param name="clientId">The client identifier.</param>
+    /// <param name="sessionId">The session identifier.</param>
     /// <returns></returns>
-    Task RemoveReferenceTokensAsync(string subjectId, string clientId);
+    Task RemoveReferenceTokensAsync(string subjectId, string clientId, string? sessionId = null);
 }

--- a/test/IdentityServer.UnitTests/Common/MockReferenceTokenStore.cs
+++ b/test/IdentityServer.UnitTests/Common/MockReferenceTokenStore.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 
@@ -21,7 +21,7 @@ class MockReferenceTokenStore : IReferenceTokenStore
         throw new NotImplementedException();
     }
 
-    public Task RemoveReferenceTokensAsync(string subjectId, string clientId)
+    public Task RemoveReferenceTokensAsync(string subjectId, string clientId, string sessionId = null)
     {
         throw new NotImplementedException();
     }


### PR DESCRIPTION
Fixes: https://github.com/DuendeSoftware/IdentityServer/issues/906

Does add a new param to RemoveReferenceTokensAsync on IReferenceTokenStore, and to the RemoveAllAsync helper on DefaultGrantStore\<T>. I don't expect many customers are overriding these classes/methods, but it's possible.