### PR TITLE
Add DPoP support to our AddLocalApi access token validation

### DIFF
--- a/clients/src/APIs/DPoPApi/DPoP/DPoPProofValidator.cs
+++ b/clients/src/APIs/DPoPApi/DPoP/DPoPProofValidator.cs
@@ -116,14 +116,14 @@ public class DPoPProofValidator
             return Task.CompletedTask;
         }
 
-        if (!token.TryGetHeaderValue<string>("typ", out var typ) || typ != JwtClaimTypes.JwtTypes.DPoPProofToken)
+        if (!token.TryGetHeaderValue<string>(JwtClaimTypes.TokenType, out var typ) || typ != JwtClaimTypes.JwtTypes.DPoPProofToken)
         {
             result.IsError = true;
             result.ErrorDescription = "Invalid 'typ' value.";
             return Task.CompletedTask;
         }
 
-        if (!token.TryGetHeaderValue<string>("alg", out var alg) || !SupportedDPoPSigningAlgorithms.Contains(alg))
+        if (!token.TryGetHeaderValue<string>(JwtClaimTypes.Algorithm, out var alg) || !SupportedDPoPSigningAlgorithms.Contains(alg))
         {
             result.IsError = true;
             result.ErrorDescription = "Invalid 'alg' value.";

--- a/clients/src/APIs/DPoPApi/DPoP/DPoPProofValidator.cs
+++ b/clients/src/APIs/DPoPApi/DPoP/DPoPProofValidator.cs
@@ -87,7 +87,7 @@ public class DPoPProofValidator
         }
         finally
         {
-            if (result.IsError)
+            if (result.IsError && String.IsNullOrWhiteSpace(result.Error))
             {
                 result.Error = OidcConstants.TokenErrors.InvalidDPoPProof;
             }
@@ -269,11 +269,11 @@ public class DPoPProofValidator
         {
             if (iat is int)
             {
-                result.IssuedAt = (int) iat;
+                result.IssuedAt = (int)iat;
             }
             if (iat is long)
             {
-                result.IssuedAt = (long) iat;
+                result.IssuedAt = (long)iat;
             }
         }
 
@@ -336,6 +336,9 @@ public class DPoPProofValidator
         // longer than the likelyhood of proof token expiration, which is done before replay
         skew *= 2;
         var cacheDuration = dpopOptions.ProofTokenValidityDuration + skew;
+        
+        Logger.LogDebug("Adding proof token with jti {jti} to replay cache for duration {cacheDuration}", result.TokenId, cacheDuration);
+
         await ReplayCache.AddAsync(ReplayCachePurpose, result.TokenId, DateTimeOffset.UtcNow.Add(cacheDuration));
     }
 
@@ -446,11 +449,11 @@ public class DPoPProofValidator
                 return ValueTask.FromResult(iat);
             }
         }
-        catch (Exception ex)
+        catch(Exception ex)
         {
             Logger.LogDebug("Error parsing DPoP 'nonce' value: {error}", ex.ToString());
         }
-
+        
         return ValueTask.FromResult<long>(0);
     }
 

--- a/clients/src/APIs/DPoPApi/DPoP/DPoPProofValidator.cs
+++ b/clients/src/APIs/DPoPApi/DPoP/DPoPProofValidator.cs
@@ -82,7 +82,7 @@ public class DPoPProofValidator
                 return result;
             }
 
-            Logger.LogDebug("Successfully validated DPoP proof token");
+            Logger.LogDebug("Successfully validated DPoP proof token with thumbprint: {jkt}", result.JsonWebKeyThumbprint);
             result.IsError = false;
         }
         finally

--- a/src/IdentityServer/Hosting/LocalApiAuthentication/LocalApiAuthenticationHandler.cs
+++ b/src/IdentityServer/Hosting/LocalApiAuthentication/LocalApiAuthenticationHandler.cs
@@ -11,6 +11,11 @@ using System.Security.Claims;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Duende.IdentityServer.Validation;
+using System.Linq;
+using Microsoft.Net.Http.Headers;
+using System.Text;
+using Duende.IdentityServer.Stores;
+using static IdentityModel.OidcConstants;
 
 namespace Duende.IdentityServer.Hosting.LocalApiAuthentication;
 
@@ -20,13 +25,23 @@ namespace Duende.IdentityServer.Hosting.LocalApiAuthentication;
 public class LocalApiAuthenticationHandler : AuthenticationHandler<LocalApiAuthenticationOptions>
 {
     private readonly ITokenValidator _tokenValidator;
+    private readonly IDPoPProofValidator _dpopValidator;
+    private readonly IClientStore _clientStore;
     private readonly ILogger _logger;
 
     /// <inheritdoc />
-    public LocalApiAuthenticationHandler(IOptionsMonitor<LocalApiAuthenticationOptions> options, ILoggerFactory logger, UrlEncoder encoder, ITokenValidator tokenValidator)
+    public LocalApiAuthenticationHandler(
+        IOptionsMonitor<LocalApiAuthenticationOptions> options, 
+        ILoggerFactory logger, 
+        UrlEncoder encoder, 
+        ITokenValidator tokenValidator,
+        IDPoPProofValidator dpopValidator,
+        IClientStore clientStore)
         : base(options, logger, encoder)
     {
         _tokenValidator = tokenValidator;
+        _dpopValidator = dpopValidator;
+        _clientStore = clientStore;
         _logger = logger.CreateLogger<LocalApiAuthenticationHandler>();
     }
 
@@ -57,9 +72,28 @@ public class LocalApiAuthenticationHandler : AuthenticationHandler<LocalApiAuthe
             return AuthenticateResult.NoResult();
         }
 
+        var wasDPoPToken = false;
+
         if (authorization.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
         {
+            if (Options.TokenMode == LocalApiTokenMode.DPoPOnly)
+            {
+                _logger.LogTrace("Bearer token sent, but mode is DPoP only. Ignoring token.");
+                return AuthenticateResult.NoResult();
+            }
+
             token = authorization.Substring("Bearer ".Length).Trim();
+        }
+        else if (authorization.StartsWith("DPoP ", StringComparison.OrdinalIgnoreCase))
+        {
+            if (Options.TokenMode == LocalApiTokenMode.BearerOnly)
+            {
+                _logger.LogTrace("DPoP token sent, but mode is Bearer only. Ignoring token.");
+                return AuthenticateResult.NoResult();
+            }
+
+            wasDPoPToken = true;
+            token = authorization.Substring("DPoP ".Length).Trim();
         }
 
         if (string.IsNullOrEmpty(token))
@@ -69,18 +103,69 @@ public class LocalApiAuthenticationHandler : AuthenticationHandler<LocalApiAuthe
 
         _logger.LogTrace("Token found: {token}", token);
 
-        TokenValidationResult result = await _tokenValidator.ValidateAccessTokenAsync(token, Options.ExpectedScope);
-
-        if (result.IsError)
+        var tokenResult = await _tokenValidator.ValidateAccessTokenAsync(token, Options.ExpectedScope);
+        if (tokenResult.IsError)
         {
             _logger.LogTrace("Failed to validate the token");
 
-            return AuthenticateResult.Fail(result.Error);
+            return AuthenticateResult.Fail(tokenResult.Error);
+        }
+
+        if (wasDPoPToken)
+        {
+            var clientId = tokenResult.Claims.FirstOrDefault(x => x.Type == JwtClaimTypes.ClientId)?.Value;
+            var client = await _clientStore.FindClientByIdAsync(clientId);
+            if (client == null)
+            {
+                // invalid or missing client id
+                return AuthenticateResult.Fail("Invalid or missing client_id from access token");
+            }
+
+            var proofToken = Context.Request.Headers[OidcConstants.HttpHeaders.DPoP].FirstOrDefault();
+            var validationContext = new DPoPProofValidatonContext
+            {
+                ProofToken = proofToken,
+                Method = Context.Request.Method,
+                Url = Context.Request.Scheme + "://" + Context.Request.Host + Context.Request.PathBase + Context.Request.Path,
+                ValidateAccessToken = true,
+                AccessToken = token,
+                ExpirationValidationMode = client.DPoPValidationMode,
+                ClientClockSkew = client.DPoPClockSkew,
+            };
+            
+            var dpopResult = await _dpopValidator.ValidateAsync(validationContext);
+            if (dpopResult.IsError)
+            {
+                // we need to stash these values away so they are available later when the Challenge method is called later
+                Context.Items["DPoP-Error"] = dpopResult.Error;
+                if (!string.IsNullOrWhiteSpace(dpopResult.ErrorDescription))
+                {
+                    Context.Items["DPoP-ErrorDescription"] = dpopResult.ErrorDescription;
+                }
+                if (!string.IsNullOrWhiteSpace(dpopResult.ServerIssuedNonce))
+                {
+                    Context.Items["DPoP-Nonce"] = dpopResult.ServerIssuedNonce;
+                }
+
+                // fails the result
+                return AuthenticateResult.Fail(dpopResult.ErrorDescription ?? dpopResult.Error);
+            }
+        }
+        else if (Options.TokenMode == LocalApiTokenMode.DPoPAndBearer)
+        {
+            // if the scheme used was not DPoP, then it was Bearer
+            // and if a access token was presented with a cnf, then the 
+            // client should have sent it as DPoP, so we fail the request
+            if (tokenResult.Claims.Any(x => x.Type == JwtClaimTypes.Confirmation))
+            {
+                Context.Items["Bearer-ErrorDescription"] = "Must use DPoP when using an access token with a 'cnf' claim";
+                return AuthenticateResult.Fail("Must use DPoP when using an access token with a 'cnf' claim");
+            }
         }
 
         _logger.LogTrace("Successfully validated the token.");
 
-        var claimsIdentity = new ClaimsIdentity(result.Claims, Scheme.Name, JwtClaimTypes.Name, JwtClaimTypes.Role);
+        var claimsIdentity = new ClaimsIdentity(tokenResult.Claims, Scheme.Name, JwtClaimTypes.Name, JwtClaimTypes.Role);
         var claimsPrincipal = new ClaimsPrincipal(claimsIdentity);
         var authenticationProperties = new AuthenticationProperties();
 
@@ -102,5 +187,72 @@ public class LocalApiAuthenticationHandler : AuthenticationHandler<LocalApiAuthe
 
         var authenticationTicket = new AuthenticationTicket(claimsTransformationContext.Principal, authenticationProperties, Scheme.Name);
         return AuthenticateResult.Success(authenticationTicket);
+    }
+
+    /// <inheritdoc/>
+    protected override Task HandleChallengeAsync(AuthenticationProperties properties)
+    {
+        Response.StatusCode = 401;
+
+        // Format:
+        // WWW-Authenticate: DPoP error="invalid_dpop_proof", error_description="Invalid 'iat' value."
+
+        if (Options.TokenMode == LocalApiTokenMode.BearerOnly || Options.TokenMode == LocalApiTokenMode.DPoPAndBearer)
+        {
+            var sb = new StringBuilder("Bearer");
+
+            if (Context.Items.ContainsKey("Bearer-Error"))
+            {
+                sb.Append(" error=\"");
+                sb.Append(Context.Items["Bearer-Error"] as string);
+                sb.Append('\"');
+
+                if (Context.Items.ContainsKey("Bearer-ErrorDescription"))
+                {
+                    sb.Append(", error_description=\"");
+                    sb.Append(Context.Items["Bearer-ErrorDescription"] as string);
+                    sb.Append('\"');
+                }
+            }
+
+            Response.Headers.Add(HeaderNames.WWWAuthenticate, sb.ToString());
+        }
+        
+        if (Options.TokenMode == LocalApiTokenMode.DPoPOnly || Options.TokenMode == LocalApiTokenMode.DPoPAndBearer)
+        {
+            var sb = new StringBuilder("DPoP");
+
+            if (Context.Items.ContainsKey("DPoP-Error"))
+            {
+                sb.Append(" error=\"");
+                sb.Append(Context.Items["DPoP-Error"] as string);
+                sb.Append('\"');
+
+                if (Context.Items.ContainsKey("DPoP-ErrorDescription"))
+                {
+                    sb.Append(", error_description=\"");
+                    sb.Append(Context.Items["DPoP-ErrorDescription"] as string);
+                    sb.Append('\"');
+                }
+            }
+
+            Response.Headers.Add(HeaderNames.WWWAuthenticate, sb.ToString());
+
+            // Emit a nonce if we have it
+            if (Context.Items.ContainsKey("DPoP-Nonce"))
+            {
+                // this is from our validator above
+                var nonce = Context.Items["DPoP-Nonce"] as string;
+                Context.Response.Headers[HttpHeaders.DPoPNonce] = nonce;
+            }
+            else if (properties.Items.ContainsKey("DPoP-Nonce"))
+            {
+                // this allows the API itself to set the nonce
+                var nonce = properties.Items["DPoP-Nonce"];
+                Context.Response.Headers[HttpHeaders.DPoPNonce] = nonce;
+            }
+        }
+
+        return Task.CompletedTask;
     }
 }

--- a/src/IdentityServer/Hosting/LocalApiAuthentication/LocalApiAuthenticationOptions.cs
+++ b/src/IdentityServer/Hosting/LocalApiAuthentication/LocalApiAuthenticationOptions.cs
@@ -14,6 +14,11 @@ namespace Duende.IdentityServer.Hosting.LocalApiAuthentication;
 public class LocalApiAuthenticationOptions : AuthenticationSchemeOptions
 {
     /// <summary>
+    /// Indicates if bearer and/or DPoP tokens are accepted.
+    /// </summary>
+    public LocalApiTokenMode TokenMode { get; set; } = LocalApiTokenMode.BearerOnly;
+
+    /// <summary>
     /// Allows setting a specific required scope (optional)
     /// </summary>
     public string? ExpectedScope { get; set; }

--- a/src/IdentityServer/Hosting/LocalApiAuthentication/LocalApiTokenMode.cs
+++ b/src/IdentityServer/Hosting/LocalApiAuthentication/LocalApiTokenMode.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+#nullable enable
+
+
+namespace Duende.IdentityServer.Hosting.LocalApiAuthentication;
+
+/// <summary>
+/// Models the type of tokens accepted for local API authentication
+/// </summary>
+public enum LocalApiTokenMode
+{
+    /// <summary>
+    /// Only bearer tokens will be accepted
+    /// </summary>
+    BearerOnly,
+    /// <summary>
+    /// Only DPoP tokens will be accepted
+    /// </summary>
+    DPoPOnly,
+    /// <summary>
+    /// Both DPoP and Bearer tokens will be accepted
+    /// </summary>
+    DPoPAndBearer
+}

--- a/src/IdentityServer/Validation/Contexts/DPoPProofValidatonContext.cs
+++ b/src/IdentityServer/Validation/Contexts/DPoPProofValidatonContext.cs
@@ -25,11 +25,6 @@ public class DPoPProofValidatonContext
     /// </summary>
     public TimeSpan DPoPClockSkew { get; set; } = TimeSpan.FromMinutes(5);
 
-    ///// <summary>
-    ///// The client presenting the DPoP proof
-    ///// </summary>
-    //public Client Client { get; set; } = default!;
-
     /// <summary>
     /// The HTTP URL to validate
     /// </summary>

--- a/src/IdentityServer/Validation/Contexts/DPoPProofValidatonContext.cs
+++ b/src/IdentityServer/Validation/Contexts/DPoPProofValidatonContext.cs
@@ -4,6 +4,7 @@
 #nullable enable
 
 using Duende.IdentityServer.Models;
+using System;
 
 namespace Duende.IdentityServer.Validation;
 
@@ -13,9 +14,21 @@ namespace Duende.IdentityServer.Validation;
 public class DPoPProofValidatonContext
 {
     /// <summary>
-    /// The client presenting the DPoP proof
+    /// Enum setting to control validation for the DPoP proof token expiration.
+    /// This supports both the client generated 'iat' value and/or the server generated 'nonce' value. 
+    /// Defaults to only using the 'iat' value.
     /// </summary>
-    public Client Client { get; set; } = default!;
+    public DPoPTokenExpirationValidationMode DPoPValidationMode { get; set; } = DPoPTokenExpirationValidationMode.Iat;
+
+    /// <summary>
+    /// Clock skew used in validating the DPoP proof token 'iat' claim value. Defaults to 5 minutes.
+    /// </summary>
+    public TimeSpan DPoPClockSkew { get; set; } = TimeSpan.FromMinutes(5);
+
+    ///// <summary>
+    ///// The client presenting the DPoP proof
+    ///// </summary>
+    //public Client Client { get; set; } = default!;
 
     /// <summary>
     /// The HTTP URL to validate

--- a/src/IdentityServer/Validation/Contexts/DPoPProofValidatonContext.cs
+++ b/src/IdentityServer/Validation/Contexts/DPoPProofValidatonContext.cs
@@ -18,12 +18,12 @@ public class DPoPProofValidatonContext
     /// This supports both the client generated 'iat' value and/or the server generated 'nonce' value. 
     /// Defaults to only using the 'iat' value.
     /// </summary>
-    public DPoPTokenExpirationValidationMode DPoPValidationMode { get; set; } = DPoPTokenExpirationValidationMode.Iat;
+    public DPoPTokenExpirationValidationMode ExpirationValidationMode { get; set; } = DPoPTokenExpirationValidationMode.Iat;
 
     /// <summary>
     /// Clock skew used in validating the DPoP proof token 'iat' claim value. Defaults to 5 minutes.
     /// </summary>
-    public TimeSpan DPoPClockSkew { get; set; } = TimeSpan.FromMinutes(5);
+    public TimeSpan ClientClockSkew { get; set; } = TimeSpan.FromMinutes(5);
 
     /// <summary>
     /// The HTTP URL to validate
@@ -39,4 +39,14 @@ public class DPoPProofValidatonContext
     /// The DPoP proof token to validate
     /// </summary>
     public string ProofToken { get; set; } = default!;
+
+    /// <summary>
+    /// If the access token should also be validated
+    /// </summary>
+    public bool ValidateAccessToken { get; set; }
+
+    /// <summary>
+    /// The access token to validate if ValidateAccessToken is set
+    /// </summary>
+    public string? AccessToken { get; set; }
 }

--- a/src/IdentityServer/Validation/Contexts/DPoPProofValidatonContext.cs
+++ b/src/IdentityServer/Validation/Contexts/DPoPProofValidatonContext.cs
@@ -18,6 +18,16 @@ public class DPoPProofValidatonContext
     public Client Client { get; set; } = default!;
 
     /// <summary>
+    /// The HTTP URL to validate
+    /// </summary>
+    public string Url { get; set; } = default!;
+
+    /// <summary>
+    /// The HTTP method to validate
+    /// </summary>
+    public string Method { get; set; } = default!;
+
+    /// <summary>
     /// The DPoP proof token to validate
     /// </summary>
     public string ProofToken { get; set; } = default!;

--- a/src/IdentityServer/Validation/Default/DefaultDPoPProofValidator.cs
+++ b/src/IdentityServer/Validation/Default/DefaultDPoPProofValidator.cs
@@ -254,15 +254,14 @@ public class DefaultDPoPProofValidator : IDPoPProofValidator
             return;
         }
 
-        if (!result.Payload.TryGetValue(JwtClaimTypes.DPoPHttpMethod, out var htm) || !"POST".Equals(htm))
+        if (!result.Payload.TryGetValue(JwtClaimTypes.DPoPHttpMethod, out var htm) || context.Method?.Equals(htm) == false)
         {
             result.IsError = true;
             result.ErrorDescription = "Invalid 'htm' value.";
             return;
         }
 
-        var tokenUrl = ServerUrls.BaseUrl.EnsureTrailingSlash() + ProtocolRoutePaths.Token;
-        if (!result.Payload.TryGetValue(JwtClaimTypes.DPoPHttpUrl, out var htu) || !tokenUrl.Equals(htu))
+        if (!result.Payload.TryGetValue(JwtClaimTypes.DPoPHttpUrl, out var htu) || context.Url?.Equals(htu) == false)
         {
             result.IsError = true;
             result.ErrorDescription = "Invalid 'htu' value.";

--- a/src/IdentityServer/Validation/Default/DefaultDPoPProofValidator.cs
+++ b/src/IdentityServer/Validation/Default/DefaultDPoPProofValidator.cs
@@ -321,12 +321,12 @@ public class DefaultDPoPProofValidator : IDPoPProofValidator
         }
 
         // get largest skew based on how client's freshness is validated
-        var validateIat = (context.Client.DPoPValidationMode & DPoPTokenExpirationValidationMode.Iat) == DPoPTokenExpirationValidationMode.Iat;
-        var validateNonce = (context.Client.DPoPValidationMode & DPoPTokenExpirationValidationMode.Nonce) == DPoPTokenExpirationValidationMode.Nonce;
+        var validateIat = (context.DPoPValidationMode & DPoPTokenExpirationValidationMode.Iat) == DPoPTokenExpirationValidationMode.Iat;
+        var validateNonce = (context.DPoPValidationMode & DPoPTokenExpirationValidationMode.Nonce) == DPoPTokenExpirationValidationMode.Nonce;
         var skew = TimeSpan.Zero;
-        if (validateIat && context.Client.DPoPClockSkew > skew)
+        if (validateIat && context.DPoPClockSkew > skew)
         {
-            skew = context.Client.DPoPClockSkew;
+            skew = context.DPoPClockSkew;
         }
         if (validateNonce && Options.DPoP.ServerClockSkew > skew)
         {
@@ -348,7 +348,7 @@ public class DefaultDPoPProofValidator : IDPoPProofValidator
     /// </summary>
     protected virtual async Task ValidateFreshnessAsync(DPoPProofValidatonContext context, DPoPProofValidatonResult result)
     {
-        var validateIat = (context.Client.DPoPValidationMode & DPoPTokenExpirationValidationMode.Iat) == DPoPTokenExpirationValidationMode.Iat;
+        var validateIat = (context.DPoPValidationMode & DPoPTokenExpirationValidationMode.Iat) == DPoPTokenExpirationValidationMode.Iat;
         if (validateIat)
         {
             await ValidateIatAsync(context, result);
@@ -358,7 +358,7 @@ public class DefaultDPoPProofValidator : IDPoPProofValidator
             }
         }
 
-        var validateNonce = (context.Client.DPoPValidationMode & DPoPTokenExpirationValidationMode.Nonce) == DPoPTokenExpirationValidationMode.Nonce;
+        var validateNonce = (context.DPoPValidationMode & DPoPTokenExpirationValidationMode.Nonce) == DPoPTokenExpirationValidationMode.Nonce;
         if (validateNonce)
         {
             await ValidateNonceAsync(context, result);
@@ -374,7 +374,7 @@ public class DefaultDPoPProofValidator : IDPoPProofValidator
     /// </summary>
     protected virtual Task ValidateIatAsync(DPoPProofValidatonContext context, DPoPProofValidatonResult result)
     {
-        if (IsExpired(context, result, context.Client.DPoPClockSkew, result.IssuedAt.Value))
+        if (IsExpired(context, result, context.DPoPClockSkew, result.IssuedAt.Value))
         {
             result.IsError = true;
             result.ErrorDescription = "Invalid 'iat' value.";

--- a/src/IdentityServer/Validation/Default/DefaultDPoPProofValidator.cs
+++ b/src/IdentityServer/Validation/Default/DefaultDPoPProofValidator.cs
@@ -45,11 +45,6 @@ public class DefaultDPoPProofValidator : IDPoPProofValidator
     protected IReplayCache ReplayCache;
 
     /// <summary>
-    /// The server urls service
-    /// </summary>
-    protected readonly IServerUrls ServerUrls;
-
-    /// <summary>
     /// The data protection provider
     /// </summary>
     protected IDataProtector DataProtector { get; }
@@ -64,7 +59,6 @@ public class DefaultDPoPProofValidator : IDPoPProofValidator
     /// </summary>
     public DefaultDPoPProofValidator(
         IdentityServerOptions options,
-        IServerUrls server,
         IReplayCache replayCache,
         IClock clock,
         IDataProtectionProvider dataProtectionProvider,
@@ -73,7 +67,6 @@ public class DefaultDPoPProofValidator : IDPoPProofValidator
         Options = options;
         Clock = clock;
         ReplayCache = replayCache;
-        ServerUrls = server;
         DataProtector = dataProtectionProvider.CreateProtector(DataProtectorPurpose);
         Logger = logger;
     }

--- a/src/IdentityServer/Validation/Default/TokenRequestValidator.cs
+++ b/src/IdentityServer/Validation/Default/TokenRequestValidator.cs
@@ -17,6 +17,7 @@ using Duende.IdentityServer.Events;
 using Duende.IdentityServer.Logging.Models;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services;
+using static Duende.IdentityServer.IdentityServerConstants;
 
 namespace Duende.IdentityServer.Validation;
 

--- a/src/IdentityServer/Validation/Default/TokenRequestValidator.cs
+++ b/src/IdentityServer/Validation/Default/TokenRequestValidator.cs
@@ -238,7 +238,8 @@ internal class TokenRequestValidator : ITokenRequestValidator
             var tokenUrl = _serverUrls.BaseUrl.EnsureTrailingSlash() + ProtocolRoutePaths.Token;
             var dpopContext = new DPoPProofValidatonContext
             {
-                Client = _validatedRequest.Client,
+                DPoPValidationMode = _validatedRequest.Client.DPoPValidationMode,
+                DPoPClockSkew = _validatedRequest.Client.DPoPClockSkew,
                 ProofToken = context.DPoPProofToken,
                 Url = tokenUrl,
                 Method = "POST",

--- a/src/IdentityServer/Validation/Default/TokenRequestValidator.cs
+++ b/src/IdentityServer/Validation/Default/TokenRequestValidator.cs
@@ -24,6 +24,7 @@ internal class TokenRequestValidator : ITokenRequestValidator
 {
     private readonly IdentityServerOptions _options;
     private readonly IIssuerNameService _issuerNameService;
+    private readonly IServerUrls _serverUrls;
     private readonly IAuthorizationCodeStore _authorizationCodeStore;
     private readonly ExtensionGrantValidator _extensionGrantValidator;
     private readonly ICustomTokenRequestValidator _customRequestValidator;
@@ -44,6 +45,7 @@ internal class TokenRequestValidator : ITokenRequestValidator
     public TokenRequestValidator(
         IdentityServerOptions options,
         IIssuerNameService issuerNameService,
+        IServerUrls serverUrls,
         IAuthorizationCodeStore authorizationCodeStore,
         IResourceOwnerPasswordValidator resourceOwnerValidator,
         IProfileService profile,
@@ -62,6 +64,7 @@ internal class TokenRequestValidator : ITokenRequestValidator
         _logger = logger;
         _options = options;
         _issuerNameService = issuerNameService;
+        _serverUrls = serverUrls;
         _clock = clock;
         _authorizationCodeStore = authorizationCodeStore;
         _resourceOwnerValidator = resourceOwnerValidator;
@@ -232,10 +235,13 @@ internal class TokenRequestValidator : ITokenRequestValidator
                 return Invalid(OidcConstants.TokenErrors.InvalidDPoPProof);
             }
 
+            var tokenUrl = _serverUrls.BaseUrl.EnsureTrailingSlash() + ProtocolRoutePaths.Token;
             var dpopContext = new DPoPProofValidatonContext
             {
                 Client = _validatedRequest.Client,
                 ProofToken = context.DPoPProofToken,
+                Url = tokenUrl,
+                Method = "POST",
             };
             var dpopResult = await _dPoPProofValidator.ValidateAsync(dpopContext);
             if (dpopResult.IsError)

--- a/src/IdentityServer/Validation/Default/TokenRequestValidator.cs
+++ b/src/IdentityServer/Validation/Default/TokenRequestValidator.cs
@@ -238,8 +238,8 @@ internal class TokenRequestValidator : ITokenRequestValidator
             var tokenUrl = _serverUrls.BaseUrl.EnsureTrailingSlash() + ProtocolRoutePaths.Token;
             var dpopContext = new DPoPProofValidatonContext
             {
-                DPoPValidationMode = _validatedRequest.Client.DPoPValidationMode,
-                DPoPClockSkew = _validatedRequest.Client.DPoPClockSkew,
+                ExpirationValidationMode = _validatedRequest.Client.DPoPValidationMode,
+                ClientClockSkew = _validatedRequest.Client.DPoPClockSkew,
                 ProofToken = context.DPoPProofToken,
                 Url = tokenUrl,
                 Method = "POST",

--- a/src/IdentityServer/Validation/Models/DPoPProofValidatonResult.cs
+++ b/src/IdentityServer/Validation/Models/DPoPProofValidatonResult.cs
@@ -33,6 +33,11 @@ public class DPoPProofValidatonResult : ValidationResult
     public IDictionary<string, object>? Payload { get; internal set; }
 
     /// <summary>
+    /// The ath value read from the payload.
+    /// </summary>
+    public string? AccessTokenHash { get; set; }
+
+    /// <summary>
     /// The 'jti' value read from the payload.
     /// </summary>
     public string? TokenId { get; set; }

--- a/test/IdentityServer.IntegrationTests/Endpoints/Token/DPoPTokenEndpointTests.cs
+++ b/test/IdentityServer.IntegrationTests/Endpoints/Token/DPoPTokenEndpointTests.cs
@@ -28,7 +28,6 @@ using Duende.IdentityServer.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 using System.Text;
 using Duende.IdentityServer;
-using Microsoft.AspNetCore.DataProtection;
 
 namespace IntegrationTests.Endpoints.Token;
 
@@ -1002,7 +1001,7 @@ public class DPoPTokenEndpointTests
 
     public class MockDPoPProofValidator : DefaultDPoPProofValidator
     {
-        public MockDPoPProofValidator(IdentityServerOptions options, IReplayCache replayCache, IClock clock, IDataProtectionProvider dataProtectionProvider, ILogger<DefaultDPoPProofValidator> logger) : base(options, replayCache, clock, dataProtectionProvider, logger)
+        public MockDPoPProofValidator(IdentityServerOptions options, IReplayCache replayCache, IClock clock, Microsoft.AspNetCore.DataProtection.IDataProtectionProvider dataProtectionProvider, ILogger<DefaultDPoPProofValidator> logger) : base(options, replayCache, clock, dataProtectionProvider, logger)
         {
         }
 

--- a/test/IdentityServer.IntegrationTests/Endpoints/Token/DPoPTokenEndpointTests.cs
+++ b/test/IdentityServer.IntegrationTests/Endpoints/Token/DPoPTokenEndpointTests.cs
@@ -28,6 +28,7 @@ using Duende.IdentityServer.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 using System.Text;
 using Duende.IdentityServer;
+using Microsoft.AspNetCore.DataProtection;
 
 namespace IntegrationTests.Endpoints.Token;
 
@@ -1001,7 +1002,7 @@ public class DPoPTokenEndpointTests
 
     public class MockDPoPProofValidator : DefaultDPoPProofValidator
     {
-        public MockDPoPProofValidator(IdentityServerOptions options, IServerUrls server, IReplayCache replayCache, IClock clock, Microsoft.AspNetCore.DataProtection.IDataProtectionProvider dataProtectionProvider, ILogger<DefaultDPoPProofValidator> logger) : base(options, server, replayCache, clock, dataProtectionProvider, logger)
+        public MockDPoPProofValidator(IdentityServerOptions options, IReplayCache replayCache, IClock clock, IDataProtectionProvider dataProtectionProvider, ILogger<DefaultDPoPProofValidator> logger) : base(options, replayCache, clock, dataProtectionProvider, logger)
         {
         }
 

--- a/test/IdentityServer.IntegrationTests/Hosting/LocalApiAuthentication/LocalApiAuthenticationTests.cs
+++ b/test/IdentityServer.IntegrationTests/Hosting/LocalApiAuthentication/LocalApiAuthenticationTests.cs
@@ -1,0 +1,414 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Duende.IdentityServer.Hosting.LocalApiAuthentication;
+using Duende.IdentityServer.Models;
+using FluentAssertions;
+using IdentityModel;
+using IdentityModel.Client;
+using IntegrationTests.Common;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+namespace IntegrationTests.Hosting.LocalApiAuthentication;
+
+public class LocalApiAuthenticationTests
+{
+    private const string Category = "Local API Integration";
+
+    private IdentityServerPipeline _pipeline = new IdentityServerPipeline();
+
+    private static string _jwk;
+    private Client _client;
+
+    public LocalApiTokenMode Mode { get; set; }
+    
+    public bool ApiWasCalled { get; set; }
+    public ClaimsPrincipal ApiPrincipal { get; set; }
+
+    static LocalApiAuthenticationTests()
+    {
+        var rsaKey = new RsaSecurityKey(RSA.Create(2048));
+        var jsonWebKey = JsonWebKeyConverter.ConvertFromRSASecurityKey(rsaKey);
+        jsonWebKey.Alg = "PS256";
+        _jwk = JsonSerializer.Serialize(jsonWebKey);
+    }
+
+    public LocalApiAuthenticationTests()
+    {
+        _pipeline.Clients.AddRange(new Client[] {
+            _client = new Client
+            {
+                ClientId = "client",
+                AllowedGrantTypes = GrantTypes.ClientCredentials,
+                ClientSecrets = { new Secret("secret".Sha256()) },
+                AllowedScopes = new List<string> { "api1", "api2" },
+            }
+        });
+
+        _pipeline.ApiResources.AddRange(new ApiResource[] {
+            new ApiResource
+            {
+                Name = "api",
+                Scopes = { "api1", "api2" }
+            }
+        });
+        _pipeline.ApiScopes.AddRange(new[] {
+            new ApiScope
+            {
+                Name = "api1"
+            },
+            new ApiScope
+            {
+                Name = "api2"
+            }
+        });
+
+        _pipeline.OnPostConfigureServices += services => 
+        {
+            services.AddAuthentication()
+                .AddLocalApi("local", options => 
+                {
+                    options.TokenMode = Mode;
+                });
+        };
+
+        _pipeline.OnPreConfigureServices += services =>
+        {
+            services.AddRouting();
+            services.AddAuthorization(options =>
+            {
+                options.AddPolicy("token", policy =>
+                {
+                    policy.AddAuthenticationSchemes("local");
+                    policy.RequireAuthenticatedUser();
+                });
+            });
+        };
+
+        _pipeline.OnPreConfigure += app => 
+        {
+            app.UseRouting();
+        };
+
+        _pipeline.OnPostConfigure += app => 
+        {
+            app.UseAuthorization();
+
+            app.UseEndpoints(eps => 
+            {
+                eps.MapGet("/api", ctx =>
+                { 
+                    ApiWasCalled = true;
+                    ApiPrincipal = ctx.User;
+                    return Task.CompletedTask;
+                }).RequireAuthorization("token");
+            });
+        };
+
+        Init();
+    }
+    void Init(LocalApiTokenMode mode = LocalApiTokenMode.DPoPAndBearer)
+    {
+        Mode = mode;
+        _pipeline.Initialize();
+    }
+
+    async Task<string> GetAccessTokenAsync(bool dpop = false)
+    {
+        var req = new ClientCredentialsTokenRequest
+        {
+            Address = "https://server/connect/token",
+            ClientId = "client",
+            ClientSecret = "secret",
+            Scope = "api1",
+        };
+
+        if (dpop)
+        {
+            req.DPoPProofToken = CreateProofToken("POST", "https://server/connect/token");
+        }
+
+        var result = await _pipeline.BackChannelClient.RequestClientCredentialsTokenAsync(req);
+        result.IsError.Should().BeFalse();
+
+        if (dpop) result.TokenType.Should().Be("DPoP");
+        else result.TokenType.Should().Be("Bearer");
+
+        return result.AccessToken;
+    }
+    string CreateProofToken(string method, string url, string accessToken = null, string nonce = null)
+    {
+        var jsonWebKey = new Microsoft.IdentityModel.Tokens.JsonWebKey(_jwk);
+
+        // jwk: representing the public key chosen by the client, in JSON Web Key (JWK) [RFC7517] format,
+        // as defined in Section 4.1.3 of [RFC7515]. MUST NOT contain a private key.
+        object jwk;
+        if (string.Equals(jsonWebKey.Kty, JsonWebAlgorithmsKeyTypes.EllipticCurve))
+        {
+            jwk = new
+            {
+                kty = jsonWebKey.Kty,
+                x = jsonWebKey.X,
+                y = jsonWebKey.Y,
+                crv = jsonWebKey.Crv
+            };
+        }
+        else if (string.Equals(jsonWebKey.Kty, JsonWebAlgorithmsKeyTypes.RSA))
+        {
+            jwk = new
+            {
+                kty = jsonWebKey.Kty,
+                e = jsonWebKey.E,
+                n = jsonWebKey.N
+            };
+        }
+        else
+        {
+            throw new InvalidOperationException("invalid key type.");
+        }
+
+        var header = new Dictionary<string, object>()
+        {
+            //{ "alg", "RS265" }, // JsonWebTokenHandler requires adding this itself
+            { "typ", JwtClaimTypes.JwtTypes.DPoPProofToken },
+            { JwtClaimTypes.JsonWebKey, jwk },
+        };
+
+        var payload = new Dictionary<string, object>
+        {
+            { JwtClaimTypes.JwtId, CryptoRandom.CreateUniqueId() },
+            { JwtClaimTypes.DPoPHttpMethod, method },
+            { JwtClaimTypes.DPoPHttpUrl, url },
+            { JwtClaimTypes.IssuedAt, DateTimeOffset.UtcNow.ToUnixTimeSeconds() },
+        };
+
+        if (!string.IsNullOrWhiteSpace(accessToken))
+        {
+            // ath: hash of the access token. The value MUST be the result of a base64url encoding 
+            // the SHA-256 hash of the ASCII encoding of the associated access token's value.
+            using var sha256 = SHA256.Create();
+            var hash = sha256.ComputeHash(Encoding.ASCII.GetBytes(accessToken));
+            var ath = Base64Url.Encode(hash);
+
+            payload.Add(JwtClaimTypes.DPoPAccessTokenHash, ath);
+        }
+
+        if (!string.IsNullOrEmpty(nonce))
+        {
+            payload.Add(JwtClaimTypes.Nonce, nonce);
+        }
+
+        var handler = new JsonWebTokenHandler() { SetDefaultTimesOnTokenCreation = false };
+        var key = new SigningCredentials(jsonWebKey, jsonWebKey.Alg);
+        var proofToken = handler.CreateToken(JsonSerializer.Serialize(payload), key, header);
+        return proofToken;
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task bearer_jwt_token_should_validate()
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get, "https://server/api");
+        var at = await GetAccessTokenAsync();
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", at);
+
+        var response = await _pipeline.BackChannelClient.SendAsync(req);
+
+        response.IsSuccessStatusCode.Should().BeTrue();
+        ApiWasCalled.Should().BeTrue();
+        ApiPrincipal.Identity.IsAuthenticated.Should().BeTrue();
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task bearer_ref_token_should_validate()
+    {
+        _client.AccessTokenType = AccessTokenType.Reference;
+
+        var req = new HttpRequestMessage(HttpMethod.Get, "https://server/api");
+        var at = await GetAccessTokenAsync();
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", at);
+
+        var response = await _pipeline.BackChannelClient.SendAsync(req);
+
+        response.IsSuccessStatusCode.Should().BeTrue();
+        ApiWasCalled.Should().BeTrue();
+        ApiPrincipal.Identity.IsAuthenticated.Should().BeTrue();
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task dpop_token_should_validate()
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get, "https://server/api");
+        var at = await GetAccessTokenAsync(true);
+        req.Headers.Authorization = new AuthenticationHeaderValue("DPoP", at);
+        req.Headers.Add("DPoP", CreateProofToken("GET", "https://server/api", at));
+
+        var response = await _pipeline.BackChannelClient.SendAsync(req);
+
+        response.IsSuccessStatusCode.Should().BeTrue();
+        ApiWasCalled.Should().BeTrue();
+        ApiPrincipal.Identity.IsAuthenticated.Should().BeTrue();
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task dpop_nonce_required_should_require_nonce()
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get, "https://server/api");
+        var at = await GetAccessTokenAsync(true);
+        req.Headers.Authorization = new AuthenticationHeaderValue("DPoP", at);
+        req.Headers.Add("DPoP", CreateProofToken("GET", "https://server/api", at));
+
+        _client.DPoPValidationMode = DPoPTokenExpirationValidationMode.Nonce;
+        var response = await _pipeline.BackChannelClient.SendAsync(req);
+
+        response.IsSuccessStatusCode.Should().BeFalse();
+        response.Headers.Contains("DPoP-Nonce").Should().BeTrue();
+    }
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task dpop_nonce_should_validate()
+    {
+        var at = await GetAccessTokenAsync(true);
+        
+        var req = new HttpRequestMessage(HttpMethod.Get, "https://server/api");
+        req.Headers.Authorization = new AuthenticationHeaderValue("DPoP", at);
+        req.Headers.Add("DPoP", CreateProofToken("GET", "https://server/api", at));
+
+        _client.DPoPValidationMode = DPoPTokenExpirationValidationMode.Nonce;
+        var response = await _pipeline.BackChannelClient.SendAsync(req);
+        var nonce = response.Headers.GetValues("DPoP-Nonce").FirstOrDefault();
+
+        var req2 = new HttpRequestMessage(HttpMethod.Get, "https://server/api");
+        req2.Headers.Authorization = new AuthenticationHeaderValue("DPoP", at);
+        req2.Headers.Add("DPoP", CreateProofToken("GET", "https://server/api", at, nonce));
+
+        var response2 = await _pipeline.BackChannelClient.SendAsync(req2);
+        response2.IsSuccessStatusCode.Should().BeTrue();
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task bearer_only_dpop_token_should_fail()
+    {
+        Init(LocalApiTokenMode.BearerOnly);
+        var req = new HttpRequestMessage(HttpMethod.Get, "https://server/api");
+        var at = await GetAccessTokenAsync(true);
+        req.Headers.Authorization = new AuthenticationHeaderValue("DPoP", at);
+        req.Headers.Add("DPoP", CreateProofToken("GET", "https://server/api", at));
+
+        var response = await _pipeline.BackChannelClient.SendAsync(req);
+
+        response.IsSuccessStatusCode.Should().BeFalse();
+        response.Headers.WwwAuthenticate.Select(x => x.Scheme).Should().BeEquivalentTo(new[] { "Bearer" });
+
+    }
+    
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task dpop_only_bearer_should_fail()
+    {
+        Init(LocalApiTokenMode.DPoPOnly);
+        var req = new HttpRequestMessage(HttpMethod.Get, "https://server/api");
+        var at = await GetAccessTokenAsync();
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", at);
+
+        var response = await _pipeline.BackChannelClient.SendAsync(req);
+
+        response.IsSuccessStatusCode.Should().BeFalse();
+        response.Headers.WwwAuthenticate.Select(x => x.Scheme).Should().BeEquivalentTo(new[] { "DPoP" });
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task missing_authz_should_fail()
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get, "https://server/api");
+
+        var response = await _pipeline.BackChannelClient.SendAsync(req);
+
+        response.IsSuccessStatusCode.Should().BeFalse();
+        response.Headers.WwwAuthenticate.Select(x => x.Scheme).Should().BeEquivalentTo(new[] { "Bearer", "DPoP" });
+    }
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task missing_token_should_fail()
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get, "https://server/api");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "");
+
+        var response = await _pipeline.BackChannelClient.SendAsync(req);
+
+        response.IsSuccessStatusCode.Should().BeFalse();
+    }
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task malformed_token_should_fail()
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get, "https://server/api");
+        var at = await GetAccessTokenAsync();
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", at.Substring(at.Length / 2));
+
+        var response = await _pipeline.BackChannelClient.SendAsync(req);
+
+        response.IsSuccessStatusCode.Should().BeFalse();
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task dpop_token_for_disabled_client_should_fail()
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get, "https://server/api");
+        var at = await GetAccessTokenAsync(true);
+        req.Headers.Authorization = new AuthenticationHeaderValue("DPoP", at);
+        req.Headers.Add("DPoP", CreateProofToken("GET", "https://server/api", at));
+
+        _client.Enabled = false;
+
+        var response = await _pipeline.BackChannelClient.SendAsync(req);
+
+        response.IsSuccessStatusCode.Should().BeFalse();
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task dpop_validation_failure_should_fail()
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get, "https://server/api");
+        var at = await GetAccessTokenAsync(true);
+        req.Headers.Authorization = new AuthenticationHeaderValue("DPoP", at);
+
+        var response = await _pipeline.BackChannelClient.SendAsync(req);
+
+        response.IsSuccessStatusCode.Should().BeFalse();
+    }
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task dpop_token_using_bearer_scheme_should_fail()
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get, "https://server/api");
+        var at = await GetAccessTokenAsync(true);
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", at);
+
+        var response = await _pipeline.BackChannelClient.SendAsync(req);
+
+        response.IsSuccessStatusCode.Should().BeFalse();
+    }
+}

--- a/test/IdentityServer.UnitTests/Validation/DPoPProofValidatorTests.cs
+++ b/test/IdentityServer.UnitTests/Validation/DPoPProofValidatorTests.cs
@@ -66,7 +66,6 @@ Dictionary<string, object> _header;
 
         _subject = new DefaultDPoPProofValidator(
             _options, 
-            new MockServerUrls() { BasePath = "/", Origin = "https://identityserver" },
             _testReplayCache,
             _clock,
             _stubDataProtectionProvider,

--- a/test/IdentityServer.UnitTests/Validation/DPoPProofValidatorTests.cs
+++ b/test/IdentityServer.UnitTests/Validation/DPoPProofValidatorTests.cs
@@ -128,7 +128,7 @@ public class DPoPProofValidatorTests
     public async Task valid_dpop_jwt_should_pass_validation()
     {
         var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client };
+        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
         var result = await _subject.ValidateAsync(ctx);
 
         result.IsError.Should().BeFalse();
@@ -150,7 +150,7 @@ public class DPoPProofValidatorTests
             var token = CreateDPoPProofToken();
             _now = _now.AddMinutes(5);
 
-            var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client };
+            var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
             var result = await _subject.ValidateAsync(ctx);
             result.IsError.Should().BeFalse();
         }
@@ -162,7 +162,7 @@ public class DPoPProofValidatorTests
             var token = CreateDPoPProofToken();
             _now = _now.AddMinutes(-5);
 
-            var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client };
+            var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
             var result = await _subject.ValidateAsync(ctx);
             result.IsError.Should().BeFalse();
         }
@@ -184,12 +184,12 @@ public class DPoPProofValidatorTests
             _now = _now.AddMinutes(5);
 
             {
-                var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client };
+                var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
                 var result = await _subject.ValidateAsync(ctx);
                 result.IsError.Should().BeFalse();
             }
             {
-                var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client };
+                var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
                 var result = await _subject.ValidateAsync(ctx);
                 result.IsError.Should().BeTrue();
             }
@@ -203,12 +203,12 @@ public class DPoPProofValidatorTests
             _now = _now.AddMinutes(-5);
 
             {
-                var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client };
+                var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
                 var result = await _subject.ValidateAsync(ctx);
                 result.IsError.Should().BeFalse();
             }
             {
-                var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client };
+                var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
                 var result = await _subject.ValidateAsync(ctx);
                 result.IsError.Should().BeTrue();
             }
@@ -228,7 +228,7 @@ public class DPoPProofValidatorTests
             var token = CreateDPoPProofToken();
             _now = _now.AddMinutes(5);
 
-            var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client };
+            var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
             var result = await _subject.ValidateAsync(ctx);
             result.IsError.Should().BeFalse();
         }
@@ -239,7 +239,7 @@ public class DPoPProofValidatorTests
             var token = CreateDPoPProofToken();
             _now = _now.AddMinutes(-5);
 
-            var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client };
+            var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
             var result = await _subject.ValidateAsync(ctx);
             result.IsError.Should().BeFalse();
         }
@@ -259,12 +259,12 @@ public class DPoPProofValidatorTests
             _now = _now.AddMinutes(5);
 
             {
-                var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client };
+                var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
                 var result = await _subject.ValidateAsync(ctx);
                 result.IsError.Should().BeFalse();
             }
             {
-                var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client };
+                var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
                 var result = await _subject.ValidateAsync(ctx);
                 result.IsError.Should().BeTrue();
             }
@@ -277,12 +277,12 @@ public class DPoPProofValidatorTests
             _now = _now.AddMinutes(-5);
 
             {
-                var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client };
+                var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
                 var result = await _subject.ValidateAsync(ctx);
                 result.IsError.Should().BeFalse();
             }
             {
-                var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client };
+                var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
                 var result = await _subject.ValidateAsync(ctx);
                 result.IsError.Should().BeTrue();
             }
@@ -299,12 +299,12 @@ public class DPoPProofValidatorTests
         var token = CreateDPoPProofToken();
 
         {
-            var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client };
+            var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
             var result = await _subject.ValidateAsync(ctx);
             result.IsError.Should().BeFalse();
         }
         {
-            var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client };
+            var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
             var result = await _subject.ValidateAsync(ctx);
             result.IsError.Should().BeTrue();
         }
@@ -315,7 +315,7 @@ public class DPoPProofValidatorTests
     public async Task empty_string_should_fail_validation()
     {
         var popToken = "";
-        var ctx = new DPoPProofValidatonContext { ProofToken = popToken, Client = _client };
+        var ctx = new DPoPProofValidatonContext { ProofToken = popToken, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
         var result = await _subject.ValidateAsync(ctx);
         result.IsError.Should().BeTrue();
         result.Error.Should().Be("invalid_dpop_proof");
@@ -326,7 +326,7 @@ public class DPoPProofValidatorTests
     public async Task malformed_dpop_jwt_should_fail_validation()
     {
         var token = "malformed";
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client };
+        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
         var result = await _subject.ValidateAsync(ctx);
 
         result.IsError.Should().BeTrue();
@@ -340,7 +340,7 @@ public class DPoPProofValidatorTests
         _header["typ"] = "JWT";
 
         var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client };
+        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
         var result = await _subject.ValidateAsync(ctx);
 
         result.IsError.Should().BeTrue();
@@ -356,7 +356,7 @@ public class DPoPProofValidatorTests
         CreateHeaderValuesFromPublicKey();
         var token = CreateDPoPProofToken("HS256", key);
 
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client };
+        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
         var result = await _subject.ValidateAsync(ctx);
         
         result.IsError.Should().BeTrue();
@@ -371,7 +371,7 @@ public class DPoPProofValidatorTests
         CreateHeaderValuesFromPublicKey();
 
         var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client };
+        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
         var result = await _subject.ValidateAsync(ctx);
 
         result.IsError.Should().BeTrue();
@@ -385,7 +385,7 @@ public class DPoPProofValidatorTests
         _header["typ"] = true;
 
         var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client };
+        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
         var result = await _subject.ValidateAsync(ctx);
 
         result.IsError.Should().BeTrue();
@@ -399,7 +399,7 @@ public class DPoPProofValidatorTests
         _header.Remove("jwk");
 
         var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client };
+        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
         var result = await _subject.ValidateAsync(ctx);
 
         result.IsError.Should().BeTrue();
@@ -413,7 +413,7 @@ public class DPoPProofValidatorTests
         _header["jwk"] = "malformed";
         
         var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client };
+        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
         var result = await _subject.ValidateAsync(ctx);
 
         result.IsError.Should().BeTrue();
@@ -429,7 +429,7 @@ public class DPoPProofValidatorTests
         _privateJWK = JsonSerializer.Serialize(jwk);
 
         var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client };
+        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
         var result = await _subject.ValidateAsync(ctx);
         
         result.IsError.Should().BeTrue();
@@ -443,7 +443,7 @@ public class DPoPProofValidatorTests
         _payload.Remove("jti");
 
         var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client };
+        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
         var result = await _subject.ValidateAsync(ctx);
 
         result.IsError.Should().BeTrue();
@@ -457,7 +457,7 @@ public class DPoPProofValidatorTests
         _payload.Remove("htm");
 
         var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client };
+        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
         var result = await _subject.ValidateAsync(ctx);
 
         result.IsError.Should().BeTrue();
@@ -471,7 +471,7 @@ public class DPoPProofValidatorTests
         _payload.Remove("htu");
 
         var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client };
+        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
         var result = await _subject.ValidateAsync(ctx);
 
         result.IsError.Should().BeTrue();
@@ -485,7 +485,7 @@ public class DPoPProofValidatorTests
         _payload["htu"] = "https://identityserver";
 
         var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client };
+        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
         var result = await _subject.ValidateAsync(ctx);
 
         result.IsError.Should().BeTrue();
@@ -499,7 +499,7 @@ public class DPoPProofValidatorTests
         _payload.Remove("iat");
 
         var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client };
+        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
         var result = await _subject.ValidateAsync(ctx);
 
         result.IsError.Should().BeTrue();
@@ -513,7 +513,7 @@ public class DPoPProofValidatorTests
         _payload["iat"] = "invalid";
 
         var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client };
+        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
         var result = await _subject.ValidateAsync(ctx);
 
         result.IsError.Should().BeTrue();
@@ -527,7 +527,7 @@ public class DPoPProofValidatorTests
         _payload["iat"] = _clock.UtcNow.Subtract(TimeSpan.FromSeconds(61)).ToUnixTimeSeconds();
 
         var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client };
+        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
         var result = await _subject.ValidateAsync(ctx);
 
         result.IsError.Should().BeTrue();
@@ -541,7 +541,7 @@ public class DPoPProofValidatorTests
         _payload["iat"] = _clock.UtcNow.Add(TimeSpan.FromSeconds(1)).ToUnixTimeSeconds();
 
         var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client };
+        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
         var result = await _subject.ValidateAsync(ctx);
 
         result.IsError.Should().BeTrue();
@@ -557,7 +557,7 @@ public class DPoPProofValidatorTests
         _payload["iat"] = _clock.UtcNow.Subtract(TimeSpan.FromSeconds(61)).ToUnixTimeSeconds();
 
         var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client };
+        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
         var result = await _subject.ValidateAsync(ctx);
 
         result.IsError.Should().BeFalse();
@@ -572,7 +572,7 @@ public class DPoPProofValidatorTests
         _payload["iat"] = _clock.UtcNow.Subtract(TimeSpan.FromSeconds(121)).ToUnixTimeSeconds();
 
         var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client };
+        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
         var result = await _subject.ValidateAsync(ctx);
 
         result.IsError.Should().BeTrue();
@@ -588,7 +588,7 @@ public class DPoPProofValidatorTests
         _payload["iat"] = _clock.UtcNow.Add(TimeSpan.FromSeconds(59)).ToUnixTimeSeconds();
 
         var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client };
+        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
         var result = await _subject.ValidateAsync(ctx);
 
         result.IsError.Should().BeFalse();
@@ -603,7 +603,7 @@ public class DPoPProofValidatorTests
         _payload["iat"] = _clock.UtcNow.Add(TimeSpan.FromSeconds(61)).ToUnixTimeSeconds();
 
         var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client };
+        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
         var result = await _subject.ValidateAsync(ctx);
 
         result.IsError.Should().BeTrue();
@@ -618,7 +618,7 @@ public class DPoPProofValidatorTests
         _payload["nonce"] = "nonce";
 
         var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client };
+        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
         var result = await _subject.ValidateAsync(ctx);
 
         result.IsError.Should().BeTrue();
@@ -633,7 +633,7 @@ public class DPoPProofValidatorTests
         _client.DPoPValidationMode = DPoPTokenExpirationValidationMode.Nonce;
 
         var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client };
+        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
         var result = await _subject.ValidateAsync(ctx);
 
         result.IsError.Should().BeTrue();
@@ -648,7 +648,7 @@ public class DPoPProofValidatorTests
         _client.DPoPValidationMode = DPoPTokenExpirationValidationMode.Nonce;
 
         var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client };
+        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
         var result = await _subject.ValidateAsync(ctx);
 
         result.IsError.Should().BeTrue();
@@ -656,7 +656,7 @@ public class DPoPProofValidatorTests
         _payload["nonce"] = result.ServerIssuedNonce;
 
         token = CreateDPoPProofToken();
-        ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client };
+        ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
         result = await _subject.ValidateAsync(ctx);
 
         result.IsError.Should().BeFalse();
@@ -670,7 +670,7 @@ public class DPoPProofValidatorTests
         _client.DPoPValidationMode = DPoPTokenExpirationValidationMode.Nonce;
 
         var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client };
+        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
         var result = await _subject.ValidateAsync(ctx);
 
         result.IsError.Should().BeTrue();
@@ -678,7 +678,7 @@ public class DPoPProofValidatorTests
         _payload["nonce"] = result.ServerIssuedNonce + "invalid_stuff";
 
         token = CreateDPoPProofToken();
-        ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client };
+        ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
         result = await _subject.ValidateAsync(ctx);
 
         result.IsError.Should().BeTrue();
@@ -693,7 +693,7 @@ public class DPoPProofValidatorTests
         _client.DPoPValidationMode = DPoPTokenExpirationValidationMode.Nonce;
 
         var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client };
+        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
         var result = await _subject.ValidateAsync(ctx);
 
         result.IsError.Should().BeTrue();
@@ -703,7 +703,7 @@ public class DPoPProofValidatorTests
         _now = _now.AddSeconds(61);
 
         token = CreateDPoPProofToken();
-        ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client };
+        ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
         result = await _subject.ValidateAsync(ctx);
 
         result.IsError.Should().BeTrue();
@@ -716,7 +716,7 @@ public class DPoPProofValidatorTests
         _now = _now.AddSeconds(-61);
 
         token = CreateDPoPProofToken();
-        ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client };
+        ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
         result = await _subject.ValidateAsync(ctx);
 
         result.IsError.Should().BeTrue();

--- a/test/IdentityServer.UnitTests/Validation/DPoPProofValidatorTests.cs
+++ b/test/IdentityServer.UnitTests/Validation/DPoPProofValidatorTests.cs
@@ -38,14 +38,14 @@ public class DPoPProofValidatorTests
         }
     }
 
-    Client _client = new Client 
+    private DPoPProofValidatonContext _context = new DPoPProofValidatonContext
     { 
-        ClientId = "client1", 
-        DPoPValidationMode = DPoPTokenExpirationValidationMode.Iat, 
-        DPoPClockSkew = TimeSpan.Zero 
+        DPoPClockSkew = TimeSpan.Zero, 
+        Url = "https://identityserver/connect/token", 
+        Method = "POST" 
     };
 
-    Dictionary<string, object> _header;
+Dictionary<string, object> _header;
     Dictionary<string, object> _payload;
     string _privateJWK = "{\"Crv\":null,\"D\":\"QeBWodq0hSYjfAxxo0VZleXLqwwZZeNWvvFfES4WyItao_-OJv1wKA7zfkZxbWkpK5iRbKrl2AMJ52AtUo5JJ6QZ7IjAQlgM0lBg3ltjb1aA0gBsK5XbiXcsV8DiAnRuy6-XgjAKPR8Lo-wZl_fdPbVoAmpSdmfn_6QXXPBai5i7FiyDbQa16pI6DL-5SCj7F78QDTRiJOqn5ElNvtoJEfJBm13giRdqeriFi3pCWo7H3QBgTEWtDNk509z4w4t64B2HTXnM0xj9zLnS42l7YplJC7MRibD4nVBMtzfwtGRKLj8beuDgtW9pDlQqf7RVWX5pHQgiHAZmUi85TEbYdQ\",\"DP\":\"h2F54OMaC9qq1yqR2b55QNNaChyGtvmTHSdqZJ8lJFqvUorlz-Uocj2BTowWQnaMd8zRKMdKlSeUuSv4Z6WmjSxSsNbonI6_II5XlZLWYqFdmqDS-xCmJY32voT5Wn7OwB9xj1msDqrFPg-PqSBOh5OppjCqXqDFcNvSkQSajXc\",\"DQ\":\"VABdS20Nxkmq6JWLQj7OjRxVJuYsHrfmWJmDA7_SYtlXaPUcg-GiHGQtzdDWEeEi0dlJjv9I3FdjKGC7CGwqtVygW38DzVYJsV2EmRNJc1-j-1dRs_pK9GWR4NYm0mVz_IhS8etIf9cfRJk90xU3AL3_J6p5WNF7I5ctkLpnt8M\",\"E\":\"AQAB\",\"K\":null,\"KeyOps\":[],\"Kty\":\"RSA\",\"N\":\"yWWAOSV3Z_BW9rJEFvbZyeU-q2mJWC0l8WiHNqwVVf7qXYgm9hJC0j1aPHku_Wpl38DpK3Xu3LjWOFG9OrCqga5Pzce3DDJKI903GNqz5wphJFqweoBFKOjj1wegymvySsLoPqqDNVYTKp4nVnECZS4axZJoNt2l1S1bC8JryaNze2stjW60QT-mIAGq9konKKN3URQ12dr478m0Oh-4WWOiY4HrXoSOklFmzK-aQx1JV_SZ04eIGfSw1pZZyqTaB1BwBotiy-QA03IRxwIXQ7BSx5EaxC5uMCMbzmbvJqjt-q8Y1wyl-UQjRucgp7hkfHSE1QT3zEex2Q3NFux7SQ\",\"Oth\":null,\"P\":\"_T7MTkeOh5QyqlYCtLQ2RWf2dAJ9i3wrCx4nEDm1c1biijhtVTL7uJTLxwQIM9O2PvOi5Dq-UiGy6rhHZqf5akWTeHtaNyI-2XslQfaS3ctRgmGtRQL_VihK-R9AQtDx4eWL4h-bDJxPaxby_cVo_j2MX5AeoC1kNmcCdDf_X0M\",\"Q\":\"y5ZSThaGLjaPj8Mk2nuD8TiC-sb4aAZVh9K-W4kwaWKfDNoPcNb_dephBNMnOp9M1br6rDbyG7P-Sy_LOOsKg3Q0wHqv4hnzGaOQFeMJH4HkXYdENC7B5JG9PefbC6zwcgZWiBnsxgKpScNWuzGF8x2CC-MdsQ1bkQeTPbJklIM\",\"QI\":\"i716Vt9II_Rt6qnjsEhfE4bej52QFG9a1hSnx5PDNvRrNqR_RpTA0lO9qeXSZYGHTW_b6ZXdh_0EUwRDEDHmaxjkIcTADq6JLuDltOhZuhLUSc5NCKLAVCZlPcaSzv8-bZm57mVcIpx0KyFHxvk50___Jgx1qyzwLX03mPGUbDQ\",\"Use\":null,\"X\":null,\"X5c\":[],\"X5t\":null,\"X5tS256\":null,\"X5u\":null,\"Y\":null,\"KeySize\":2048,\"HasPrivateKey\":true,\"CryptoProviderFactory\":{\"CryptoProviderCache\":{},\"CustomCryptoProvider\":null,\"CacheSignatureProviders\":true,\"SignatureProviderObjectPoolCacheSize\":80}}";
     string _publicJWK = "{\"kty\":\"RSA\",\"use\":\"sig\",\"x5t\":null,\"e\":\"AQAB\",\"n\":\"yWWAOSV3Z_BW9rJEFvbZyeU-q2mJWC0l8WiHNqwVVf7qXYgm9hJC0j1aPHku_Wpl38DpK3Xu3LjWOFG9OrCqga5Pzce3DDJKI903GNqz5wphJFqweoBFKOjj1wegymvySsLoPqqDNVYTKp4nVnECZS4axZJoNt2l1S1bC8JryaNze2stjW60QT-mIAGq9konKKN3URQ12dr478m0Oh-4WWOiY4HrXoSOklFmzK-aQx1JV_SZ04eIGfSw1pZZyqTaB1BwBotiy-QA03IRxwIXQ7BSx5EaxC5uMCMbzmbvJqjt-q8Y1wyl-UQjRucgp7hkfHSE1QT3zEex2Q3NFux7SQ\",\"x5c\":null,\"x\":null,\"y\":null,\"crv\":null}";
@@ -127,9 +127,9 @@ public class DPoPProofValidatorTests
     [Trait("Category", Category)]
     public async Task valid_dpop_jwt_should_pass_validation()
     {
-        var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
-        var result = await _subject.ValidateAsync(ctx);
+        _context.ProofToken = CreateDPoPProofToken();
+
+        var result = await _subject.ValidateAsync(_context);
 
         result.IsError.Should().BeFalse();
         result.JsonWebKeyThumbprint.Should().Be(_JKT);
@@ -139,19 +139,19 @@ public class DPoPProofValidatorTests
     [Trait("Category", Category)]
     public async Task server_clock_skew_should_allow_tokens_outside_normal_duration()
     {
-        _client.DPoPValidationMode = DPoPTokenExpirationValidationMode.Nonce;
         _options.DPoP.ProofTokenValidityDuration = TimeSpan.FromMinutes(1);
         _options.DPoP.ServerClockSkew = TimeSpan.FromMinutes(5);
+
+        _context.DPoPValidationMode = DPoPTokenExpirationValidationMode.Nonce;
 
         {
             // test 1: client behind server
             _payload["jti"] = Guid.NewGuid().ToString();
             _payload["nonce"] = _stubDataProtectionProvider.Protect(new DateTimeOffset(_now).ToUnixTimeSeconds().ToString());
-            var token = CreateDPoPProofToken();
+            _context.ProofToken = CreateDPoPProofToken();
             _now = _now.AddMinutes(5);
 
-            var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
-            var result = await _subject.ValidateAsync(ctx);
+            var result = await _subject.ValidateAsync(_context);
             result.IsError.Should().BeFalse();
         }
 
@@ -159,11 +159,10 @@ public class DPoPProofValidatorTests
             // test 2: client ahead of server
             _payload["jti"] = Guid.NewGuid().ToString();
             _payload["nonce"] = _stubDataProtectionProvider.Protect(new DateTimeOffset(_now).ToUnixTimeSeconds().ToString());
-            var token = CreateDPoPProofToken();
+            _context.ProofToken = CreateDPoPProofToken();
             _now = _now.AddMinutes(-5);
 
-            var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
-            var result = await _subject.ValidateAsync(ctx);
+            var result = await _subject.ValidateAsync(_context);
             result.IsError.Should().BeFalse();
         }
     }
@@ -172,25 +171,24 @@ public class DPoPProofValidatorTests
     [Trait("Category", Category)]
     public async Task server_clock_skew_should_extend_replay_cache()
     {
-        _client.DPoPValidationMode = DPoPTokenExpirationValidationMode.Nonce;
         _options.DPoP.ProofTokenValidityDuration = TimeSpan.FromMinutes(1);
         _options.DPoP.ServerClockSkew = TimeSpan.FromMinutes(5);
+
+        _context.DPoPValidationMode = DPoPTokenExpirationValidationMode.Nonce;
 
         {
             // test 1: client behind server
             _payload["jti"] = Guid.NewGuid().ToString();
             _payload["nonce"] = _stubDataProtectionProvider.Protect(new DateTimeOffset(_now).ToUnixTimeSeconds().ToString());
-            var token = CreateDPoPProofToken();
+            _context.ProofToken = CreateDPoPProofToken();
             _now = _now.AddMinutes(5);
 
             {
-                var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
-                var result = await _subject.ValidateAsync(ctx);
+                var result = await _subject.ValidateAsync(_context);
                 result.IsError.Should().BeFalse();
             }
             {
-                var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
-                var result = await _subject.ValidateAsync(ctx);
+                var result = await _subject.ValidateAsync(_context);
                 result.IsError.Should().BeTrue();
             }
         }
@@ -199,17 +197,15 @@ public class DPoPProofValidatorTests
             // test 2: client ahead of server
             _payload["jti"] = Guid.NewGuid().ToString();
             _payload["nonce"] = _stubDataProtectionProvider.Protect(new DateTimeOffset(_now).ToUnixTimeSeconds().ToString());
-            var token = CreateDPoPProofToken();
+            _context.ProofToken = CreateDPoPProofToken();
             _now = _now.AddMinutes(-5);
-
+            
             {
-                var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
-                var result = await _subject.ValidateAsync(ctx);
+                var result = await _subject.ValidateAsync(_context);
                 result.IsError.Should().BeFalse();
             }
             {
-                var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
-                var result = await _subject.ValidateAsync(ctx);
+                var result = await _subject.ValidateAsync(_context);
                 result.IsError.Should().BeTrue();
             }
         }
@@ -220,27 +216,26 @@ public class DPoPProofValidatorTests
     public async Task client_clock_skew_should_allow_tokens_outside_normal_duration()
     {
         _options.DPoP.ProofTokenValidityDuration = TimeSpan.FromMinutes(1);
-        _client.DPoPClockSkew = TimeSpan.FromMinutes(5);
+        
+        _context.DPoPClockSkew = TimeSpan.FromMinutes(5);
 
         {
             // test 1: client behind server
             _payload["jti"] = Guid.NewGuid().ToString();
-            var token = CreateDPoPProofToken();
+            _context.ProofToken = CreateDPoPProofToken();
             _now = _now.AddMinutes(5);
 
-            var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
-            var result = await _subject.ValidateAsync(ctx);
+            var result = await _subject.ValidateAsync(_context);
             result.IsError.Should().BeFalse();
         }
 
         {
             // test 2: client ahead of server
             _payload["jti"] = Guid.NewGuid().ToString();
-            var token = CreateDPoPProofToken();
+            _context.ProofToken = CreateDPoPProofToken();
             _now = _now.AddMinutes(-5);
 
-            var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
-            var result = await _subject.ValidateAsync(ctx);
+            var result = await _subject.ValidateAsync(_context);
             result.IsError.Should().BeFalse();
         }
     }
@@ -250,22 +245,21 @@ public class DPoPProofValidatorTests
     public async Task client_clock_skew_should_extend_replay_cache()
     {
         _options.DPoP.ProofTokenValidityDuration = TimeSpan.FromMinutes(1);
-        _client.DPoPClockSkew = TimeSpan.FromMinutes(5);
+        
+        _context.DPoPClockSkew = TimeSpan.FromMinutes(5);
 
         {
             // test 1: client behind server
             _payload["jti"] = Guid.NewGuid().ToString();
-            var token = CreateDPoPProofToken();
+            _context.ProofToken = CreateDPoPProofToken();
             _now = _now.AddMinutes(5);
 
             {
-                var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
-                var result = await _subject.ValidateAsync(ctx);
+                var result = await _subject.ValidateAsync(_context);
                 result.IsError.Should().BeFalse();
             }
             {
-                var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
-                var result = await _subject.ValidateAsync(ctx);
+                var result = await _subject.ValidateAsync(_context);
                 result.IsError.Should().BeTrue();
             }
         }
@@ -273,17 +267,15 @@ public class DPoPProofValidatorTests
         {
             // test 2: client ahead of server
             _payload["jti"] = Guid.NewGuid().ToString();
-            var token = CreateDPoPProofToken();
+            _context.ProofToken = CreateDPoPProofToken();
             _now = _now.AddMinutes(-5);
 
             {
-                var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
-                var result = await _subject.ValidateAsync(ctx);
+                var result = await _subject.ValidateAsync(_context);
                 result.IsError.Should().BeFalse();
             }
             {
-                var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
-                var result = await _subject.ValidateAsync(ctx);
+                var result = await _subject.ValidateAsync(_context);
                 result.IsError.Should().BeTrue();
             }
         }
@@ -295,17 +287,15 @@ public class DPoPProofValidatorTests
     {
         _options.DPoP.ProofTokenValidityDuration = TimeSpan.FromMinutes(1);
         _options.DPoP.ServerClockSkew = TimeSpan.Zero;
-        
-        var token = CreateDPoPProofToken();
+
+        _context.ProofToken = CreateDPoPProofToken();
 
         {
-            var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
-            var result = await _subject.ValidateAsync(ctx);
+            var result = await _subject.ValidateAsync(_context);
             result.IsError.Should().BeFalse();
         }
         {
-            var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
-            var result = await _subject.ValidateAsync(ctx);
+            var result = await _subject.ValidateAsync(_context);
             result.IsError.Should().BeTrue();
         }
     }
@@ -314,9 +304,9 @@ public class DPoPProofValidatorTests
     [Trait("Category", Category)]
     public async Task empty_string_should_fail_validation()
     {
-        var popToken = "";
-        var ctx = new DPoPProofValidatonContext { ProofToken = popToken, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
-        var result = await _subject.ValidateAsync(ctx);
+        _context.ProofToken = "";
+
+        var result = await _subject.ValidateAsync(_context);
         result.IsError.Should().BeTrue();
         result.Error.Should().Be("invalid_dpop_proof");
     }
@@ -325,9 +315,9 @@ public class DPoPProofValidatorTests
     [Trait("Category", Category)]
     public async Task malformed_dpop_jwt_should_fail_validation()
     {
-        var token = "malformed";
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
-        var result = await _subject.ValidateAsync(ctx);
+        _context.ProofToken = "malformed";
+
+        var result = await _subject.ValidateAsync(_context);
 
         result.IsError.Should().BeTrue();
         result.Error.Should().Be("invalid_dpop_proof");
@@ -339,9 +329,9 @@ public class DPoPProofValidatorTests
     {
         _header["typ"] = "JWT";
 
-        var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
-        var result = await _subject.ValidateAsync(ctx);
+        _context.ProofToken = CreateDPoPProofToken();
+
+        var result = await _subject.ValidateAsync(_context);
 
         result.IsError.Should().BeTrue();
         result.Error.Should().Be("invalid_dpop_proof");
@@ -354,10 +344,10 @@ public class DPoPProofValidatorTests
         var key = new SymmetricSecurityKey(IdentityModel.CryptoRandom.CreateRandomKey(32));
         _publicJWK = JsonSerializer.Serialize(key);
         CreateHeaderValuesFromPublicKey();
-        var token = CreateDPoPProofToken("HS256", key);
+        
+        _context.ProofToken = CreateDPoPProofToken("HS256", key);
 
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
-        var result = await _subject.ValidateAsync(ctx);
+        var result = await _subject.ValidateAsync(_context);
         
         result.IsError.Should().BeTrue();
         result.Error.Should().Be("invalid_dpop_proof");
@@ -370,9 +360,9 @@ public class DPoPProofValidatorTests
         _publicJWK = _privateJWK;
         CreateHeaderValuesFromPublicKey();
 
-        var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
-        var result = await _subject.ValidateAsync(ctx);
+        _context.ProofToken = CreateDPoPProofToken();
+
+        var result = await _subject.ValidateAsync(_context);
 
         result.IsError.Should().BeTrue();
         result.Error.Should().Be("invalid_dpop_proof");
@@ -384,9 +374,9 @@ public class DPoPProofValidatorTests
     {
         _header["typ"] = true;
 
-        var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
-        var result = await _subject.ValidateAsync(ctx);
+        _context.ProofToken = CreateDPoPProofToken();
+
+        var result = await _subject.ValidateAsync(_context);
 
         result.IsError.Should().BeTrue();
         result.Error.Should().Be("invalid_dpop_proof");
@@ -398,9 +388,9 @@ public class DPoPProofValidatorTests
     {
         _header.Remove("jwk");
 
-        var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
-        var result = await _subject.ValidateAsync(ctx);
+        _context.ProofToken = CreateDPoPProofToken();
+
+        var result = await _subject.ValidateAsync(_context);
 
         result.IsError.Should().BeTrue();
         result.Error.Should().Be("invalid_dpop_proof");
@@ -411,10 +401,10 @@ public class DPoPProofValidatorTests
     public async Task jwk_with_malformed_key_should_fail_validation()
     {
         _header["jwk"] = "malformed";
-        
-        var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
-        var result = await _subject.ValidateAsync(ctx);
+
+        _context.ProofToken = CreateDPoPProofToken();
+
+        var result = await _subject.ValidateAsync(_context);
 
         result.IsError.Should().BeTrue();
         result.Error.Should().Be("invalid_dpop_proof");
@@ -428,9 +418,9 @@ public class DPoPProofValidatorTests
         var jwk = JsonWebKeyConverter.ConvertFromRSASecurityKey(key);
         _privateJWK = JsonSerializer.Serialize(jwk);
 
-        var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
-        var result = await _subject.ValidateAsync(ctx);
+        _context.ProofToken = CreateDPoPProofToken();
+
+        var result = await _subject.ValidateAsync(_context);
         
         result.IsError.Should().BeTrue();
         result.Error.Should().Be("invalid_dpop_proof");
@@ -442,9 +432,9 @@ public class DPoPProofValidatorTests
     {
         _payload.Remove("jti");
 
-        var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
-        var result = await _subject.ValidateAsync(ctx);
+        _context.ProofToken = CreateDPoPProofToken();
+
+        var result = await _subject.ValidateAsync(_context);
 
         result.IsError.Should().BeTrue();
         result.Error.Should().Be("invalid_dpop_proof");
@@ -456,9 +446,9 @@ public class DPoPProofValidatorTests
     {
         _payload.Remove("htm");
 
-        var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
-        var result = await _subject.ValidateAsync(ctx);
+        _context.ProofToken = CreateDPoPProofToken();
+
+        var result = await _subject.ValidateAsync(_context);
 
         result.IsError.Should().BeTrue();
         result.Error.Should().Be("invalid_dpop_proof");
@@ -470,9 +460,9 @@ public class DPoPProofValidatorTests
     {
         _payload.Remove("htu");
 
-        var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
-        var result = await _subject.ValidateAsync(ctx);
+        _context.ProofToken = CreateDPoPProofToken();
+
+        var result = await _subject.ValidateAsync(_context);
 
         result.IsError.Should().BeTrue();
         result.Error.Should().Be("invalid_dpop_proof");
@@ -484,9 +474,9 @@ public class DPoPProofValidatorTests
     {
         _payload["htu"] = "https://identityserver";
 
-        var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
-        var result = await _subject.ValidateAsync(ctx);
+        _context.ProofToken = CreateDPoPProofToken();
+
+        var result = await _subject.ValidateAsync(_context);
 
         result.IsError.Should().BeTrue();
         result.Error.Should().Be("invalid_dpop_proof");
@@ -498,9 +488,9 @@ public class DPoPProofValidatorTests
     {
         _payload.Remove("iat");
 
-        var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
-        var result = await _subject.ValidateAsync(ctx);
+        _context.ProofToken = CreateDPoPProofToken();
+
+        var result = await _subject.ValidateAsync(_context);
 
         result.IsError.Should().BeTrue();
         result.Error.Should().Be("invalid_dpop_proof");
@@ -512,9 +502,9 @@ public class DPoPProofValidatorTests
     {
         _payload["iat"] = "invalid";
 
-        var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
-        var result = await _subject.ValidateAsync(ctx);
+        _context.ProofToken = CreateDPoPProofToken();
+
+        var result = await _subject.ValidateAsync(_context);
 
         result.IsError.Should().BeTrue();
         result.Error.Should().Be("invalid_dpop_proof");
@@ -526,9 +516,9 @@ public class DPoPProofValidatorTests
     {
         _payload["iat"] = _clock.UtcNow.Subtract(TimeSpan.FromSeconds(61)).ToUnixTimeSeconds();
 
-        var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
-        var result = await _subject.ValidateAsync(ctx);
+        _context.ProofToken = CreateDPoPProofToken();
+
+        var result = await _subject.ValidateAsync(_context);
 
         result.IsError.Should().BeTrue();
         result.Error.Should().Be("invalid_dpop_proof");
@@ -540,9 +530,9 @@ public class DPoPProofValidatorTests
     {
         _payload["iat"] = _clock.UtcNow.Add(TimeSpan.FromSeconds(1)).ToUnixTimeSeconds();
 
-        var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
-        var result = await _subject.ValidateAsync(ctx);
+        _context.ProofToken = CreateDPoPProofToken();
+
+        var result = await _subject.ValidateAsync(_context);
 
         result.IsError.Should().BeTrue();
         result.Error.Should().Be("invalid_dpop_proof");
@@ -552,13 +542,12 @@ public class DPoPProofValidatorTests
     [Trait("Category", Category)]
     public async Task too_old_but_within_clock_skew_iat_should_succeed()
     {
-        _client.DPoPClockSkew = TimeSpan.FromMinutes(1);
-
         _payload["iat"] = _clock.UtcNow.Subtract(TimeSpan.FromSeconds(61)).ToUnixTimeSeconds();
 
-        var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
-        var result = await _subject.ValidateAsync(ctx);
+        _context.ProofToken = CreateDPoPProofToken();
+        _context.DPoPClockSkew = TimeSpan.FromMinutes(1);
+
+        var result = await _subject.ValidateAsync(_context);
 
         result.IsError.Should().BeFalse();
     }
@@ -567,13 +556,13 @@ public class DPoPProofValidatorTests
     [Trait("Category", Category)]
     public async Task too_old_past_clock_skew_iat_should_fail_validation()
     {
-        _client.DPoPClockSkew = TimeSpan.FromMinutes(1);
+        _context.DPoPClockSkew = TimeSpan.FromMinutes(1);
 
         _payload["iat"] = _clock.UtcNow.Subtract(TimeSpan.FromSeconds(121)).ToUnixTimeSeconds();
 
-        var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
-        var result = await _subject.ValidateAsync(ctx);
+        _context.ProofToken = CreateDPoPProofToken();
+
+        var result = await _subject.ValidateAsync(_context);
 
         result.IsError.Should().BeTrue();
         result.Error.Should().Be("invalid_dpop_proof");
@@ -583,13 +572,13 @@ public class DPoPProofValidatorTests
     [Trait("Category", Category)]
     public async Task too_new_but_within_clock_skew_iat_should_succeed()
     {
-        _client.DPoPClockSkew = TimeSpan.FromMinutes(1);
+        _context.DPoPClockSkew = TimeSpan.FromMinutes(1);
 
         _payload["iat"] = _clock.UtcNow.Add(TimeSpan.FromSeconds(59)).ToUnixTimeSeconds();
 
-        var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
-        var result = await _subject.ValidateAsync(ctx);
+        _context.ProofToken = CreateDPoPProofToken();
+
+        var result = await _subject.ValidateAsync(_context);
 
         result.IsError.Should().BeFalse();
     }
@@ -598,13 +587,13 @@ public class DPoPProofValidatorTests
     [Trait("Category", Category)]
     public async Task too_new_past_clock_skew_iat_should_fail_validation()
     {
-        _client.DPoPClockSkew = TimeSpan.FromMinutes(1);
+        _context.DPoPClockSkew = TimeSpan.FromMinutes(1);
 
         _payload["iat"] = _clock.UtcNow.Add(TimeSpan.FromSeconds(61)).ToUnixTimeSeconds();
 
-        var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
-        var result = await _subject.ValidateAsync(ctx);
+        _context.ProofToken = CreateDPoPProofToken();
+
+        var result = await _subject.ValidateAsync(_context);
 
         result.IsError.Should().BeTrue();
         result.Error.Should().Be("invalid_dpop_proof");
@@ -617,9 +606,9 @@ public class DPoPProofValidatorTests
         _payload.Remove("iat");
         _payload["nonce"] = "nonce";
 
-        var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
-        var result = await _subject.ValidateAsync(ctx);
+        _context.ProofToken = CreateDPoPProofToken();
+
+        var result = await _subject.ValidateAsync(_context);
 
         result.IsError.Should().BeTrue();
         result.Error.Should().Be("invalid_dpop_proof");
@@ -630,11 +619,10 @@ public class DPoPProofValidatorTests
     [Trait("Category", Category)]
     public async Task missing_nonce_when_required_should_fail_validation_and_issue_nonce()
     {
-        _client.DPoPValidationMode = DPoPTokenExpirationValidationMode.Nonce;
+        _context.DPoPValidationMode = DPoPTokenExpirationValidationMode.Nonce;
+        _context.ProofToken = CreateDPoPProofToken();
 
-        var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
-        var result = await _subject.ValidateAsync(ctx);
+        var result = await _subject.ValidateAsync(_context);
 
         result.IsError.Should().BeTrue();
         result.Error.Should().Be("use_dpop_nonce");
@@ -645,19 +633,18 @@ public class DPoPProofValidatorTests
     [Trait("Category", Category)]
     public async Task nonce_provided_when_required_should_succeed()
     {
-        _client.DPoPValidationMode = DPoPTokenExpirationValidationMode.Nonce;
+        _context.DPoPValidationMode = DPoPTokenExpirationValidationMode.Nonce;
+        _context.ProofToken = CreateDPoPProofToken();
 
-        var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
-        var result = await _subject.ValidateAsync(ctx);
+        var result = await _subject.ValidateAsync(_context);
 
         result.IsError.Should().BeTrue();
         
         _payload["nonce"] = result.ServerIssuedNonce;
 
-        token = CreateDPoPProofToken();
-        ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
-        result = await _subject.ValidateAsync(ctx);
+        _context.ProofToken = CreateDPoPProofToken();
+        
+        result = await _subject.ValidateAsync(_context);
 
         result.IsError.Should().BeFalse();
         result.JsonWebKeyThumbprint.Should().Be(_JKT);
@@ -667,19 +654,18 @@ public class DPoPProofValidatorTests
     [Trait("Category", Category)]
     public async Task invalid_nonce_provided_when_required_should_fail_validation()
     {
-        _client.DPoPValidationMode = DPoPTokenExpirationValidationMode.Nonce;
+        _context.ProofToken = CreateDPoPProofToken();
+        _context.DPoPValidationMode = DPoPTokenExpirationValidationMode.Nonce;
 
-        var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
-        var result = await _subject.ValidateAsync(ctx);
+        var result = await _subject.ValidateAsync(_context);
 
         result.IsError.Should().BeTrue();
 
         _payload["nonce"] = result.ServerIssuedNonce + "invalid_stuff";
 
-        token = CreateDPoPProofToken();
-        ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
-        result = await _subject.ValidateAsync(ctx);
+        _context.ProofToken = CreateDPoPProofToken();
+
+        result = await _subject.ValidateAsync(_context);
 
         result.IsError.Should().BeTrue();
         result.Error.Should().Be("invalid_dpop_proof");
@@ -690,11 +676,10 @@ public class DPoPProofValidatorTests
     [Trait("Category", Category)]
     public async Task expired_nonce_provided_when_required_should_fail_validation()
     {
-        _client.DPoPValidationMode = DPoPTokenExpirationValidationMode.Nonce;
+        _context.DPoPValidationMode = DPoPTokenExpirationValidationMode.Nonce;
+        _context.ProofToken = CreateDPoPProofToken();
 
-        var token = CreateDPoPProofToken();
-        var ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
-        var result = await _subject.ValidateAsync(ctx);
+        var result = await _subject.ValidateAsync(_context);
 
         result.IsError.Should().BeTrue();
 
@@ -702,9 +687,9 @@ public class DPoPProofValidatorTests
         // too late
         _now = _now.AddSeconds(61);
 
-        token = CreateDPoPProofToken();
-        ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
-        result = await _subject.ValidateAsync(ctx);
+        _context.ProofToken = CreateDPoPProofToken();
+
+        result = await _subject.ValidateAsync(_context);
 
         result.IsError.Should().BeTrue();
         result.Error.Should().Be("invalid_dpop_proof");
@@ -715,9 +700,9 @@ public class DPoPProofValidatorTests
         // too early
         _now = _now.AddSeconds(-61);
 
-        token = CreateDPoPProofToken();
-        ctx = new DPoPProofValidatonContext { ProofToken = token, Client = _client, Url = "https://identityserver/connect/token", Method = "POST" };
-        result = await _subject.ValidateAsync(ctx);
+        _context.ProofToken = CreateDPoPProofToken();
+
+        result = await _subject.ValidateAsync(_context);
 
         result.IsError.Should().BeTrue();
         result.Error.Should().Be("invalid_dpop_proof");

--- a/test/IdentityServer.UnitTests/Validation/Setup/Factory.cs
+++ b/test/IdentityServer.UnitTests/Validation/Setup/Factory.cs
@@ -30,6 +30,7 @@ internal static class Factory
     public static TokenRequestValidator CreateTokenRequestValidator(
         IdentityServerOptions options = null,
         IIssuerNameService issuerNameService = null,
+        IServerUrls serverUrls = null,
         IResourceStore resourceStore = null,
         IAuthorizationCodeStore authorizationCodeStore = null,
         IRefreshTokenStore refreshTokenStore = null,
@@ -50,6 +51,14 @@ internal static class Factory
         if (issuerNameService == null)
         {
             issuerNameService = new TestIssuerNameService(options.IssuerUri);
+        }
+
+        if (serverUrls == null)
+        {
+            serverUrls = new MockServerUrls()
+            {
+                Origin = options.IssuerUri ?? "https://identityserver",
+            };
         }
 
         if (resourceStore == null)
@@ -117,6 +126,7 @@ internal static class Factory
         return new TokenRequestValidator(
             options,
             issuerNameService,
+            serverUrls,
             authorizationCodeStore,
             resourceOwnerValidator,
             profile,

--- a/test/IdentityServer.UnitTests/Validation/Setup/Factory.cs
+++ b/test/IdentityServer.UnitTests/Validation/Setup/Factory.cs
@@ -137,7 +137,7 @@ internal static class Factory
             resourceValidator,
             resourceStore,
             refreshTokenService,
-            new DefaultDPoPProofValidator(options, new MockServerUrls(), new MockReplayCache(), new StubClock(), new StubDataProtectionProvider(), new LoggerFactory().CreateLogger< DefaultDPoPProofValidator >()),
+            new DefaultDPoPProofValidator(options, new MockReplayCache(), new StubClock(), new StubDataProtectionProvider(), new LoggerFactory().CreateLogger< DefaultDPoPProofValidator >()),
             new TestEventService(),
             new StubClock(),
             TestLogger.Create<TokenRequestValidator>());


### PR DESCRIPTION
This PR attempts to preserve the existing handler and options and simply layers on the option to use DPoP.

Closes: https://github.com/DuendeSoftware/IdentityServer/issues/1261