### PR TITLE
Use new clock abstraction

### DIFF
--- a/hosts/AspNetIdentity/Pages/Grants/Index.cshtml.cs
+++ b/hosts/AspNetIdentity/Pages/Grants/Index.cshtml.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
-using System.ComponentModel.DataAnnotations;
 using Duende.IdentityServer.Events;
 using Duende.IdentityServer.Extensions;
 using Duende.IdentityServer.Services;

--- a/hosts/Configuration/Pages/Account/Create/Index.cshtml.cs
+++ b/hosts/Configuration/Pages/Account/Create/Index.cshtml.cs
@@ -2,10 +2,8 @@
 // See LICENSE in the project root for license information.
 
 using Duende.IdentityServer;
-using Duende.IdentityServer.Events;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services;
-using Duende.IdentityServer.Stores;
 using Duende.IdentityServer.Test;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;

--- a/hosts/Configuration/Pages/Grants/Index.cshtml.cs
+++ b/hosts/Configuration/Pages/Grants/Index.cshtml.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
-using System.ComponentModel.DataAnnotations;
 using Duende.IdentityServer.Events;
 using Duende.IdentityServer.Extensions;
 using Duende.IdentityServer.Services;

--- a/hosts/EntityFramework/Pages/Account/Create/Index.cshtml.cs
+++ b/hosts/EntityFramework/Pages/Account/Create/Index.cshtml.cs
@@ -2,10 +2,8 @@
 // See LICENSE in the project root for license information.
 
 using Duende.IdentityServer;
-using Duende.IdentityServer.Events;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services;
-using Duende.IdentityServer.Stores;
 using Duende.IdentityServer.Test;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;

--- a/hosts/EntityFramework/Pages/Grants/Index.cshtml.cs
+++ b/hosts/EntityFramework/Pages/Grants/Index.cshtml.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
-using System.ComponentModel.DataAnnotations;
 using Duende.IdentityServer.Events;
 using Duende.IdentityServer.Extensions;
 using Duende.IdentityServer.Services;

--- a/hosts/main/Pages/Account/Create/Index.cshtml.cs
+++ b/hosts/main/Pages/Account/Create/Index.cshtml.cs
@@ -2,10 +2,8 @@
 // See LICENSE in the project root for license information.
 
 using Duende.IdentityServer;
-using Duende.IdentityServer.Events;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services;
-using Duende.IdentityServer.Stores;
 using Duende.IdentityServer.Test;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;

--- a/hosts/main/Pages/Grants/Index.cshtml.cs
+++ b/hosts/main/Pages/Grants/Index.cshtml.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
-using System.ComponentModel.DataAnnotations;
 using Duende.IdentityServer.Events;
 using Duende.IdentityServer.Extensions;
 using Duende.IdentityServer.Services;

--- a/src/Configuration/Licensing/License.cs
+++ b/src/Configuration/Licensing/License.cs
@@ -3,7 +3,6 @@
 
 #nullable disable
 
-using System;
 using System.Security.Claims;
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/src/EntityFramework.Storage/Stores/ServerSideSessionStore.cs
+++ b/src/EntityFramework.Storage/Stores/ServerSideSessionStore.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Duende.IdentityServer.EntityFramework.Extensions;

--- a/src/EntityFramework/Services/CorsPolicyService.cs
+++ b/src/EntityFramework/Services/CorsPolicyService.cs
@@ -5,7 +5,6 @@
 using Duende.IdentityServer.EntityFramework.Interfaces;
 using Duende.IdentityServer.Services;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Linq;

--- a/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Additional.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Additional.cs
@@ -549,4 +549,16 @@ public static class IdentityServerBuilderExtensionsAdditional
 
         return builder;
     }
+
+    /// <summary>
+    /// Adds the legacy clock based on the pre-.NET8 ISystemClock.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    /// <returns></returns>
+    public static IIdentityServerBuilder AddLegacyClock(this IIdentityServerBuilder builder)
+    {
+        builder.Services.AddTransient<IClock, LegacyClock>();
+
+        return builder;
+    }
 }

--- a/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -23,7 +23,6 @@ using System.Linq;
 using Duende.IdentityServer.Models;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication;
-using static Duende.IdentityServer.Constants;
 using static Duende.IdentityServer.IdentityServerConstants;
 using Duende.IdentityServer.Extensions;
 using Duende.IdentityServer.Hosting.FederatedSignOut;
@@ -219,6 +218,7 @@ public static class IdentityServerBuilderExtensionsCore
         builder.Services.TryAddTransient<IScopeParser, DefaultScopeParser>();
         builder.Services.TryAddTransient<ISessionCoordinationService, DefaultSessionCoordinationService>();
         builder.Services.TryAddTransient<IReplayCache, DefaultReplayCache>();
+        builder.Services.TryAddTransient<IClock, DefaultClock>();
 
         builder.Services.TryAddTransient<IBackchannelAuthenticationThrottlingService, DistributedBackchannelAuthenticationThrottlingService>();
         builder.Services.TryAddTransient<IBackchannelAuthenticationUserNotificationService, NopBackchannelAuthenticationUserNotificationService>();

--- a/src/IdentityServer/Configuration/DependencyInjection/PostConfigureApplicationCookieTicketStore.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/PostConfigureApplicationCookieTicketStore.cs
@@ -2,7 +2,6 @@
 // See LICENSE in the project root for license information.
 
 using Duende.IdentityServer.Stores;
-using Duende.IdentityServer.Validation;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Http;

--- a/src/IdentityServer/Duende.IdentityServer.csproj
+++ b/src/IdentityServer/Duende.IdentityServer.csproj
@@ -11,15 +11,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect"/>
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Storage\Duende.IdentityServer.Storage.csproj"/>
+        <ProjectReference Include="..\Storage\Duende.IdentityServer.Storage.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/IdentityServer/Endpoints/Results/AuthorizeResult.cs
+++ b/src/IdentityServer/Endpoints/Results/AuthorizeResult.cs
@@ -8,7 +8,6 @@ using IdentityModel;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using System;
-using Microsoft.AspNetCore.Authentication;
 using System.Text.Encodings.Web;
 using Duende.IdentityServer.Configuration;
 using Duende.IdentityServer.Hosting;
@@ -34,7 +33,7 @@ internal class AuthorizeResult : IEndpointResult
         IUserSession userSession,
         IMessageStore<ErrorMessage> errorMessageStore,
         IServerUrls urls,
-        ISystemClock clock)
+        IClock clock)
         : this(response)
     {
         _options = options;
@@ -48,7 +47,7 @@ internal class AuthorizeResult : IEndpointResult
     private IUserSession _userSession;
     private IMessageStore<ErrorMessage> _errorMessageStore;
     private IServerUrls _urls;
-    private ISystemClock _clock;
+    private IClock _clock;
 
     private void Init(HttpContext context)
     {
@@ -56,7 +55,7 @@ internal class AuthorizeResult : IEndpointResult
         _userSession ??= context.RequestServices.GetRequiredService<IUserSession>();
         _errorMessageStore ??= context.RequestServices.GetRequiredService<IMessageStore<ErrorMessage>>();
         _urls = _urls ?? context.RequestServices.GetRequiredService<IServerUrls>();
-        _clock ??= context.RequestServices.GetRequiredService<ISystemClock>();
+        _clock ??= context.RequestServices.GetRequiredService<IClock>();
     }
 
     public async Task ExecuteAsync(HttpContext context)

--- a/src/IdentityServer/Endpoints/Results/EndSessionResult.cs
+++ b/src/IdentityServer/Endpoints/Results/EndSessionResult.cs
@@ -12,7 +12,6 @@ using Duende.IdentityServer.Hosting;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Stores;
 using Duende.IdentityServer.Validation;
-using Microsoft.AspNetCore.Authentication;
 using Duende.IdentityServer.Services;
 
 namespace Duende.IdentityServer.Endpoints.Results;
@@ -38,7 +37,7 @@ public class EndSessionResult : IEndpointResult
     internal EndSessionResult(
         EndSessionValidationResult result,
         IdentityServerOptions options,
-        ISystemClock clock,
+        IClock clock,
         IServerUrls urls,
         IMessageStore<LogoutMessage> logoutMessageStore)
         : this(result)
@@ -50,14 +49,14 @@ public class EndSessionResult : IEndpointResult
     }
 
     private IdentityServerOptions _options;
-    private ISystemClock _clock;
+    private IClock _clock;
     private IServerUrls _urls;
     private IMessageStore<LogoutMessage> _logoutMessageStore;
 
     private void Init(HttpContext context)
     {
         _options = _options ?? context.RequestServices.GetRequiredService<IdentityServerOptions>();
-        _clock = _clock ?? context.RequestServices.GetRequiredService<ISystemClock>();
+        _clock = _clock ?? context.RequestServices.GetRequiredService<IClock>();
         _urls = _urls ?? context.RequestServices.GetRequiredService<IServerUrls>();
         _logoutMessageStore = _logoutMessageStore ?? context.RequestServices.GetRequiredService<IMessageStore<LogoutMessage>>();
     }

--- a/src/IdentityServer/Extensions/HttpContextExtensions.cs
+++ b/src/IdentityServer/Extensions/HttpContextExtensions.cs
@@ -177,7 +177,7 @@ public static class HttpContextExtensions
 
         if (endSessionMsg != null)
         {
-            var clock = context.RequestServices.GetRequiredService<ISystemClock>();
+            var clock = context.RequestServices.GetRequiredService<IClock>();
             var msg = new Message<LogoutNotificationContext>(endSessionMsg, clock.UtcNow.UtcDateTime);
 
             var endSessionMessageStore = context.RequestServices.GetRequiredService<IMessageStore<LogoutNotificationContext>>();

--- a/src/IdentityServer/Extensions/KeyManagementExtensions.cs
+++ b/src/IdentityServer/Extensions/KeyManagementExtensions.cs
@@ -3,7 +3,6 @@
 
 
 using Duende.IdentityServer.Configuration;
-using Microsoft.AspNetCore.Authentication;
 using Microsoft.IdentityModel.Tokens;
 using System;
 
@@ -34,7 +33,7 @@ public static class KeyManagementExtensions
         return (age <= options.InitializationDuration);
     }
 
-    internal static TimeSpan GetAge(this ISystemClock clock, DateTime date)
+    internal static TimeSpan GetAge(this IClock clock, DateTime date)
     {
         var now = clock.UtcNow.UtcDateTime;
         if (date > now) now = date;

--- a/src/IdentityServer/Extensions/TokenExtensions.cs
+++ b/src/IdentityServer/Extensions/TokenExtensions.cs
@@ -4,7 +4,6 @@
 
 using IdentityModel;
 using Duende.IdentityServer.Models;
-using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
@@ -30,7 +29,7 @@ public static class TokenExtensions
     /// <param name="logger"></param>
     /// <returns></returns>
     public static Dictionary<string, object> CreateJwtPayloadDictionary(this Token token,
-        IdentityServerOptions options, ISystemClock clock, ILogger logger)
+        IdentityServerOptions options, IClock clock, ILogger logger)
     {
         try
         {

--- a/src/IdentityServer/Hosting/DynamicProviders/DynamicSchemes/DynamicAuthenticationSchemeProvider.cs
+++ b/src/IdentityServer/Hosting/DynamicProviders/DynamicSchemes/DynamicAuthenticationSchemeProvider.cs
@@ -4,7 +4,6 @@
 using Duende.IdentityServer.Configuration;
 using Duende.IdentityServer.Configuration.DependencyInjection;
 using Duende.IdentityServer.Stores;
-using Duende.IdentityServer.Validation;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/IdentityServer/Hosting/IdentityServerAuthenticationService.cs
+++ b/src/IdentityServer/Hosting/IdentityServerAuthenticationService.cs
@@ -27,14 +27,14 @@ internal class IdentityServerAuthenticationService : IAuthenticationService
 {
     private readonly IAuthenticationService _inner;
     private readonly IAuthenticationSchemeProvider _schemes;
-    private readonly ISystemClock _clock;
+    private readonly IClock _clock;
     private readonly IUserSession _session;
     private readonly ILogger<IdentityServerAuthenticationService> _logger;
 
     public IdentityServerAuthenticationService(
         Decorator<IAuthenticationService> decorator,
         IAuthenticationSchemeProvider schemes,
-        ISystemClock clock,
+        IClock clock,
         IUserSession session,
         ILogger<IdentityServerAuthenticationService> logger)
     {

--- a/src/IdentityServer/Hosting/IdentityServerMiddleware.cs
+++ b/src/IdentityServer/Hosting/IdentityServerMiddleware.cs
@@ -9,7 +9,6 @@ using System;
 using System.Threading.Tasks;
 using Duende.IdentityServer.Events;
 using Duende.IdentityServer.Services;
-using Duende.IdentityServer.Validation;
 using Duende.IdentityServer.Models;
 using System.Linq;
 using Duende.IdentityServer.Configuration;

--- a/src/IdentityServer/Hosting/LocalApiAuthentication/LocalApiAuthenticationHandler.cs
+++ b/src/IdentityServer/Hosting/LocalApiAuthentication/LocalApiAuthenticationHandler.cs
@@ -23,8 +23,8 @@ public class LocalApiAuthenticationHandler : AuthenticationHandler<LocalApiAuthe
     private readonly ILogger _logger;
 
     /// <inheritdoc />
-    public LocalApiAuthenticationHandler(IOptionsMonitor<LocalApiAuthenticationOptions> options, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock, ITokenValidator tokenValidator)
-        : base(options, logger, encoder, clock)
+    public LocalApiAuthenticationHandler(IOptionsMonitor<LocalApiAuthenticationOptions> options, ILoggerFactory logger, UrlEncoder encoder, ITokenValidator tokenValidator)
+        : base(options, logger, encoder)
     {
         _tokenValidator = tokenValidator;
         _logger = logger.CreateLogger<LocalApiAuthenticationHandler>();

--- a/src/IdentityServer/IdentityServerTools.cs
+++ b/src/IdentityServer/IdentityServerTools.cs
@@ -6,7 +6,6 @@
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services;
 using IdentityModel;
-using Microsoft.AspNetCore.Authentication;
 using System;
 using System.Collections.Generic;
 using System.Security.Claims;
@@ -22,7 +21,7 @@ public class IdentityServerTools
     internal readonly IServiceProvider ServiceProvider;
     internal readonly IIssuerNameService IssuerNameService;
     private readonly ITokenCreationService _tokenCreation;
-    private readonly ISystemClock _clock;
+    private readonly IClock _clock;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="IdentityServerTools" /> class.
@@ -31,7 +30,7 @@ public class IdentityServerTools
     /// <param name="issuerNameService">The issuer name service</param>
     /// <param name="tokenCreation">The token creation service.</param>
     /// <param name="clock">The clock.</param>
-    public IdentityServerTools(IServiceProvider serviceProvider, IIssuerNameService issuerNameService, ITokenCreationService tokenCreation, ISystemClock clock)
+    public IdentityServerTools(IServiceProvider serviceProvider, IIssuerNameService issuerNameService, ITokenCreationService tokenCreation, IClock clock)
     {
         ServiceProvider = serviceProvider;
         IssuerNameService = issuerNameService;

--- a/src/IdentityServer/Infrastructure/Clock/DefaultClock.cs
+++ b/src/IdentityServer/Infrastructure/Clock/DefaultClock.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+using System;
+
+namespace Duende.IdentityServer;
+
+class DefaultClock : IClock
+{
+    private readonly TimeProvider _timeProvider;
+
+    public DefaultClock()
+    {
+        _timeProvider = TimeProvider.System;
+    }
+
+    public DefaultClock(TimeProvider timeProvider)
+    {
+        _timeProvider = timeProvider;
+    }
+
+    public DateTimeOffset UtcNow { get => _timeProvider.GetUtcNow(); }
+}

--- a/src/IdentityServer/Infrastructure/Clock/IClock.cs
+++ b/src/IdentityServer/Infrastructure/Clock/IClock.cs
@@ -15,16 +15,26 @@ public interface IClock
     /// <summary>
     /// The current UTC date/time.
     /// </summary>
-    DateTimeOffset UtcNow 
-    { 
-        get
-        {
-            return DateTimeOffset.UtcNow;
-        }
-    } 
+    DateTimeOffset UtcNow { get; }
 }
 
-class DefaultClock : IClock { }
+class DefaultClock : IClock
+{
+    private readonly TimeProvider _timeProvider;
+
+    public DefaultClock()
+    {
+        _timeProvider = TimeProvider.System;
+    }
+
+    public DefaultClock(TimeProvider timeProvider)
+    {
+        _timeProvider = timeProvider;
+    }
+
+    public DateTimeOffset UtcNow { get => _timeProvider.GetUtcNow(); }
+}
+
 class LegacyClock : IClock
 {
 #pragma warning disable CS0618 // Type or member is obsolete

--- a/src/IdentityServer/Infrastructure/Clock/IClock.cs
+++ b/src/IdentityServer/Infrastructure/Clock/IClock.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+using Microsoft.AspNetCore.Authentication;
+using System;
+
+namespace Duende.IdentityServer;
+
+/// <summary>
+/// Abstraction for the date/time.
+/// </summary>
+public interface IClock
+{
+    /// <summary>
+    /// The current UTC date/time.
+    /// </summary>
+    DateTimeOffset UtcNow 
+    { 
+        get
+        {
+            return DateTimeOffset.UtcNow;
+        }
+    } 
+}
+
+class DefaultClock : IClock { }
+class LegacyClock : IClock
+{
+#pragma warning disable CS0618 // Type or member is obsolete
+    private readonly ISystemClock _clock;
+#pragma warning restore CS0618 // Type or member is obsolete
+
+#pragma warning disable CS0618 // Type or member is obsolete
+    public LegacyClock(ISystemClock clock)
+#pragma warning restore CS0618 // Type or member is obsolete
+    {
+        _clock = clock;
+    }
+
+    public DateTimeOffset UtcNow
+    {
+        get => _clock.UtcNow;
+    }
+}

--- a/src/IdentityServer/Infrastructure/Clock/IClock.cs
+++ b/src/IdentityServer/Infrastructure/Clock/IClock.cs
@@ -2,7 +2,6 @@
 // See LICENSE in the project root for license information.
 
 
-using Microsoft.AspNetCore.Authentication;
 using System;
 
 namespace Duende.IdentityServer;
@@ -16,40 +15,4 @@ public interface IClock
     /// The current UTC date/time.
     /// </summary>
     DateTimeOffset UtcNow { get; }
-}
-
-class DefaultClock : IClock
-{
-    private readonly TimeProvider _timeProvider;
-
-    public DefaultClock()
-    {
-        _timeProvider = TimeProvider.System;
-    }
-
-    public DefaultClock(TimeProvider timeProvider)
-    {
-        _timeProvider = timeProvider;
-    }
-
-    public DateTimeOffset UtcNow { get => _timeProvider.GetUtcNow(); }
-}
-
-class LegacyClock : IClock
-{
-#pragma warning disable CS0618 // Type or member is obsolete
-    private readonly ISystemClock _clock;
-#pragma warning restore CS0618 // Type or member is obsolete
-
-#pragma warning disable CS0618 // Type or member is obsolete
-    public LegacyClock(ISystemClock clock)
-#pragma warning restore CS0618 // Type or member is obsolete
-    {
-        _clock = clock;
-    }
-
-    public DateTimeOffset UtcNow
-    {
-        get => _clock.UtcNow;
-    }
 }

--- a/src/IdentityServer/Infrastructure/Clock/LegacyClock.cs
+++ b/src/IdentityServer/Infrastructure/Clock/LegacyClock.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+using Microsoft.AspNetCore.Authentication;
+using System;
+
+namespace Duende.IdentityServer;
+
+class LegacyClock : IClock
+{
+#pragma warning disable CS0618 // Type or member is obsolete
+    private readonly ISystemClock _clock;
+#pragma warning restore CS0618 // Type or member is obsolete
+
+#pragma warning disable CS0618 // Type or member is obsolete
+    public LegacyClock(ISystemClock clock)
+#pragma warning restore CS0618 // Type or member is obsolete
+    {
+        _clock = clock;
+    }
+
+    public DateTimeOffset UtcNow
+    {
+        get => _clock.UtcNow;
+    }
+}

--- a/src/IdentityServer/ResponseHandling/Default/AuthorizeInteractionResponseGenerator.cs
+++ b/src/IdentityServer/ResponseHandling/Default/AuthorizeInteractionResponseGenerator.cs
@@ -11,7 +11,6 @@ using System.Threading.Tasks;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services;
 using Duende.IdentityServer.Validation;
-using Microsoft.AspNetCore.Authentication;
 using Duende.IdentityServer.Configuration;
 
 namespace Duende.IdentityServer.ResponseHandling;
@@ -40,7 +39,7 @@ public class AuthorizeInteractionResponseGenerator : IAuthorizeInteractionRespon
     /// <summary>
     /// The clock
     /// </summary>
-    protected readonly ISystemClock Clock;
+    protected readonly IClock Clock;
         
     /// <summary>
     /// The options
@@ -57,7 +56,7 @@ public class AuthorizeInteractionResponseGenerator : IAuthorizeInteractionRespon
     /// <param name="profile">The profile.</param>
     public AuthorizeInteractionResponseGenerator(
         IdentityServerOptions options,
-        ISystemClock clock,
+        IClock clock,
         ILogger<AuthorizeInteractionResponseGenerator> logger,
         IConsentService consent, 
         IProfileService profile)

--- a/src/IdentityServer/ResponseHandling/Default/AuthorizeResponseGenerator.cs
+++ b/src/IdentityServer/ResponseHandling/Default/AuthorizeResponseGenerator.cs
@@ -13,7 +13,6 @@ using Duende.IdentityServer.Configuration;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services;
 using Duende.IdentityServer.Validation;
-using Microsoft.AspNetCore.Authentication;
 
 namespace Duende.IdentityServer.ResponseHandling;
 
@@ -51,7 +50,7 @@ public class AuthorizeResponseGenerator : IAuthorizeResponseGenerator
     /// <summary>
     /// The clock
     /// </summary>
-    protected readonly ISystemClock Clock;
+    protected readonly IClock Clock;
 
     /// <summary>
     /// The key material service
@@ -70,7 +69,7 @@ public class AuthorizeResponseGenerator : IAuthorizeResponseGenerator
     /// <param name="events">The events.</param>
     public AuthorizeResponseGenerator(
         IdentityServerOptions options,
-        ISystemClock clock,
+        IClock clock,
         ITokenService tokenService,
         IKeyMaterialService keyMaterialService,
         IAuthorizationCodeStore authorizationCodeStore,

--- a/src/IdentityServer/ResponseHandling/Default/BackchannelAuthenticationResponseGenerator.cs
+++ b/src/IdentityServer/ResponseHandling/Default/BackchannelAuthenticationResponseGenerator.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using Duende.IdentityServer.Configuration;
 using Duende.IdentityServer.Validation;
 using Duende.IdentityServer.Models;
-using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Logging;
 using Duende.IdentityServer.Stores;
 using Duende.IdentityServer.Services;
@@ -38,7 +37,7 @@ public class BackchannelAuthenticationResponseGenerator : IBackchannelAuthentica
     /// <summary>
     /// The clock
     /// </summary>
-    protected readonly ISystemClock Clock;
+    protected readonly IClock Clock;
 
     /// <summary>
     /// The logger
@@ -56,7 +55,7 @@ public class BackchannelAuthenticationResponseGenerator : IBackchannelAuthentica
     public BackchannelAuthenticationResponseGenerator(IdentityServerOptions options,
         IBackChannelAuthenticationRequestStore backChannelAuthenticationRequestStore,
         IBackchannelAuthenticationUserNotificationService userLoginService,
-        ISystemClock clock, 
+        IClock clock, 
         ILogger<BackchannelAuthenticationResponseGenerator> logger)
     {
         Options = options;

--- a/src/IdentityServer/ResponseHandling/Default/DeviceAuthorizationResponseGenerator.cs
+++ b/src/IdentityServer/ResponseHandling/Default/DeviceAuthorizationResponseGenerator.cs
@@ -9,7 +9,6 @@ using Duende.IdentityServer.Services;
 using Duende.IdentityServer.Validation;
 using Duende.IdentityServer.Extensions;
 using Duende.IdentityServer.Models;
-using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Logging;
 
 namespace Duende.IdentityServer.ResponseHandling;
@@ -38,7 +37,7 @@ public class DeviceAuthorizationResponseGenerator : IDeviceAuthorizationResponse
     /// <summary>
     /// The clock
     /// </summary>
-    protected readonly ISystemClock Clock;
+    protected readonly IClock Clock;
 
     /// <summary>
     /// The logger
@@ -53,7 +52,7 @@ public class DeviceAuthorizationResponseGenerator : IDeviceAuthorizationResponse
     /// <param name="deviceFlowCodeService">The device flow code service.</param>
     /// <param name="clock">The clock.</param>
     /// <param name="logger">The logger.</param>
-    public DeviceAuthorizationResponseGenerator(IdentityServerOptions options, IUserCodeService userCodeService, IDeviceFlowCodeService deviceFlowCodeService, ISystemClock clock, ILogger<DeviceAuthorizationResponseGenerator> logger)
+    public DeviceAuthorizationResponseGenerator(IdentityServerOptions options, IUserCodeService userCodeService, IDeviceFlowCodeService deviceFlowCodeService, IClock clock, ILogger<DeviceAuthorizationResponseGenerator> logger)
     {
         Options = options;
         UserCodeService = userCodeService;

--- a/src/IdentityServer/ResponseHandling/Default/TokenResponseGenerator.cs
+++ b/src/IdentityServer/ResponseHandling/Default/TokenResponseGenerator.cs
@@ -12,7 +12,6 @@ using System.Threading.Tasks;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services;
 using Duende.IdentityServer.Validation;
-using Microsoft.AspNetCore.Authentication;
 using System.Collections.Generic;
 
 namespace Duende.IdentityServer.ResponseHandling;
@@ -56,7 +55,7 @@ public class TokenResponseGenerator : ITokenResponseGenerator
     /// <summary>
     ///  The clock
     /// </summary>
-    protected readonly ISystemClock Clock;
+    protected readonly IClock Clock;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TokenResponseGenerator" /> class.
@@ -68,7 +67,7 @@ public class TokenResponseGenerator : ITokenResponseGenerator
     /// <param name="resources">The resources.</param>
     /// <param name="clients">The clients.</param>
     /// <param name="logger">The logger.</param>
-    public TokenResponseGenerator(ISystemClock clock, ITokenService tokenService, IRefreshTokenService refreshTokenService, IScopeParser scopeParser, IResourceStore resources, IClientStore clients, ILogger<TokenResponseGenerator> logger)
+    public TokenResponseGenerator(IClock clock, ITokenService tokenService, IRefreshTokenService refreshTokenService, IScopeParser scopeParser, IResourceStore resources, IClientStore clients, ILogger<TokenResponseGenerator> logger)
     {
         Clock = clock;
         TokenService = tokenService;

--- a/src/IdentityServer/Services/Default/DefaultBackChannelLogoutService.cs
+++ b/src/IdentityServer/Services/Default/DefaultBackChannelLogoutService.cs
@@ -9,7 +9,6 @@ using System.Security.Claims;
 using System.Threading.Tasks;
 using Duende.IdentityServer.Models;
 using IdentityModel;
-using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Logging;
 
 namespace Duende.IdentityServer.Services;
@@ -27,7 +26,7 @@ public class DefaultBackChannelLogoutService : IBackChannelLogoutService
     /// <summary>
     /// The system clock;
     /// </summary>
-    protected ISystemClock Clock { get; }
+    protected IClock Clock { get; }
         
     /// <summary>
     /// The IdentityServerTools used to create and the JWT.
@@ -58,7 +57,7 @@ public class DefaultBackChannelLogoutService : IBackChannelLogoutService
     /// <param name="backChannelLogoutHttpClient"></param>
     /// <param name="logger"></param>
     public DefaultBackChannelLogoutService(
-        ISystemClock clock,
+        IClock clock,
         IdentityServerTools tools,
         ILogoutNotificationService logoutNotificationService,
         IBackChannelLogoutHttpClient backChannelLogoutHttpClient,

--- a/src/IdentityServer/Services/Default/DefaultBackchannelAuthenticationInteractionService.cs
+++ b/src/IdentityServer/Services/Default/DefaultBackchannelAuthenticationInteractionService.cs
@@ -6,7 +6,6 @@ using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Stores;
 using Duende.IdentityServer.Validation;
 using IdentityModel;
-using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
@@ -25,7 +24,7 @@ public class DefaultBackchannelAuthenticationInteractionService : IBackchannelAu
     private readonly IClientStore _clientStore;
     private readonly IUserSession _session;
     private readonly IResourceValidator _resourceValidator;
-    private readonly ISystemClock _systemClock;
+    private readonly IClock _systemClock;
     private readonly ILogger<DefaultBackchannelAuthenticationInteractionService> _logger;
 
     /// <summary>
@@ -36,7 +35,7 @@ public class DefaultBackchannelAuthenticationInteractionService : IBackchannelAu
         IClientStore clients,
         IUserSession session,
         IResourceValidator resourceValidator,
-        ISystemClock systemClock,
+        IClock systemClock,
         ILogger<DefaultBackchannelAuthenticationInteractionService> logger
     )
     {

--- a/src/IdentityServer/Services/Default/DefaultConsentService.cs
+++ b/src/IdentityServer/Services/Default/DefaultConsentService.cs
@@ -11,7 +11,6 @@ using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Duende.IdentityServer.Validation;
-using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Logging;
 
 namespace Duende.IdentityServer.Services;
@@ -29,7 +28,7 @@ public class DefaultConsentService : IConsentService
     /// <summary>
     ///  The clock
     /// </summary>
-    protected readonly ISystemClock Clock;
+    protected readonly IClock Clock;
 
     /// <summary>
     /// The logger
@@ -43,7 +42,7 @@ public class DefaultConsentService : IConsentService
     /// <param name="userConsentStore">The user consent store.</param>
     /// <param name="logger">The logger.</param>
     /// <exception cref="System.ArgumentNullException">store</exception>
-    public DefaultConsentService(ISystemClock clock, IUserConsentStore userConsentStore, ILogger<DefaultConsentService> logger)
+    public DefaultConsentService(IClock clock, IUserConsentStore userConsentStore, ILogger<DefaultConsentService> logger)
     {
         Clock = clock;
         UserConsentStore = userConsentStore;

--- a/src/IdentityServer/Services/Default/DefaultEventService.cs
+++ b/src/IdentityServer/Services/Default/DefaultEventService.cs
@@ -112,7 +112,7 @@ public class DefaultEventService : IEventService
     protected virtual async Task PrepareEventAsync(Event evt)
     {
         evt.ActivityId = Context.HttpContext.TraceIdentifier;
-        evt.TimeStamp = DateTime.UtcNow;
+        evt.TimeStamp = Clock.UtcNow.DateTime;
         evt.ProcessId = Process.GetCurrentProcess().Id;
 
         if (Context.HttpContext?.Connection.LocalIpAddress != null)

--- a/src/IdentityServer/Services/Default/DefaultEventService.cs
+++ b/src/IdentityServer/Services/Default/DefaultEventService.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNetCore.Http;
 using System.Threading.Tasks;
 using Duende.IdentityServer.Configuration;
 using Duende.IdentityServer.Services;
-using Microsoft.AspNetCore.Authentication;
 
 namespace Duende.IdentityServer.Events;
 
@@ -36,7 +35,7 @@ public class DefaultEventService : IEventService
     /// <summary>
     /// The clock
     /// </summary>
-    protected readonly ISystemClock Clock;
+    protected readonly IClock Clock;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DefaultEventService"/> class.
@@ -45,7 +44,7 @@ public class DefaultEventService : IEventService
     /// <param name="context">The context.</param>
     /// <param name="sink">The sink.</param>
     /// <param name="clock">The clock.</param>
-    public DefaultEventService(IdentityServerOptions options, IHttpContextAccessor context, IEventSink sink, ISystemClock clock)
+    public DefaultEventService(IdentityServerOptions options, IHttpContextAccessor context, IEventSink sink, IClock clock)
     {
         Options = options;
         Context = context;

--- a/src/IdentityServer/Services/Default/DefaultIdentityServerInteractionService.cs
+++ b/src/IdentityServer/Services/Default/DefaultIdentityServerInteractionService.cs
@@ -11,13 +11,12 @@ using Microsoft.Extensions.Logging;
 using System.Linq;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Stores;
-using Microsoft.AspNetCore.Authentication;
 
 namespace Duende.IdentityServer.Services;
 
 internal class DefaultIdentityServerInteractionService : IIdentityServerInteractionService
 {
-    private readonly ISystemClock _clock;
+    private readonly IClock _clock;
     private readonly IHttpContextAccessor _context;
     private readonly IMessageStore<LogoutMessage> _logoutMessageStore;
     private readonly IMessageStore<ErrorMessage> _errorMessageStore;
@@ -28,7 +27,7 @@ internal class DefaultIdentityServerInteractionService : IIdentityServerInteract
     private readonly ReturnUrlParser _returnUrlParser;
 
     public DefaultIdentityServerInteractionService(
-        ISystemClock clock,
+        IClock clock,
         IHttpContextAccessor context,
         IMessageStore<LogoutMessage> logoutMessageStore,
         IMessageStore<ErrorMessage> errorMessageStore,

--- a/src/IdentityServer/Services/Default/DefaultRefreshTokenService.cs
+++ b/src/IdentityServer/Services/Default/DefaultRefreshTokenService.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Validation;
 using IdentityModel;
-using Microsoft.AspNetCore.Authentication;
 using Duende.IdentityServer.Stores.Serialization;
 
 namespace Duende.IdentityServer.Services;
@@ -37,7 +36,7 @@ public class DefaultRefreshTokenService : IRefreshTokenService
     /// <summary>
     /// The clock
     /// </summary>
-    protected ISystemClock Clock { get; }
+    protected IClock Clock { get; }
 
     /// <summary>
     /// The persistent grant options
@@ -55,7 +54,7 @@ public class DefaultRefreshTokenService : IRefreshTokenService
     public DefaultRefreshTokenService(
         IRefreshTokenStore refreshTokenStore, 
         IProfileService profile,
-        ISystemClock clock,
+        IClock clock,
         PersistentGrantOptions options,
         ILogger<DefaultRefreshTokenService> logger)
     {

--- a/src/IdentityServer/Services/Default/DefaultTokenCreationService.cs
+++ b/src/IdentityServer/Services/Default/DefaultTokenCreationService.cs
@@ -4,7 +4,6 @@
 
 using Duende.IdentityServer.Extensions;
 using Duende.IdentityServer.Models;
-using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
@@ -34,7 +33,7 @@ public class DefaultTokenCreationService : ITokenCreationService
     /// <summary>
     ///  The clock
     /// </summary>
-    protected readonly ISystemClock Clock;
+    protected readonly IClock Clock;
 
     /// <summary>
     /// The options
@@ -49,7 +48,7 @@ public class DefaultTokenCreationService : ITokenCreationService
     /// <param name="options">The options.</param>
     /// <param name="logger">The logger.</param>
     public DefaultTokenCreationService(
-        ISystemClock clock,
+        IClock clock,
         IKeyMaterialService keys,
         IdentityServerOptions options,
         ILogger<DefaultTokenCreationService> logger)

--- a/src/IdentityServer/Services/Default/DefaultTokenService.cs
+++ b/src/IdentityServer/Services/Default/DefaultTokenService.cs
@@ -5,7 +5,6 @@
 using IdentityModel;
 using Duende.IdentityServer.Extensions;
 using Duende.IdentityServer.Stores;
-using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using System;
@@ -52,7 +51,7 @@ public class DefaultTokenService : ITokenService
     /// <summary>
     /// The clock
     /// </summary>
-    protected readonly ISystemClock Clock;
+    protected readonly IClock Clock;
 
     /// <summary>
     /// The key material service
@@ -80,7 +79,7 @@ public class DefaultTokenService : ITokenService
         IReferenceTokenStore referenceTokenStore,
         ITokenCreationService creationService,
         IHttpContextAccessor contextAccessor,
-        ISystemClock clock,
+        IClock clock,
         IKeyMaterialService keyMaterialService,
         IdentityServerOptions options,
         ILogger<DefaultTokenService> logger)

--- a/src/IdentityServer/Services/Default/DefaultUserSession.cs
+++ b/src/IdentityServer/Services/Default/DefaultUserSession.cs
@@ -36,7 +36,7 @@ public class DefaultUserSession : IUserSession
     /// <summary>
     /// The clock
     /// </summary>
-    protected readonly ISystemClock Clock;
+    protected readonly IClock Clock;
 
     /// <summary>
     /// The server URL service.
@@ -103,7 +103,7 @@ public class DefaultUserSession : IUserSession
         IHttpContextAccessor httpContextAccessor,
         IAuthenticationHandlerProvider handlers,
         IdentityServerOptions options,
-        ISystemClock clock,
+        IClock clock,
         IServerUrls urls,
         ILogger<IUserSession> logger)
     {

--- a/src/IdentityServer/Services/Default/DistributedBackchannelAuthenticationThrottlingService.cs
+++ b/src/IdentityServer/Services/Default/DistributedBackchannelAuthenticationThrottlingService.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using Duende.IdentityServer.Configuration;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Stores;
-using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Caching.Distributed;
 
 namespace Duende.IdentityServer.Services;
@@ -19,7 +18,7 @@ public class DistributedBackchannelAuthenticationThrottlingService : IBackchanne
 {
     private readonly IDistributedCache _cache;
     private readonly IClientStore _clientStore;
-    private readonly ISystemClock _clock;
+    private readonly IClock _clock;
     private readonly IdentityServerOptions _options;
 
     private const string KeyPrefix = "backchannel_";
@@ -30,7 +29,7 @@ public class DistributedBackchannelAuthenticationThrottlingService : IBackchanne
     public DistributedBackchannelAuthenticationThrottlingService(
         IDistributedCache cache,
         IClientStore clientStore,
-        ISystemClock clock,
+        IClock clock,
         IdentityServerOptions options)
     {
         _cache = cache;

--- a/src/IdentityServer/Services/Default/DistributedDeviceFlowThrottlingService.cs
+++ b/src/IdentityServer/Services/Default/DistributedDeviceFlowThrottlingService.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using Duende.IdentityServer.Configuration;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Stores;
-using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Caching.Distributed;
 
 namespace Duende.IdentityServer.Services;
@@ -20,7 +19,7 @@ public class DistributedDeviceFlowThrottlingService : IDeviceFlowThrottlingServi
 {
     private readonly IDistributedCache _cache;
     private readonly IClientStore _clientStore;
-    private readonly ISystemClock _clock;
+    private readonly IClock _clock;
     private readonly IdentityServerOptions _options;
 
     private const string KeyPrefix = "devicecode_";
@@ -35,7 +34,7 @@ public class DistributedDeviceFlowThrottlingService : IDeviceFlowThrottlingServi
     public DistributedDeviceFlowThrottlingService(
         IDistributedCache cache,
         IClientStore clientStore,
-        ISystemClock clock,
+        IClock clock,
         IdentityServerOptions options)
     {
         _cache = cache;

--- a/src/IdentityServer/Services/Default/KeyManagement/InMemoryKeyStoreCache.cs
+++ b/src/IdentityServer/Services/Default/KeyManagement/InMemoryKeyStoreCache.cs
@@ -2,7 +2,6 @@
 // See LICENSE in the project root for license information.
 
 
-using Microsoft.AspNetCore.Authentication;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -14,7 +13,7 @@ namespace Duende.IdentityServer.Services.KeyManagement;
 /// </summary>
 class InMemoryKeyStoreCache : ISigningKeyStoreCache
 {
-    private readonly ISystemClock _clock;
+    private readonly IClock _clock;
 
     private object _lock = new object();
 
@@ -25,7 +24,7 @@ class InMemoryKeyStoreCache : ISigningKeyStoreCache
     /// Constructor for InMemoryKeyStoreCache.
     /// </summary>
     /// <param name="clock"></param>
-    public InMemoryKeyStoreCache(ISystemClock clock)
+    public InMemoryKeyStoreCache(IClock clock)
     {
         _clock = clock;
     }

--- a/src/IdentityServer/Services/Default/KeyManagement/KeyManager.cs
+++ b/src/IdentityServer/Services/Default/KeyManagement/KeyManager.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Duende.IdentityServer.Stores;
 using Duende.IdentityServer.Configuration;
-using Microsoft.AspNetCore.Authentication;
 using Duende.IdentityServer.Extensions;
 using Duende.IdentityServer.Internal;
 using System.Security.Cryptography;
@@ -25,7 +24,7 @@ public class KeyManager : IKeyManager
     private readonly ISigningKeyStore _store;
     private readonly ISigningKeyStoreCache _cache;
     private readonly ISigningKeyProtector _protector;
-    private readonly ISystemClock _clock;
+    private readonly IClock _clock;
     private readonly IConcurrencyLock<KeyManager> _newKeyLock;
     private readonly ILogger<KeyManager> _logger;
     private readonly IIssuerNameService _issuerNameService;
@@ -46,7 +45,7 @@ public class KeyManager : IKeyManager
         ISigningKeyStore store,
         ISigningKeyStoreCache cache,
         ISigningKeyProtector protector,
-        ISystemClock clock,
+        IClock clock,
         IConcurrencyLock<KeyManager> newKeyLock,
         ILogger<KeyManager> logger,
         IIssuerNameService issuerNameService)

--- a/src/IdentityServer/Test/TestUserResourceOwnerPasswordValidator.cs
+++ b/src/IdentityServer/Test/TestUserResourceOwnerPasswordValidator.cs
@@ -6,7 +6,6 @@ using IdentityModel;
 using System.Threading.Tasks;
 using System;
 using Duende.IdentityServer.Validation;
-using Microsoft.AspNetCore.Authentication;
 
 namespace Duende.IdentityServer.Test;
 
@@ -17,14 +16,14 @@ namespace Duende.IdentityServer.Test;
 public class TestUserResourceOwnerPasswordValidator : IResourceOwnerPasswordValidator
 {
     private readonly TestUserStore _users;
-    private readonly ISystemClock _clock;
+    private readonly IClock _clock;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TestUserResourceOwnerPasswordValidator"/> class.
     /// </summary>
     /// <param name="users">The users.</param>
     /// <param name="clock">The clock.</param>
-    public TestUserResourceOwnerPasswordValidator(TestUserStore users, ISystemClock clock)
+    public TestUserResourceOwnerPasswordValidator(TestUserStore users, IClock clock)
     {
         _users = users;
         _clock = clock;

--- a/src/IdentityServer/Validation/Contexts/TokenRequestValidationContext.cs
+++ b/src/IdentityServer/Validation/Contexts/TokenRequestValidationContext.cs
@@ -2,10 +2,7 @@
 // See LICENSE in the project root for license information.
 
 
-using Microsoft.AspNetCore.Http;
-using System;
 using System.Collections.Specialized;
-using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 
 namespace Duende.IdentityServer.Validation;

--- a/src/IdentityServer/Validation/Default/BackchannelAuthenticationRequestIdValidator.cs
+++ b/src/IdentityServer/Validation/Default/BackchannelAuthenticationRequestIdValidator.cs
@@ -7,7 +7,6 @@ using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services;
 using Duende.IdentityServer.Stores;
 using IdentityModel;
-using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Logging;
 using System.Linq;
 using System.Threading.Tasks;
@@ -22,14 +21,14 @@ internal class BackchannelAuthenticationRequestIdValidator : IBackchannelAuthent
     private readonly IBackChannelAuthenticationRequestStore _backchannelAuthenticationStore;
     private readonly IProfileService _profile;
     private readonly IBackchannelAuthenticationThrottlingService _throttlingService;
-    private readonly ISystemClock _systemClock;
+    private readonly IClock _systemClock;
     private readonly ILogger<BackchannelAuthenticationRequestIdValidator> _logger;
 
     public BackchannelAuthenticationRequestIdValidator(
         IBackChannelAuthenticationRequestStore backchannelAuthenticationStore,
         IProfileService profile,
         IBackchannelAuthenticationThrottlingService throttlingService,
-        ISystemClock systemClock,
+        IClock systemClock,
         ILogger<BackchannelAuthenticationRequestIdValidator> logger)
     {
         _backchannelAuthenticationStore = backchannelAuthenticationStore;

--- a/src/IdentityServer/Validation/Default/DefaultDPoPProofValidator.cs
+++ b/src/IdentityServer/Validation/Default/DefaultDPoPProofValidator.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Duende.IdentityServer.Configuration;
-using Microsoft.AspNetCore.Authentication;
 using Microsoft.IdentityModel.JsonWebTokens;
 using System;
 using Duende.IdentityServer.Extensions;
@@ -36,7 +35,7 @@ public class DefaultDPoPProofValidator : IDPoPProofValidator
     /// <summary>
     /// The clock
     /// </summary>
-    protected readonly ISystemClock Clock;
+    protected readonly IClock Clock;
 
     /// <summary>
     /// The replay cache
@@ -65,7 +64,7 @@ public class DefaultDPoPProofValidator : IDPoPProofValidator
         IdentityServerOptions options,
         IServerUrls server,
         IReplayCache replayCache,
-        ISystemClock clock,
+        IClock clock,
         IDataProtectionProvider dataProtectionProvider,
         ILogger<DefaultDPoPProofValidator> logger)
     {

--- a/src/IdentityServer/Validation/Default/DeviceCodeValidator.cs
+++ b/src/IdentityServer/Validation/Default/DeviceCodeValidator.cs
@@ -8,7 +8,6 @@ using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services;
 using IdentityModel;
 using Duende.IdentityServer.Extensions;
-using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Logging;
 
 namespace Duende.IdentityServer.Validation;
@@ -21,7 +20,7 @@ internal class DeviceCodeValidator : IDeviceCodeValidator
     private readonly IDeviceFlowCodeService _devices;
     private readonly IProfileService _profile;
     private readonly IDeviceFlowThrottlingService _throttlingService;
-    private readonly ISystemClock _systemClock;
+    private readonly IClock _systemClock;
     private readonly ILogger<DeviceCodeValidator> _logger;
 
     /// <summary>
@@ -36,7 +35,7 @@ internal class DeviceCodeValidator : IDeviceCodeValidator
         IDeviceFlowCodeService devices,
         IProfileService profile,
         IDeviceFlowThrottlingService throttlingService,
-        ISystemClock systemClock,
+        IClock systemClock,
         ILogger<DeviceCodeValidator> logger)
     {
         _devices = devices;

--- a/src/IdentityServer/Validation/Default/JwtBearerClientAssertionSecretParser.cs
+++ b/src/IdentityServer/Validation/Default/JwtBearerClientAssertionSecretParser.cs
@@ -2,7 +2,6 @@
 // See LICENSE in the project root for license information.
 
 
-using System;
 using System.Threading.Tasks;
 using System.Linq;
 using System.IdentityModel.Tokens.Jwt;

--- a/src/IdentityServer/Validation/Default/SecretValidator.cs
+++ b/src/IdentityServer/Validation/Default/SecretValidator.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Duende.IdentityServer.Models;
-using Microsoft.AspNetCore.Authentication;
 
 namespace Duende.IdentityServer.Validation;
 
@@ -19,7 +18,7 @@ public class SecretValidator : ISecretsListValidator
 {
     private readonly ILogger _logger;
     private readonly IEnumerable<ISecretValidator> _validators;
-    private readonly ISystemClock _clock;
+    private readonly IClock _clock;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SecretValidator"/> class.
@@ -27,7 +26,7 @@ public class SecretValidator : ISecretsListValidator
     /// <param name="clock">The clock.</param>
     /// <param name="validators">The validators.</param>
     /// <param name="logger">The logger.</param>
-    public SecretValidator(ISystemClock clock, IEnumerable<ISecretValidator> validators, ILogger<ISecretsListValidator> logger)
+    public SecretValidator(IClock clock, IEnumerable<ISecretValidator> validators, ILogger<ISecretsListValidator> logger)
     {
         _clock = clock;
         _validators = validators;

--- a/src/IdentityServer/Validation/Default/TokenRequestValidator.cs
+++ b/src/IdentityServer/Validation/Default/TokenRequestValidator.cs
@@ -17,7 +17,6 @@ using Duende.IdentityServer.Events;
 using Duende.IdentityServer.Logging.Models;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services;
-using Microsoft.AspNetCore.Authentication;
 
 namespace Duende.IdentityServer.Validation;
 
@@ -37,7 +36,7 @@ internal class TokenRequestValidator : ITokenRequestValidator
     private readonly IProfileService _profile;
     private readonly IDeviceCodeValidator _deviceCodeValidator;
     private readonly IBackchannelAuthenticationRequestIdValidator _backchannelAuthenticationRequestIdValidator;
-    private readonly ISystemClock _clock;
+    private readonly IClock _clock;
     private readonly ILogger _logger;
 
     private ValidatedTokenRequest _validatedRequest;
@@ -57,7 +56,7 @@ internal class TokenRequestValidator : ITokenRequestValidator
         IRefreshTokenService refreshTokenService,
         IDPoPProofValidator dPoPProofValidator,
         IEventService events,
-        ISystemClock clock,
+        IClock clock,
         ILogger<TokenRequestValidator> logger)
     {
         _logger = logger;

--- a/src/IdentityServer/Validation/Default/TokenValidator.cs
+++ b/src/IdentityServer/Validation/Default/TokenValidator.cs
@@ -17,7 +17,6 @@ using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services;
 using Microsoft.IdentityModel.Tokens;
 using Duende.IdentityServer.Stores;
-using Microsoft.AspNetCore.Authentication;
 using Microsoft.IdentityModel.JsonWebTokens;
 
 namespace Duende.IdentityServer.Validation;
@@ -33,7 +32,7 @@ internal class TokenValidator : ITokenValidator
     private readonly IProfileService _profile;
     private readonly IKeyMaterialService _keys;
     private readonly ISessionCoordinationService _sessionCoordinationService;
-    private readonly ISystemClock _clock;
+    private readonly IClock _clock;
     private readonly TokenValidationLog _log;
 
     public TokenValidator(
@@ -45,7 +44,7 @@ internal class TokenValidator : ITokenValidator
         ICustomTokenValidator customValidator,
         IKeyMaterialService keys,
         ISessionCoordinationService sessionCoordinationService,
-        ISystemClock clock,
+        IClock clock,
         ILogger<TokenValidator> logger)
     {
         _options = options;

--- a/test/Configuration.IntegrationTests/TestFramework/MockClock.cs
+++ b/test/Configuration.IntegrationTests/TestFramework/MockClock.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
-using Microsoft.AspNetCore.Authentication;
+using Duende.IdentityServer;
 
 namespace IntegrationTests.TestFramework;
 
-public class MockClock : ISystemClock
+public class MockClock : IClock
 {
     public DateTimeOffset UtcNow { get; set; }
 }

--- a/test/Configuration.IntegrationTests/TestHosts/ConfigurationHost.cs
+++ b/test/Configuration.IntegrationTests/TestHosts/ConfigurationHost.cs
@@ -4,7 +4,6 @@
 using IntegrationTests.TestFramework;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Duende.IdentityServer.Configuration;
 using Duende.IdentityServer.Configuration.EntityFramework;
 using Duende.IdentityServer.EntityFramework.DbContexts;

--- a/test/EntityFramework.Tests/Services/CorsPolicyServiceTests.cs
+++ b/test/EntityFramework.Tests/Services/CorsPolicyServiceTests.cs
@@ -3,14 +3,12 @@
 
 
 using Duende.IdentityServer.EntityFramework.DbContexts;
-using Duende.IdentityServer.EntityFramework.Interfaces;
 using Duende.IdentityServer.EntityFramework.Mappers;
 using Duende.IdentityServer.EntityFramework.Options;
 using Duende.IdentityServer.EntityFramework.Services;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/test/IdentityServer.IntegrationTests/Common/MockClock.cs
+++ b/test/IdentityServer.IntegrationTests/Common/MockClock.cs
@@ -3,11 +3,11 @@
 
 
 using System;
-using Microsoft.AspNetCore.Authentication;
+using Duende.IdentityServer;
 
 namespace IntegrationTests.Common;
 
-class MockClock : ISystemClock
+class MockClock : IClock
 {
     public DateTimeOffset UtcNow { get; set; } = DateTimeOffset.UtcNow;
 }

--- a/test/IdentityServer.IntegrationTests/Endpoints/Token/CibaTokenEndpointTests.cs
+++ b/test/IdentityServer.IntegrationTests/Endpoints/Token/CibaTokenEndpointTests.cs
@@ -18,7 +18,6 @@ using Duende.IdentityServer.Services;
 using Duende.IdentityServer.Validation;
 using System;
 using Duende.IdentityServer;
-using Microsoft.AspNetCore.Authentication;
 
 namespace IntegrationTests.Endpoints.Token;
 
@@ -493,7 +492,7 @@ public class CibaTokenEndpointTests
     public async Task expired_request_should_return_error()
     {
         var clock = new MockClock();
-        _mockPipeline.OnPostConfigureServices += s => s.AddSingleton<ISystemClock>(clock);
+        _mockPipeline.OnPostConfigureServices += s => s.AddSingleton<IClock>(clock);
         _mockPipeline.Initialize();
 
         // ciba request
@@ -562,7 +561,7 @@ public class CibaTokenEndpointTests
     public async Task too_frequent_request_should_return_error()
     {
         var clock = new MockClock();
-        _mockPipeline.OnPostConfigureServices += s => s.AddSingleton<ISystemClock>(clock);
+        _mockPipeline.OnPostConfigureServices += s => s.AddSingleton<IClock>(clock);
         _mockPipeline.Initialize();
 
         // ciba request
@@ -637,7 +636,7 @@ public class CibaTokenEndpointTests
     public async Task calls_past_interval_should_reset_throttling()
     {
         var clock = new MockClock();
-        _mockPipeline.OnPostConfigureServices += s => s.AddSingleton<ISystemClock>(clock);
+        _mockPipeline.OnPostConfigureServices += s => s.AddSingleton<IClock>(clock);
         _mockPipeline.Initialize();
 
         // ciba request
@@ -759,7 +758,7 @@ public class CibaTokenEndpointTests
         _cibaClient.PollingInterval = 10;
 
         var clock = new MockClock();
-        _mockPipeline.OnPostConfigureServices += s => s.AddSingleton<ISystemClock>(clock);
+        _mockPipeline.OnPostConfigureServices += s => s.AddSingleton<IClock>(clock);
         _mockPipeline.Initialize();
 
         // ciba request
@@ -905,7 +904,7 @@ public class CibaTokenEndpointTests
         _cibaClient.CibaLifetime = 100;
 
         var clock = new MockClock();
-        _mockPipeline.OnPostConfigureServices += s => s.AddSingleton<ISystemClock>(clock);
+        _mockPipeline.OnPostConfigureServices += s => s.AddSingleton<IClock>(clock);
         _mockPipeline.Initialize();
 
         // ciba request

--- a/test/IdentityServer.IntegrationTests/Endpoints/Token/DPoPTokenEndpointTests.cs
+++ b/test/IdentityServer.IntegrationTests/Endpoints/Token/DPoPTokenEndpointTests.cs
@@ -27,7 +27,7 @@ using Microsoft.Extensions.Logging;
 using Duende.IdentityServer.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 using System.Text;
-using IdentityModel.Jwk;
+using Duende.IdentityServer;
 
 namespace IntegrationTests.Endpoints.Token;
 
@@ -1001,7 +1001,7 @@ public class DPoPTokenEndpointTests
 
     public class MockDPoPProofValidator : DefaultDPoPProofValidator
     {
-        public MockDPoPProofValidator(IdentityServerOptions options, IServerUrls server, IReplayCache replayCache, ISystemClock clock, Microsoft.AspNetCore.DataProtection.IDataProtectionProvider dataProtectionProvider, ILogger<DefaultDPoPProofValidator> logger) : base(options, server, replayCache, clock, dataProtectionProvider, logger)
+        public MockDPoPProofValidator(IdentityServerOptions options, IServerUrls server, IReplayCache replayCache, IClock clock, Microsoft.AspNetCore.DataProtection.IDataProtectionProvider dataProtectionProvider, ILogger<DefaultDPoPProofValidator> logger) : base(options, server, replayCache, clock, dataProtectionProvider, logger)
         {
         }
 

--- a/test/IdentityServer.IntegrationTests/Extensibility/CustomClaimsServiceTests.cs
+++ b/test/IdentityServer.IntegrationTests/Extensibility/CustomClaimsServiceTests.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using System.Security.Claims;
 using System.Text;
 using System.Text.Json;

--- a/test/IdentityServer.IntegrationTests/Extensibility/CustomTokenCreationServiceTests.cs
+++ b/test/IdentityServer.IntegrationTests/Extensibility/CustomTokenCreationServiceTests.cs
@@ -3,21 +3,17 @@
 
 
 using System.Collections.Generic;
-using System.Linq;
-using System.Net;
-using System.Security.Claims;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Duende.IdentityServer;
 using Duende.IdentityServer.Configuration;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services;
-using Duende.IdentityServer.Validation;
 using FluentAssertions;
 using IdentityModel;
 using IdentityModel.Client;
 using IntegrationTests.Common;
-using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Xunit;
@@ -80,7 +76,7 @@ public class CustomTokenCreationServiceTests
 
 public class CustomTokenCreationService : DefaultTokenCreationService
 {
-    public CustomTokenCreationService(ISystemClock clock, IKeyMaterialService keys, IdentityServerOptions options, ILogger<DefaultTokenCreationService> logger) : base(clock, keys, options, logger)
+    public CustomTokenCreationService(IClock clock, IKeyMaterialService keys, IdentityServerOptions options, ILogger<DefaultTokenCreationService> logger) : base(clock, keys, options, logger)
     {
     }
 

--- a/test/IdentityServer.IntegrationTests/Hosting/ServerSideSessionTests.cs
+++ b/test/IdentityServer.IntegrationTests/Hosting/ServerSideSessionTests.cs
@@ -18,8 +18,6 @@ using System.Collections.Generic;
 using System;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.AspNetCore.Authentication.Cookies;
-using Microsoft.AspNetCore.Session;
-using FluentAssertions.Common;
 using Duende.IdentityServer;
 using Microsoft.AspNetCore.DataProtection;
 using Duende.IdentityServer.Extensions;

--- a/test/IdentityServer.IntegrationTests/TestFramework/MockExternalAuthenticationHandler.cs
+++ b/test/IdentityServer.IntegrationTests/TestFramework/MockExternalAuthenticationHandler.cs
@@ -16,9 +16,8 @@ namespace Duende.IdentityServer.IntegrationTests.TestFramework
         public MockExternalAuthenticationHandler(
             IOptionsMonitor<MockExternalAuthenticationOptions> options, 
             ILoggerFactory logger, 
-            UrlEncoder encoder, 
-            ISystemClock clock) 
-            : base(options, logger, encoder, clock)
+            UrlEncoder encoder) 
+            : base(options, logger, encoder)
         {
         }
 

--- a/test/IdentityServer.UnitTests/Caches/MockCache.cs
+++ b/test/IdentityServer.UnitTests/Caches/MockCache.cs
@@ -1,5 +1,5 @@
+using Duende.IdentityServer;
 using Duende.IdentityServer.Services;
-using Microsoft.AspNetCore.Authentication;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -9,7 +9,7 @@ namespace IdentityServer.UnitTests.Caches;
 public class MockCache<T> : ICache<T>
     where T : class
 {
-    public MockCache(ISystemClock clock)
+    public MockCache(IClock clock)
     {
         _clock = clock;
     }
@@ -22,7 +22,7 @@ public class MockCache<T> : ICache<T>
 
     public Dictionary<string, CacheItem> CacheItems = new Dictionary<string, CacheItem>();
 
-    private readonly ISystemClock _clock;
+    private readonly IClock _clock;
 
     bool TryGetValue(string key, out T item)
     {

--- a/test/IdentityServer.UnitTests/Caches/ResourceStoreCacheTests.cs
+++ b/test/IdentityServer.UnitTests/Caches/ResourceStoreCacheTests.cs
@@ -1,8 +1,8 @@
+using Duende.IdentityServer;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services;
 using Duende.IdentityServer.Stores;
 using FluentAssertions;
-using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
@@ -46,7 +46,7 @@ namespace IdentityServer.UnitTests.Caches
 
             services.AddSingleton(typeof(MockCache<>));
             services.AddSingleton(typeof(ICache<>), typeof(MockCache<>));
-            services.AddSingleton<ISystemClock>(_mockClock);
+            services.AddSingleton<IClock>(_mockClock);
             
             _provider = services.BuildServiceProvider();
         }

--- a/test/IdentityServer.UnitTests/Common/MockHttpContextAccessor.cs
+++ b/test/IdentityServer.UnitTests/Common/MockHttpContextAccessor.cs
@@ -2,6 +2,7 @@
 // See LICENSE in the project root for license information.
 
 
+using Duende.IdentityServer;
 using Duende.IdentityServer.Configuration;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services;
@@ -32,6 +33,7 @@ internal class MockHttpContextAccessor : IHttpContextAccessor
 
         services.AddSingleton<IAuthenticationSchemeProvider>(Schemes);
         services.AddSingleton<IAuthenticationService>(AuthenticationService);
+        services.AddTransient<IClock, DefaultClock>();
 
         services.AddAuthentication(auth =>
         {

--- a/test/IdentityServer.UnitTests/Common/MockSystemClock.cs
+++ b/test/IdentityServer.UnitTests/Common/MockSystemClock.cs
@@ -2,12 +2,12 @@
 // See LICENSE in the project root for license information.
 
 
-using Microsoft.AspNetCore.Authentication;
+using Duende.IdentityServer;
 using System;
 
 namespace UnitTests.Common;
 
-class MockSystemClock : ISystemClock
+class MockSystemClock : IClock
 {
     public DateTimeOffset Now { get; set; }
 

--- a/test/IdentityServer.UnitTests/Common/StubClock.cs
+++ b/test/IdentityServer.UnitTests/Common/StubClock.cs
@@ -2,12 +2,12 @@
 // See LICENSE in the project root for license information.
 
 
+using Duende.IdentityServer;
 using System;
-using Microsoft.AspNetCore.Authentication;
 
 namespace UnitTests.Common;
 
-internal class StubClock : ISystemClock
+internal class StubClock : IClock
 {
     public Func<DateTime> UtcNowFunc { get; set; } = () => DateTime.UtcNow;
     public DateTimeOffset UtcNow => new DateTimeOffset(UtcNowFunc());

--- a/test/IdentityServer.UnitTests/Common/TestReplayCache.cs
+++ b/test/IdentityServer.UnitTests/Common/TestReplayCache.cs
@@ -3,8 +3,8 @@
 
 
 
+using Duende.IdentityServer;
 using Duende.IdentityServer.Services;
-using Microsoft.AspNetCore.Authentication;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -13,10 +13,10 @@ namespace UnitTests.Common;
 
 public class TestReplayCache : IReplayCache
 {
-    private readonly ISystemClock _clock;
+    private readonly IClock _clock;
     Dictionary<string, DateTimeOffset> _values = new Dictionary<string, DateTimeOffset>();
 
-    public TestReplayCache(ISystemClock clock)
+    public TestReplayCache(IClock clock)
     {
         _clock = clock;
     }

--- a/test/IdentityServer.UnitTests/Extensions/TokenExtensionsTests.cs
+++ b/test/IdentityServer.UnitTests/Extensions/TokenExtensionsTests.cs
@@ -2,6 +2,7 @@
 // See LICENSE in the project root for license information.
 
 
+using Duende.IdentityServer;
 using Duende.IdentityServer.Configuration;
 using Duende.IdentityServer.Extensions;
 using Duende.IdentityServer.Models;
@@ -36,7 +37,7 @@ public class TokenExtensionsTests
             Claims = new List<Claim> { new Claim(type, value, valueType) },
         };
 
-        var payloadDict = token.CreateJwtPayloadDictionary(new IdentityServerOptions(), new SystemClock(), 
+        var payloadDict = token.CreateJwtPayloadDictionary(new IdentityServerOptions(), new DefaultClock(), 
             TestLogger.Create<TokenExtensionsTests>());
 
         var payloadJson = JsonSerializer.Serialize(payloadDict);

--- a/test/IdentityServer.UnitTests/ResponseHandling/AuthorizeInteractionResponseGenerator/AuthorizeInteractionResponseGeneratorTests_Custom.cs
+++ b/test/IdentityServer.UnitTests/ResponseHandling/AuthorizeInteractionResponseGenerator/AuthorizeInteractionResponseGeneratorTests_Custom.cs
@@ -11,7 +11,6 @@ using Duende.IdentityServer.Services;
 using Duende.IdentityServer.Validation;
 using FluentAssertions;
 using UnitTests.Common;
-using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Logging;
 using Xunit;
 using static IdentityModel.OidcConstants;
@@ -22,7 +21,7 @@ public class CustomAuthorizeInteractionResponseGenerator : Duende.IdentityServer
 {
     public CustomAuthorizeInteractionResponseGenerator(
         IdentityServerOptions options,
-        ISystemClock clock, 
+        IClock clock, 
         ILogger<Duende.IdentityServer.ResponseHandling.AuthorizeInteractionResponseGenerator> logger, 
         IConsentService consent, 
         IProfileService profile) : base(options, clock, logger, consent, profile)

--- a/test/IdentityServer.UnitTests/Services/Default/DefaultRefreshTokenServiceTests.cs
+++ b/test/IdentityServer.UnitTests/Services/Default/DefaultRefreshTokenServiceTests.cs
@@ -14,7 +14,6 @@ using Duende.IdentityServer.Stores.Serialization;
 using FluentAssertions;
 using UnitTests.Validation.Setup;
 using Xunit;
-using Duende.IdentityServer.Configuration;
 
 namespace UnitTests.Services.Default;
 

--- a/test/IdentityServer.UnitTests/Services/Default/KeyManagement/MockClock.cs
+++ b/test/IdentityServer.UnitTests/Services/Default/KeyManagement/MockClock.cs
@@ -1,10 +1,9 @@
-
-using Microsoft.AspNetCore.Authentication;
+using Duende.IdentityServer;
 using System;
 
 namespace UnitTests.Services.Default.KeyManagement;
 
-class MockClock : ISystemClock
+class MockClock : IClock
 {
     public MockClock()
     {

--- a/test/IdentityServer.UnitTests/Storage/PersistedGrantFilterTests.cs
+++ b/test/IdentityServer.UnitTests/Storage/PersistedGrantFilterTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Threading.Tasks;
 using Duende.IdentityServer;
 using Duende.IdentityServer.Extensions;
 using Duende.IdentityServer.Stores;

--- a/test/IdentityServer.UnitTests/Validation/Secrets/BasicAuthenticationCredentialParsing.cs
+++ b/test/IdentityServer.UnitTests/Validation/Secrets/BasicAuthenticationCredentialParsing.cs
@@ -13,7 +13,6 @@ using UnitTests.Common;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 using Xunit;
-using System.Text.Encodings.Web;
 
 namespace UnitTests.Validation.Secrets;
 

--- a/test/IdentityServer.UnitTests/Validation/Setup/Factory.cs
+++ b/test/IdentityServer.UnitTests/Validation/Setup/Factory.cs
@@ -14,9 +14,9 @@ using Duende.IdentityServer.Stores;
 using Duende.IdentityServer.Stores.Serialization;
 using Duende.IdentityServer.Validation;
 using UnitTests.Common;
-using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Logging;
 using Duende.IdentityServer.Services.KeyManagement;
+using Duende.IdentityServer;
 
 namespace UnitTests.Validation.Setup;
 
@@ -278,7 +278,7 @@ internal static class Factory
         IProfileService profile = null,
         IIssuerNameService issuerNameService = null,
         IdentityServerOptions options = null, 
-        ISystemClock clock = null)
+        IClock clock = null)
     {
         options ??= TestIdentityServerOptions.Create();
         profile ??= new TestProfileService();
@@ -320,7 +320,7 @@ internal static class Factory
         IDeviceFlowCodeService service,
         IProfileService profile = null,
         IDeviceFlowThrottlingService throttlingService = null,
-        ISystemClock clock = null)
+        IClock clock = null)
     {
         profile = profile ?? new TestProfileService();
         throttlingService = throttlingService ?? new TestDeviceFlowThrottlingService();


### PR DESCRIPTION
Given that the old ISystemClock has only second-level granularity, and that it is deprecated, this PR introduces a new clock abstraction. The default implementation is based on the new TimeProvider in .NET 8, but a legacy implementation is provided for those who still want the older ISystemClock behavior.

Closes: https://github.com/DuendeSoftware/IdentityServer/issues/949