### PR TITLE
Support response generators for the endpoint results

### DIFF
--- a/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -115,15 +115,16 @@ public static class IdentityServerBuilderExtensionsCore
         builder.AddEndpoint<CheckSessionEndpoint>(EndpointNames.CheckSession, ProtocolRoutePaths.CheckSession.EnsureLeadingSlash());
         builder.AddEndpoint<DeviceAuthorizationEndpoint>(EndpointNames.DeviceAuthorization, ProtocolRoutePaths.DeviceAuthorization.EnsureLeadingSlash());
         builder.AddEndpoint<DiscoveryKeyEndpoint>(EndpointNames.Jwks, ProtocolRoutePaths.DiscoveryWebKeys.EnsureLeadingSlash());
-        
-        builder.AddEndpoint<DiscoveryEndpoint, DiscoveryDocumentResult, DiscoveryDocumentResultGenerator>(EndpointNames.Discovery, ProtocolRoutePaths.DiscoveryConfiguration.EnsureLeadingSlash());
-        
+        builder.AddEndpoint<DiscoveryEndpoint>(EndpointNames.Discovery, ProtocolRoutePaths.DiscoveryConfiguration.EnsureLeadingSlash());
         builder.AddEndpoint<EndSessionCallbackEndpoint>(EndpointNames.EndSession, ProtocolRoutePaths.EndSessionCallback.EnsureLeadingSlash());
         builder.AddEndpoint<EndSessionEndpoint>(EndpointNames.EndSession, ProtocolRoutePaths.EndSession.EnsureLeadingSlash());
         builder.AddEndpoint<IntrospectionEndpoint>(EndpointNames.Introspection, ProtocolRoutePaths.Introspection.EnsureLeadingSlash());
         builder.AddEndpoint<TokenRevocationEndpoint>(EndpointNames.Revocation, ProtocolRoutePaths.Revocation.EnsureLeadingSlash());
         builder.AddEndpoint<TokenEndpoint>(EndpointNames.Token, ProtocolRoutePaths.Token.EnsureLeadingSlash());
         builder.AddEndpoint<UserInfoEndpoint>(EndpointNames.UserInfo, ProtocolRoutePaths.UserInfo.EnsureLeadingSlash());
+
+        builder.AddEndpointResultGenerator<DiscoveryDocumentResult, DiscoveryDocumentResultGenerator>();
+        builder.AddEndpointResultGenerator<AuthorizeResult, AuthorizeResultGenerator>();
 
         return builder;
     }
@@ -148,16 +149,11 @@ public static class IdentityServerBuilderExtensionsCore
     /// <summary>
     /// Adds the endpoint.
     /// </summary>
-    public static IIdentityServerBuilder AddEndpoint<TEndpoint, TResult, TResultGenerator>(this IIdentityServerBuilder builder, string name, PathString path)
-        where TEndpoint : class, IEndpointHandler
+    public static IIdentityServerBuilder AddEndpointResultGenerator<TResult, TResultGenerator>(this IIdentityServerBuilder builder)
         where TResult : class, IEndpointResult
         where TResultGenerator : class, IEndpointResultGenerator<TResult>
     {
-        builder.Services.AddTransient<TEndpoint>();
         builder.Services.AddTransient<IEndpointResultGenerator<TResult>, TResultGenerator>();
-
-        builder.Services.AddSingleton(new Duende.IdentityServer.Hosting.Endpoint(name, path, typeof(TEndpoint)));
-
         return builder;
     }
 

--- a/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -123,10 +123,23 @@ public static class IdentityServerBuilderExtensionsCore
         builder.AddEndpoint<TokenEndpoint>(EndpointNames.Token, ProtocolRoutePaths.Token.EnsureLeadingSlash());
         builder.AddEndpoint<UserInfoEndpoint>(EndpointNames.UserInfo, ProtocolRoutePaths.UserInfo.EnsureLeadingSlash());
 
-        builder.AddEndpointResultGenerator<DiscoveryDocumentResult, DiscoveryDocumentResultGenerator>();
-        builder.AddEndpointResultGenerator<AuthorizeResult, AuthorizeResultGenerator>();
         builder.AddEndpointResultGenerator<AuthorizeInteractionPageResult, AuthorizeInteractionPageResultGenerator>();
+        builder.AddEndpointResultGenerator<AuthorizeResult, AuthorizeResultGenerator>();
         builder.AddEndpointResultGenerator<BackchannelAuthenticationResult, BackchannelAuthenticationResultGenerator>();
+        builder.AddEndpointResultGenerator<BadRequestResult, BadRequestResultGenerator>();
+        builder.AddEndpointResultGenerator<CheckSessionResult, CheckSessionResultGenerator>();
+        builder.AddEndpointResultGenerator<DeviceAuthorizationResult, DeviceAuthorizationResultGenerator>();
+        builder.AddEndpointResultGenerator<DiscoveryDocumentResult, DiscoveryDocumentResultGenerator>();
+        builder.AddEndpointResultGenerator<EndSessionCallbackResult, EndSessionCallbackResultGenerator>();
+        builder.AddEndpointResultGenerator<EndSessionResult, EndSessionResultGenerator>();
+        builder.AddEndpointResultGenerator<IntrospectionResult, IntrospectionResultGenerator>();
+        builder.AddEndpointResultGenerator<JsonWebKeysResult, JsonWebKeysResultGenerator>();
+        builder.AddEndpointResultGenerator<ProtectedResourceErrorResult, ProtectedResourceErrorResultGenerator>();
+        builder.AddEndpointResultGenerator<StatusCodeResult, StatusCodeResultGenerator>();
+        builder.AddEndpointResultGenerator<TokenErrorResult, TokenErrorResultGenerator>();
+        builder.AddEndpointResultGenerator<TokenResult, TokenResultGenerator>();
+        builder.AddEndpointResultGenerator<TokenRevocationErrorResult, TokenRevocationErrorResultGenerator>();
+        builder.AddEndpointResultGenerator<UserInfoResult, UserInfoResultGenerator>();
 
         return builder;
     }

--- a/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -125,6 +125,7 @@ public static class IdentityServerBuilderExtensionsCore
 
         builder.AddEndpointResultGenerator<DiscoveryDocumentResult, DiscoveryDocumentResultGenerator>();
         builder.AddEndpointResultGenerator<AuthorizeResult, AuthorizeResultGenerator>();
+        builder.AddEndpointResultGenerator<AuthorizeInteractionPageResult, AuthorizeInteractionPageResultGenerator>();
 
         return builder;
     }
@@ -151,9 +152,9 @@ public static class IdentityServerBuilderExtensionsCore
     /// </summary>
     public static IIdentityServerBuilder AddEndpointResultGenerator<TResult, TResultGenerator>(this IIdentityServerBuilder builder)
         where TResult : class, IEndpointResult
-        where TResultGenerator : class, IEndpointResultGenerator<TResult>
+        where TResultGenerator : class, Duende.IdentityServer.Hosting.IEndpointResultGenerator<TResult>
     {
-        builder.Services.AddTransient<IEndpointResultGenerator<TResult>, TResultGenerator>();
+        builder.Services.AddTransient<Duende.IdentityServer.Hosting.IEndpointResultGenerator<TResult>, TResultGenerator>();
         return builder;
     }
 

--- a/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -126,6 +126,7 @@ public static class IdentityServerBuilderExtensionsCore
         builder.AddEndpointResultGenerator<DiscoveryDocumentResult, DiscoveryDocumentResultGenerator>();
         builder.AddEndpointResultGenerator<AuthorizeResult, AuthorizeResultGenerator>();
         builder.AddEndpointResultGenerator<AuthorizeInteractionPageResult, AuthorizeInteractionPageResultGenerator>();
+        builder.AddEndpointResultGenerator<BackchannelAuthenticationResult, BackchannelAuthenticationResultGenerator>();
 
         return builder;
     }

--- a/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -32,7 +32,7 @@ using Microsoft.Extensions.Logging;
 using Duende.IdentityServer.Hosting.DynamicProviders;
 using Duende.IdentityServer.Internal;
 using Duende.IdentityServer.Stores.Empty;
-using Duende;
+using Duende.IdentityServer.Endpoints.Results;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -115,7 +115,9 @@ public static class IdentityServerBuilderExtensionsCore
         builder.AddEndpoint<CheckSessionEndpoint>(EndpointNames.CheckSession, ProtocolRoutePaths.CheckSession.EnsureLeadingSlash());
         builder.AddEndpoint<DeviceAuthorizationEndpoint>(EndpointNames.DeviceAuthorization, ProtocolRoutePaths.DeviceAuthorization.EnsureLeadingSlash());
         builder.AddEndpoint<DiscoveryKeyEndpoint>(EndpointNames.Jwks, ProtocolRoutePaths.DiscoveryWebKeys.EnsureLeadingSlash());
-        builder.AddEndpoint<DiscoveryEndpoint>(EndpointNames.Discovery, ProtocolRoutePaths.DiscoveryConfiguration.EnsureLeadingSlash());
+        
+        builder.AddEndpoint<DiscoveryEndpoint, DiscoveryDocumentResult, DiscoveryDocumentResultGenerator>(EndpointNames.Discovery, ProtocolRoutePaths.DiscoveryConfiguration.EnsureLeadingSlash());
+        
         builder.AddEndpoint<EndSessionCallbackEndpoint>(EndpointNames.EndSession, ProtocolRoutePaths.EndSessionCallback.EnsureLeadingSlash());
         builder.AddEndpoint<EndSessionEndpoint>(EndpointNames.EndSession, ProtocolRoutePaths.EndSession.EnsureLeadingSlash());
         builder.AddEndpoint<IntrospectionEndpoint>(EndpointNames.Introspection, ProtocolRoutePaths.Introspection.EnsureLeadingSlash());
@@ -129,16 +131,32 @@ public static class IdentityServerBuilderExtensionsCore
     /// <summary>
     /// Adds the endpoint.
     /// </summary>
-    /// <typeparam name="T"></typeparam>
+    /// <typeparam name="TEndpoint"></typeparam>
     /// <param name="builder">The builder.</param>
     /// <param name="name">The name.</param>
     /// <param name="path">The path.</param>
     /// <returns></returns>
-    public static IIdentityServerBuilder AddEndpoint<T>(this IIdentityServerBuilder builder, string name, PathString path)
-        where T : class, IEndpointHandler
+    public static IIdentityServerBuilder AddEndpoint<TEndpoint>(this IIdentityServerBuilder builder, string name, PathString path)
+        where TEndpoint : class, IEndpointHandler
     {
-        builder.Services.AddTransient<T>();
-        builder.Services.AddSingleton(new Duende.IdentityServer.Hosting.Endpoint(name, path, typeof(T)));
+        builder.Services.AddTransient<TEndpoint>();
+        builder.Services.AddSingleton(new Duende.IdentityServer.Hosting.Endpoint(name, path, typeof(TEndpoint)));
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds the endpoint.
+    /// </summary>
+    public static IIdentityServerBuilder AddEndpoint<TEndpoint, TResult, TResultGenerator>(this IIdentityServerBuilder builder, string name, PathString path)
+        where TEndpoint : class, IEndpointHandler
+        where TResult : class, IEndpointResult
+        where TResultGenerator : class, IEndpointResultGenerator<TResult>
+    {
+        builder.Services.AddTransient<TEndpoint>();
+        builder.Services.AddTransient<IEndpointResultGenerator<TResult>, TResultGenerator>();
+
+        builder.Services.AddSingleton(new Duende.IdentityServer.Hosting.Endpoint(name, path, typeof(TEndpoint)));
 
         return builder;
     }

--- a/src/IdentityServer/Endpoints/Results/AuthorizeInteractionPageResult.cs
+++ b/src/IdentityServer/Endpoints/Results/AuthorizeInteractionPageResult.cs
@@ -52,10 +52,7 @@ public abstract class AuthorizeInteractionPageResult : EndpointResult<AuthorizeI
     public string ReturnUrlParameterName { get; }
 }
 
-/// <summary>
-/// Result generator for AuthorizeInteractionPageResult
-/// </summary>
-public class AuthorizeInteractionPageResultGenerator : IEndpointResultGenerator<AuthorizeInteractionPageResult>
+class AuthorizeInteractionPageResultGenerator : IEndpointResultGenerator<AuthorizeInteractionPageResult>
 {
     private readonly IServerUrls _urls;
     private readonly IAuthorizationParametersMessageStore _authorizationParametersMessageStore;

--- a/src/IdentityServer/Endpoints/Results/AuthorizeInteractionPageResult.cs
+++ b/src/IdentityServer/Endpoints/Results/AuthorizeInteractionPageResult.cs
@@ -11,7 +11,6 @@ using Duende.IdentityServer.Stores;
 using Duende.IdentityServer.Validation;
 using Microsoft.AspNetCore.Http;
 using Duende.IdentityServer.Extensions;
-using Microsoft.Extensions.DependencyInjection;
 using Duende.IdentityServer.Services;
 using static Duende.IdentityServer.IdentityServerConstants;
 
@@ -21,12 +20,8 @@ namespace Duende.IdentityServer.Endpoints.Results;
 /// Result for an interactive page
 /// </summary>
 /// <seealso cref="IEndpointResult" />
-public abstract class AuthorizeInteractionPageResult : IEndpointResult
+public abstract class AuthorizeInteractionPageResult : EndpointResult<AuthorizeInteractionPageResult>
 {
-    private readonly ValidatedAuthorizeRequest _request;
-    private string _redirectUrl;
-    private string _returnUrlParameterName;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="AuthorizeInteractionPageResult"/> class.
     /// </summary>
@@ -36,43 +31,61 @@ public abstract class AuthorizeInteractionPageResult : IEndpointResult
     /// <exception cref="System.ArgumentNullException">request</exception>
     public AuthorizeInteractionPageResult(ValidatedAuthorizeRequest request, string redirectUrl, string returnUrlParameterName)
     {
-        _request = request ?? throw new ArgumentNullException(nameof(request));
-        _redirectUrl = redirectUrl ?? throw new ArgumentNullException(nameof(redirectUrl));
-        _returnUrlParameterName = returnUrlParameterName ?? throw new ArgumentNullException(nameof(returnUrlParameterName));
-    }
-
-    private IServerUrls _urls;
-    private IAuthorizationParametersMessageStore _authorizationParametersMessageStore;
-
-    private void Init(HttpContext context)
-    {
-        _urls = context.RequestServices.GetRequiredService<IServerUrls>();
-        _authorizationParametersMessageStore = context.RequestServices.GetService<IAuthorizationParametersMessageStore>();
+        Request = request ?? throw new ArgumentNullException(nameof(request));
+        RedirectUrl = redirectUrl ?? throw new ArgumentNullException(nameof(redirectUrl));
+        ReturnUrlParameterName = returnUrlParameterName ?? throw new ArgumentNullException(nameof(returnUrlParameterName));
     }
 
     /// <summary>
-    /// Executes the result.
+    /// The validated authorize request
     /// </summary>
-    /// <param name="context">The HTTP context.</param>
-    /// <returns></returns>
-    public async Task ExecuteAsync(HttpContext context)
-    {
-        Init(context);
+    public ValidatedAuthorizeRequest Request { get; }
 
+    /// <summary>
+    /// The redirect URI
+    /// </summary>
+    public string RedirectUrl { get; }
+
+    /// <summary>
+    /// The return URL param name
+    /// </summary>
+    public string ReturnUrlParameterName { get; }
+}
+
+/// <summary>
+/// Result generator for AuthorizeInteractionPageResult
+/// </summary>
+public class AuthorizeInteractionPageResultGenerator : IEndpointResultGenerator<AuthorizeInteractionPageResult>
+{
+    private readonly IServerUrls _urls;
+    private readonly IAuthorizationParametersMessageStore _authorizationParametersMessageStore;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AuthorizeInteractionPageResult"/> class.
+    /// </summary>
+    public AuthorizeInteractionPageResultGenerator(IServerUrls urls, IAuthorizationParametersMessageStore authorizationParametersMessageStore = null)
+    {
+        _urls = urls;
+        _authorizationParametersMessageStore = authorizationParametersMessageStore;
+    }
+
+    /// <inheritdoc/>
+    public async Task ExecuteAsync(AuthorizeInteractionPageResult result, HttpContext context)
+    {
         var returnUrl = _urls.BasePath.EnsureTrailingSlash() + ProtocolRoutePaths.AuthorizeCallback;
 
         if (_authorizationParametersMessageStore != null)
         {
-            var msg = new Message<IDictionary<string, string[]>>(_request.ToOptimizedFullDictionary());
+            var msg = new Message<IDictionary<string, string[]>>(result.Request.ToOptimizedFullDictionary());
             var id = await _authorizationParametersMessageStore.WriteAsync(msg);
             returnUrl = returnUrl.AddQueryString(Constants.AuthorizationParamsStore.MessageStoreIdParameterName, id);
         }
         else
         {
-            returnUrl = returnUrl.AddQueryString(_request.ToOptimizedQueryString());
+            returnUrl = returnUrl.AddQueryString(result.Request.ToOptimizedQueryString());
         }
 
-        var url = _redirectUrl;
+        var url = result.RedirectUrl;
         if (!url.IsLocalUrl())
         {
             // this converts the relative redirect path to an absolute one if we're 
@@ -80,7 +93,7 @@ public abstract class AuthorizeInteractionPageResult : IEndpointResult
             returnUrl = _urls.Origin + returnUrl;
         }
 
-        url = url.AddQueryString(_returnUrlParameterName, returnUrl);
+        url = url.AddQueryString(result.ReturnUrlParameterName, returnUrl);
         context.Response.Redirect(_urls.GetAbsoluteUrl(url));
     }
 }

--- a/src/IdentityServer/Endpoints/Results/AuthorizeResult.cs
+++ b/src/IdentityServer/Endpoints/Results/AuthorizeResult.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using Duende.IdentityServer.Extensions;
 using IdentityModel;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Text.Encodings.Web;
 using Duende.IdentityServer.Configuration;
@@ -18,7 +17,7 @@ using Duende.IdentityServer.Stores;
 
 namespace Duende.IdentityServer.Endpoints.Results;
 
-internal class AuthorizeResult : IEndpointResult
+internal class AuthorizeResult : EndpointResult<AuthorizeResult>
 {
     public AuthorizeResponse Response { get; }
 
@@ -26,15 +25,16 @@ internal class AuthorizeResult : IEndpointResult
     {
         Response = response ?? throw new ArgumentNullException(nameof(response));
     }
+}
 
-    internal AuthorizeResult(
-        AuthorizeResponse response,
+internal class AuthorizeResultGenerator : IEndpointResultGenerator<AuthorizeResult>
+{
+    public AuthorizeResultGenerator(
         IdentityServerOptions options,
         IUserSession userSession,
         IMessageStore<ErrorMessage> errorMessageStore,
         IServerUrls urls,
         IClock clock)
-        : this(response)
     {
         _options = options;
         _userSession = userSession;
@@ -49,78 +49,67 @@ internal class AuthorizeResult : IEndpointResult
     private IServerUrls _urls;
     private IClock _clock;
 
-    private void Init(HttpContext context)
+    public async Task ExecuteAsync(AuthorizeResult result, HttpContext context)
     {
-        _options ??= context.RequestServices.GetRequiredService<IdentityServerOptions>();
-        _userSession ??= context.RequestServices.GetRequiredService<IUserSession>();
-        _errorMessageStore ??= context.RequestServices.GetRequiredService<IMessageStore<ErrorMessage>>();
-        _urls = _urls ?? context.RequestServices.GetRequiredService<IServerUrls>();
-        _clock ??= context.RequestServices.GetRequiredService<IClock>();
-    }
-
-    public async Task ExecuteAsync(HttpContext context)
-    {
-        Init(context);
-
-        if (Response.IsError)
+        if (result.Response.IsError)
         {
-            await ProcessErrorAsync(context);
+            await ProcessErrorAsync(result.Response, context);
         }
         else
         {
-            await ProcessResponseAsync(context);
+            await ProcessResponseAsync(result.Response, context);
         }
     }
 
-    private async Task ProcessErrorAsync(HttpContext context)
+    private async Task ProcessErrorAsync(AuthorizeResponse response, HttpContext context)
     {
         // these are the conditions where we can send a response 
         // back directly to the client, otherwise we're only showing the error UI
         var isSafeError =
-            Response.Error == OidcConstants.AuthorizeErrors.AccessDenied ||
-            Response.Error == OidcConstants.AuthorizeErrors.AccountSelectionRequired ||
-            Response.Error == OidcConstants.AuthorizeErrors.LoginRequired ||
-            Response.Error == OidcConstants.AuthorizeErrors.ConsentRequired ||
-            Response.Error == OidcConstants.AuthorizeErrors.InteractionRequired ||
-            Response.Error == OidcConstants.AuthorizeErrors.TemporarilyUnavailable ||
-            Response.Error == OidcConstants.AuthorizeErrors.UnmetAuthenticationRequirements;
+            response.Error == OidcConstants.AuthorizeErrors.AccessDenied ||
+            response.Error == OidcConstants.AuthorizeErrors.AccountSelectionRequired ||
+            response.Error == OidcConstants.AuthorizeErrors.LoginRequired ||
+            response.Error == OidcConstants.AuthorizeErrors.ConsentRequired ||
+            response.Error == OidcConstants.AuthorizeErrors.InteractionRequired ||
+            response.Error == OidcConstants.AuthorizeErrors.TemporarilyUnavailable ||
+            response.Error == OidcConstants.AuthorizeErrors.UnmetAuthenticationRequirements;
         if (isSafeError)
         {
             // this scenario we can return back to the client
-            await ProcessResponseAsync(context);
+            await ProcessResponseAsync(response, context);
         }
         else
         {
             // we now know we must show error page
-            await RedirectToErrorPageAsync(context);
+            await RedirectToErrorPageAsync(response, context);
         }
     }
 
-    protected async Task ProcessResponseAsync(HttpContext context)
+    protected async Task ProcessResponseAsync(AuthorizeResponse response, HttpContext context)
     {
-        if (!Response.IsError)
+        if (!response.IsError)
         {
             // success response -- track client authorization for sign-out
             //_logger.LogDebug("Adding client {0} to client list cookie for subject {1}", request.ClientId, request.Subject.GetSubjectId());
-            await _userSession.AddClientIdAsync(Response.Request.ClientId);
+            await _userSession.AddClientIdAsync(response.Request.ClientId);
         }
 
-        await RenderAuthorizeResponseAsync(context);
+        await RenderAuthorizeResponseAsync(response, context);
     }
 
-    private async Task RenderAuthorizeResponseAsync(HttpContext context)
+    private async Task RenderAuthorizeResponseAsync(AuthorizeResponse response, HttpContext context)
     {
-        if (Response.Request.ResponseMode == OidcConstants.ResponseModes.Query ||
-            Response.Request.ResponseMode == OidcConstants.ResponseModes.Fragment)
+        if (response.Request.ResponseMode == OidcConstants.ResponseModes.Query ||
+            response.Request.ResponseMode == OidcConstants.ResponseModes.Fragment)
         {
             context.Response.SetNoCache();
-            context.Response.Redirect(BuildRedirectUri());
+            context.Response.Redirect(BuildRedirectUri(response));
         }
-        else if (Response.Request.ResponseMode == OidcConstants.ResponseModes.FormPost)
+        else if (response.Request.ResponseMode == OidcConstants.ResponseModes.FormPost)
         {
             context.Response.SetNoCache();
             AddSecurityHeaders(context);
-            await context.Response.WriteHtmlAsync(GetFormPostHtml());
+            await context.Response.WriteHtmlAsync(GetFormPostHtml(response));
         }
         else
         {
@@ -140,12 +129,12 @@ internal class AuthorizeResult : IEndpointResult
         }
     }
 
-    private string BuildRedirectUri()
+    private string BuildRedirectUri(AuthorizeResponse response)
     {
-        var uri = Response.RedirectUri;
-        var query = Response.ToNameValueCollection(_options).ToQueryString();
+        var uri = response.RedirectUri;
+        var query = response.ToNameValueCollection(_options).ToQueryString();
 
-        if (Response.Request.ResponseMode == OidcConstants.ResponseModes.Query)
+        if (response.Request.ResponseMode == OidcConstants.ResponseModes.Query)
         {
             uri = uri.AddQueryString(query);
         }
@@ -154,7 +143,7 @@ internal class AuthorizeResult : IEndpointResult
             uri = uri.AddHashFragment(query);
         }
 
-        if (Response.IsError && !uri.Contains("#"))
+        if (response.IsError && !uri.Contains("#"))
         {
             // https://tools.ietf.org/html/draft-bradley-oauth-open-redirector-00
             uri += "#_=_";
@@ -165,35 +154,35 @@ internal class AuthorizeResult : IEndpointResult
 
     private const string FormPostHtml = "<html><head><meta http-equiv='X-UA-Compatible' content='IE=edge' /><base target='_self'/></head><body><form method='post' action='{uri}'>{body}<noscript><button>Click to continue</button></noscript></form><script>window.addEventListener('load', function(){document.forms[0].submit();});</script></body></html>";
 
-    private string GetFormPostHtml()
+    private string GetFormPostHtml(AuthorizeResponse response)
     {
         var html = FormPostHtml;
 
-        var url = Response.Request.RedirectUri;
+        var url = response.Request.RedirectUri;
         url = HtmlEncoder.Default.Encode(url);
         html = html.Replace("{uri}", url);
-        html = html.Replace("{body}", Response.ToNameValueCollection(_options).ToFormPost());
+        html = html.Replace("{body}", response.ToNameValueCollection(_options).ToFormPost());
 
         return html;
     }
 
-    private async Task RedirectToErrorPageAsync(HttpContext context)
+    private async Task RedirectToErrorPageAsync(AuthorizeResponse response, HttpContext context)
     {
         var errorModel = new ErrorMessage
         {
             RequestId = context.TraceIdentifier,
-            Error = Response.Error,
-            ErrorDescription = Response.ErrorDescription,
-            UiLocales = Response.Request?.UiLocales,
-            DisplayMode = Response.Request?.DisplayMode,
-            ClientId = Response.Request?.ClientId
+            Error = response.Error,
+            ErrorDescription = response.ErrorDescription,
+            UiLocales = response.Request?.UiLocales,
+            DisplayMode = response.Request?.DisplayMode,
+            ClientId = response.Request?.ClientId
         };
 
-        if (Response.RedirectUri != null && Response.Request?.ResponseMode != null)
+        if (response.RedirectUri != null && response.Request?.ResponseMode != null)
         {
             // if we have a valid redirect uri, then include it to the error page
-            errorModel.RedirectUri = BuildRedirectUri();
-            errorModel.ResponseMode = Response.Request.ResponseMode;
+            errorModel.RedirectUri = BuildRedirectUri(response);
+            errorModel.ResponseMode = response.Request.ResponseMode;
         }
 
         var message = new Message<ErrorMessage>(errorModel, _clock.UtcNow.UtcDateTime);

--- a/src/IdentityServer/Endpoints/Results/AuthorizeResult.cs
+++ b/src/IdentityServer/Endpoints/Results/AuthorizeResult.cs
@@ -17,10 +17,21 @@ using Duende.IdentityServer.Stores;
 
 namespace Duende.IdentityServer.Endpoints.Results;
 
-internal class AuthorizeResult : EndpointResult<AuthorizeResult>
+/// <summary>
+/// Models the result from the authorize endpoint
+/// </summary>
+public class AuthorizeResult : EndpointResult<AuthorizeResult>
 {
+    /// <summary>
+    /// The authorize response
+    /// </summary>
     public AuthorizeResponse Response { get; }
 
+    /// <summary>
+    /// Ctor
+    /// </summary>
+    /// <param name="response"></param>
+    /// <exception cref="ArgumentNullException"></exception>
     public AuthorizeResult(AuthorizeResponse response)
     {
         Response = response ?? throw new ArgumentNullException(nameof(response));

--- a/src/IdentityServer/Endpoints/Results/BackchannelAuthenticationResult.cs
+++ b/src/IdentityServer/Endpoints/Results/BackchannelAuthenticationResult.cs
@@ -12,7 +12,7 @@ using IdentityModel;
 
 namespace Duende.IdentityServer.Endpoints.Results;
 
-internal class BackchannelAuthenticationResult : IEndpointResult
+internal class BackchannelAuthenticationResult : EndpointResult<BackchannelAuthenticationResult>
 {
     public BackchannelAuthenticationResponse Response { get; set; }
 
@@ -20,14 +20,17 @@ internal class BackchannelAuthenticationResult : IEndpointResult
     {
         Response = response ?? throw new ArgumentNullException(nameof(response));
     }
+}
 
-    public async Task ExecuteAsync(HttpContext context)
+internal class BackchannelAuthenticationResultGenerator : IEndpointResultGenerator<BackchannelAuthenticationResult>
+{
+    public async Task ExecuteAsync(BackchannelAuthenticationResult result, HttpContext context)
     {
         context.Response.SetNoCache();
 
-        if (Response.IsError)
+        if (result.Response.IsError)
         {
-            switch (Response.Error)
+            switch (result.Response.Error)
             {
                 case OidcConstants.BackchannelAuthenticationRequestErrors.InvalidClient:
                     context.Response.StatusCode = 401;
@@ -40,9 +43,10 @@ internal class BackchannelAuthenticationResult : IEndpointResult
                     break;
             }
 
-            await context.Response.WriteJsonAsync(new ErrorResultDto { 
-                error = Response.Error,
-                error_description = Response.ErrorDescription
+            await context.Response.WriteJsonAsync(new ErrorResultDto
+            {
+                error = result.Response.Error,
+                error_description = result.Response.ErrorDescription
             });
         }
         else
@@ -50,9 +54,9 @@ internal class BackchannelAuthenticationResult : IEndpointResult
             context.Response.StatusCode = 200;
             await context.Response.WriteJsonAsync(new SuccessResultDto
             {
-                auth_req_id = Response.AuthenticationRequestId,
-                expires_in = Response.ExpiresIn,
-                interval = Response.Interval
+                auth_req_id = result.Response.AuthenticationRequestId,
+                expires_in = result.Response.ExpiresIn,
+                interval = result.Response.Interval
             });
         }
     }

--- a/src/IdentityServer/Endpoints/Results/BackchannelAuthenticationResult.cs
+++ b/src/IdentityServer/Endpoints/Results/BackchannelAuthenticationResult.cs
@@ -12,10 +12,21 @@ using IdentityModel;
 
 namespace Duende.IdentityServer.Endpoints.Results;
 
-internal class BackchannelAuthenticationResult : EndpointResult<BackchannelAuthenticationResult>
+/// <summary>
+/// Models the result of backchannel authentication 
+/// </summary>
+public class BackchannelAuthenticationResult : EndpointResult<BackchannelAuthenticationResult>
 {
-    public BackchannelAuthenticationResponse Response { get; set; }
+    /// <summary>
+    /// The response
+    /// </summary>
+    public BackchannelAuthenticationResponse Response { get; }
 
+    /// <summary>
+    /// Ctor
+    /// </summary>
+    /// <param name="response"></param>
+    /// <exception cref="ArgumentNullException"></exception>
     public BackchannelAuthenticationResult(BackchannelAuthenticationResponse response)
     {
         Response = response ?? throw new ArgumentNullException(nameof(response));

--- a/src/IdentityServer/Endpoints/Results/BadRequestResult.cs
+++ b/src/IdentityServer/Endpoints/Results/BadRequestResult.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 
@@ -9,28 +9,45 @@ using Duende.IdentityServer.Extensions;
 
 namespace Duende.IdentityServer.Endpoints.Results;
 
-internal class BadRequestResult : IEndpointResult
+/// <summary>
+/// The result of a bad request
+/// </summary>
+public class BadRequestResult : EndpointResult<BadRequestResult>
 {
-    public string Error { get; set; }
-    public string ErrorDescription { get; set; }
+    /// <summary>
+    /// The error
+    /// </summary>
+    public string Error { get; }
+    /// <summary>
+    /// The error description
+    /// </summary>
+    public string ErrorDescription { get; }
 
+    /// <summary>
+    /// Ctor
+    /// </summary>
+    /// <param name="error"></param>
+    /// <param name="errorDescription"></param>
     public BadRequestResult(string error = null, string errorDescription = null)
     {
         Error = error;
         ErrorDescription = errorDescription;
     }
+}
 
-    public async Task ExecuteAsync(HttpContext context)
+internal class BadRequestResultGenerator : IEndpointResultGenerator<BadRequestResult>
+{
+    public async Task ExecuteAsync(BadRequestResult result, HttpContext context)
     {
         context.Response.StatusCode = 400;
         context.Response.SetNoCache();
 
-        if (Error.IsPresent())
+        if (result.Error.IsPresent())
         {
             var dto = new ResultDto
             {
-                error = Error,
-                error_description = ErrorDescription
+                error = result.Error,
+                error_description = result.ErrorDescription
             };
 
             await context.Response.WriteJsonAsync(dto);
@@ -41,5 +58,5 @@ internal class BadRequestResult : IEndpointResult
     {
         public string error { get; set; }
         public string error_description { get; set; }
-    }    
+    }
 }

--- a/src/IdentityServer/Endpoints/Results/CheckSessionResult.cs
+++ b/src/IdentityServer/Endpoints/Results/CheckSessionResult.cs
@@ -6,18 +6,21 @@ using System.Threading.Tasks;
 using Duende.IdentityServer.Configuration;
 using Duende.IdentityServer.Hosting;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.DependencyInjection;
 using Duende.IdentityServer.Extensions;
 
 namespace Duende.IdentityServer.Endpoints.Results;
 
-internal class CheckSessionResult : IEndpointResult
+/// <summary>
+/// The resukt of the check session endpoint
+/// </summary>
+public class CheckSessionResult : EndpointResult<CheckSessionResult>
 {
-    public CheckSessionResult()
-    {
-    }
+}
 
-    internal CheckSessionResult(IdentityServerOptions options)
+
+internal class CheckSessionResultGenerator : IEndpointResultGenerator<CheckSessionResult>
+{
+    public CheckSessionResultGenerator(IdentityServerOptions options)
     {
         _options = options;
     }
@@ -27,15 +30,8 @@ internal class CheckSessionResult : IEndpointResult
     private static readonly object Lock = new object();
     private static volatile string LastCheckSessionCookieName;
 
-    private void Init(HttpContext context)
+    public async Task ExecuteAsync(CheckSessionResult result, HttpContext context)
     {
-        _options = _options ?? context.RequestServices.GetRequiredService<IdentityServerOptions>();
-    }
-
-    public async Task ExecuteAsync(HttpContext context)
-    {
-        Init(context);
-
         AddCspHeaders(context);
 
         var html = GetHtml(_options.Authentication.CheckSessionCookieName);

--- a/src/IdentityServer/Endpoints/Results/DeviceAuthorizationResult.cs
+++ b/src/IdentityServer/Endpoints/Results/DeviceAuthorizationResult.cs
@@ -11,27 +11,41 @@ using Microsoft.AspNetCore.Http;
 
 namespace Duende.IdentityServer.Endpoints.Results;
 
-internal class DeviceAuthorizationResult : IEndpointResult
+/// <summary>
+/// The result of device authorization
+/// </summary>
+public class DeviceAuthorizationResult : EndpointResult<DeviceAuthorizationResult>
 {
+    /// <summary>
+    /// The response
+    /// </summary>
     public DeviceAuthorizationResponse Response { get; }
 
+    /// <summary>
+    /// Ctor
+    /// </summary>
+    /// <param name="response"></param>
+    /// <exception cref="ArgumentNullException"></exception>
     public DeviceAuthorizationResult(DeviceAuthorizationResponse response)
     {
         Response = response ?? throw new ArgumentNullException(nameof(response));
     }
+}
 
-    public async Task ExecuteAsync(HttpContext context)
+internal class DeviceAuthorizationResultGenerator : IEndpointResultGenerator<DeviceAuthorizationResult>
+{
+    public async Task ExecuteAsync(DeviceAuthorizationResult result, HttpContext context)
     {
         context.Response.SetNoCache();
 
         var dto = new ResultDto
         {
-            device_code = Response.DeviceCode,
-            user_code = Response.UserCode,
-            verification_uri = Response.VerificationUri,
-            verification_uri_complete = Response.VerificationUriComplete,
-            expires_in = Response.DeviceCodeLifetime,
-            interval = Response.Interval
+            device_code = result.Response.DeviceCode,
+            user_code = result.Response.UserCode,
+            verification_uri = result.Response.VerificationUri,
+            verification_uri_complete = result.Response.VerificationUriComplete,
+            expires_in = result.Response.DeviceCodeLifetime,
+            interval = result.Response.Interval
         };
 
         await context.Response.WriteJsonAsync(dto);

--- a/src/IdentityServer/Endpoints/Results/DiscoveryDocumentResult.cs
+++ b/src/IdentityServer/Endpoints/Results/DiscoveryDocumentResult.cs
@@ -15,7 +15,7 @@ namespace Duende.IdentityServer.Endpoints.Results;
 /// Result for a discovery document
 /// </summary>
 /// <seealso cref="IEndpointResult" />
-public class DiscoveryDocumentResult : IEndpointResult
+public class DiscoveryDocumentResult : EndpointResult<DiscoveryDocumentResult>
 {
     /// <summary>
     /// Gets the entries.
@@ -44,19 +44,21 @@ public class DiscoveryDocumentResult : IEndpointResult
         Entries = entries ?? throw new ArgumentNullException(nameof(entries));
         MaxAge = maxAge;
     }
+}
 
-    /// <summary>
-    /// Executes the result.
-    /// </summary>
-    /// <param name="context">The HTTP context.</param>
-    /// <returns></returns>
-    public Task ExecuteAsync(HttpContext context)
+/// <summary>
+/// The result generator for DiscoveryDocumentResult.
+/// </summary>
+public class DiscoveryDocumentResultGenerator : IEndpointResultGenerator<DiscoveryDocumentResult>
+{
+    /// <inheritdoc/>
+    public Task ProcessAsync(DiscoveryDocumentResult result, HttpContext context)
     {
-        if (MaxAge.HasValue && MaxAge.Value >= 0)
+        if (result.MaxAge.HasValue && result.MaxAge.Value >= 0)
         {
-            context.Response.SetCache(MaxAge.Value, "Origin");
+            context.Response.SetCache(result.MaxAge.Value, "Origin");
         }
 
-        return context.Response.WriteJsonAsync(Entries);
+        return context.Response.WriteJsonAsync(result.Entries);
     }
 }

--- a/src/IdentityServer/Endpoints/Results/DiscoveryDocumentResult.cs
+++ b/src/IdentityServer/Endpoints/Results/DiscoveryDocumentResult.cs
@@ -52,7 +52,7 @@ public class DiscoveryDocumentResult : EndpointResult<DiscoveryDocumentResult>
 public class DiscoveryDocumentResultGenerator : IEndpointResultGenerator<DiscoveryDocumentResult>
 {
     /// <inheritdoc/>
-    public Task ProcessAsync(DiscoveryDocumentResult result, HttpContext context)
+    public Task ExecuteAsync(DiscoveryDocumentResult result, HttpContext context)
     {
         if (result.MaxAge.HasValue && result.MaxAge.Value >= 0)
         {

--- a/src/IdentityServer/Endpoints/Results/DiscoveryDocumentResult.cs
+++ b/src/IdentityServer/Endpoints/Results/DiscoveryDocumentResult.cs
@@ -39,17 +39,14 @@ public class DiscoveryDocumentResult : EndpointResult<DiscoveryDocumentResult>
     /// <param name="entries">The entries.</param>
     /// <param name="maxAge">The maximum age.</param>
     /// <exception cref="System.ArgumentNullException">entries</exception>
-    public DiscoveryDocumentResult(Dictionary<string, object> entries, int? maxAge)
+    public DiscoveryDocumentResult(Dictionary<string, object> entries, int? maxAge = null)
     {
         Entries = entries ?? throw new ArgumentNullException(nameof(entries));
         MaxAge = maxAge;
     }
 }
 
-/// <summary>
-/// The result generator for DiscoveryDocumentResult.
-/// </summary>
-public class DiscoveryDocumentResultGenerator : Hosting.IEndpointResultGenerator<DiscoveryDocumentResult>
+class DiscoveryDocumentResultGenerator : IEndpointResultGenerator<DiscoveryDocumentResult>
 {
     /// <inheritdoc/>
     public Task ExecuteAsync(DiscoveryDocumentResult result, HttpContext context)

--- a/src/IdentityServer/Endpoints/Results/DiscoveryDocumentResult.cs
+++ b/src/IdentityServer/Endpoints/Results/DiscoveryDocumentResult.cs
@@ -49,7 +49,7 @@ public class DiscoveryDocumentResult : EndpointResult<DiscoveryDocumentResult>
 /// <summary>
 /// The result generator for DiscoveryDocumentResult.
 /// </summary>
-public class DiscoveryDocumentResultGenerator : IEndpointResultGenerator<DiscoveryDocumentResult>
+public class DiscoveryDocumentResultGenerator : Hosting.IEndpointResultGenerator<DiscoveryDocumentResult>
 {
     /// <inheritdoc/>
     public Task ExecuteAsync(DiscoveryDocumentResult result, HttpContext context)

--- a/src/IdentityServer/Endpoints/Results/EndPointResult.cs
+++ b/src/IdentityServer/Endpoints/Results/EndPointResult.cs
@@ -14,7 +14,7 @@ namespace Duende.IdentityServer.Endpoints.Results;
 /// Provides the base implementation of IEndpointResult.
 /// </summary>
 /// <typeparam name="T"></typeparam>
-public class EndpointResult<T> : IEndpointResult
+public abstract class EndpointResult<T> : IEndpointResult
     where T : class, IEndpointResult
 {
     /// <inheritdoc/>

--- a/src/IdentityServer/Endpoints/Results/EndPointResult.cs
+++ b/src/IdentityServer/Endpoints/Results/EndPointResult.cs
@@ -11,7 +11,7 @@ using Duende.IdentityServer.Hosting;
 namespace Duende.IdentityServer.Endpoints.Results;
 
 /// <summary>
-/// Provides the base implementation of IEndpointResult.
+/// Provides the base implementation of IEndpointResult that invokes the corresponding IEndpointResultGenerator<typeparamref name="T"/>.
 /// </summary>
 /// <typeparam name="T"></typeparam>
 public abstract class EndpointResult<T> : IEndpointResult

--- a/src/IdentityServer/Endpoints/Results/EndPointResult.cs
+++ b/src/IdentityServer/Endpoints/Results/EndPointResult.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using Duende.IdentityServer.Hosting;
+
+namespace Duende.IdentityServer.Endpoints.Results;
+
+/// <summary>
+/// Provides the base implementation of IEndpointResult.
+/// </summary>
+/// <typeparam name="T"></typeparam>
+public class EndpointResult<T> : IEndpointResult
+    where T : class, IEndpointResult
+{
+    /// <inheritdoc/>
+    public async Task ExecuteAsync(HttpContext context)
+    {
+        var generator = context.RequestServices.GetService<IEndpointResultGenerator<T>>();
+        if (generator != null)
+        {
+            T target = this as T;
+            if (target == null)
+            {
+                throw new Exception($"Type paramter {typeof(T)} must be the class derived from 'EndPointResult<T>'.");
+            }
+
+            await generator.ProcessAsync(target, context);
+        }
+        else
+        {
+            throw new Exception($"No IEndpointResultGenerator<T> registered for IEndpointResult type '{typeof(T)}'.");
+        }
+    }
+}

--- a/src/IdentityServer/Endpoints/Results/EndPointResult.cs
+++ b/src/IdentityServer/Endpoints/Results/EndPointResult.cs
@@ -29,7 +29,7 @@ public class EndpointResult<T> : IEndpointResult
                 throw new Exception($"Type paramter {typeof(T)} must be the class derived from 'EndPointResult<T>'.");
             }
 
-            await generator.ProcessAsync(target, context);
+            await generator.ExecuteAsync(target, context);
         }
         else
         {

--- a/src/IdentityServer/Endpoints/Results/EndSessionCallbackResult.cs
+++ b/src/IdentityServer/Endpoints/Results/EndSessionCallbackResult.cs
@@ -5,66 +5,69 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.DependencyInjection;
 using System.Net;
 using System;
 using Duende.IdentityServer.Configuration;
-using Duende.IdentityServer.Hosting;
 using Duende.IdentityServer.Validation;
 using Duende.IdentityServer.Extensions;
 using System.Text.Encodings.Web;
 using System.Text;
+using Duende.IdentityServer.Hosting;
 
 namespace Duende.IdentityServer.Endpoints.Results;
 
-internal class EndSessionCallbackResult : IEndpointResult
+/// <summary>
+/// Models the result of end session callback
+/// </summary>
+public class EndSessionCallbackResult : EndpointResult<EndSessionCallbackResult>
 {
-    private readonly EndSessionCallbackValidationResult _result;
+    /// <summary>
+    /// The result
+    /// </summary>
+    public EndSessionCallbackValidationResult Result { get; }
 
+    /// <summary>
+    /// Ctor
+    /// </summary>
+    /// <param name="result"></param>
+    /// <exception cref="ArgumentNullException"></exception>
     public EndSessionCallbackResult(EndSessionCallbackValidationResult result)
     {
-        _result = result ?? throw new ArgumentNullException(nameof(result));
+        Result = result ?? throw new ArgumentNullException(nameof(result));
     }
+}
 
-    internal EndSessionCallbackResult(
-        EndSessionCallbackValidationResult result,
-        IdentityServerOptions options)
-        : this(result)
+class EndSessionCallbackResultGenerator : IEndpointResultGenerator<EndSessionCallbackResult>
+{
+    public EndSessionCallbackResultGenerator(IdentityServerOptions options)
     {
         _options = options;
     }
 
     private IdentityServerOptions _options;
 
-    private void Init(HttpContext context)
+    public async Task ExecuteAsync(EndSessionCallbackResult result, HttpContext context)
     {
-        _options = _options ?? context.RequestServices.GetRequiredService<IdentityServerOptions>();
-    }
-
-    public async Task ExecuteAsync(HttpContext context)
-    {
-        Init(context);
-
-        if (_result.IsError)
+        if (result.Result.IsError)
         {
-            context.Response.StatusCode = (int)HttpStatusCode.BadRequest;
+            context.Response.StatusCode = (int) HttpStatusCode.BadRequest;
         }
         else
         {
             context.Response.SetNoCache();
-            AddCspHeaders(context);
+            AddCspHeaders(result, context);
 
-            var html = GetHtml();
+            var html = GetHtml(result);
             await context.Response.WriteHtmlAsync(html);
         }
     }
 
-    private void AddCspHeaders(HttpContext context)
+    private void AddCspHeaders(EndSessionCallbackResult result, HttpContext context)
     {
         if (_options.Authentication.RequireCspFrameSrcForSignout)
         {
             var sb = new StringBuilder();
-            var origins = _result.FrontChannelLogoutUrls?.Select(x => x.GetOrigin());
+            var origins = result.Result.FrontChannelLogoutUrls?.Select(x => x.GetOrigin());
             if (origins != null)
             {
                 foreach (var origin in origins.Distinct())
@@ -79,14 +82,14 @@ internal class EndSessionCallbackResult : IEndpointResult
         }
     }
 
-    private string GetHtml()
+    private string GetHtml(EndSessionCallbackResult result)
     {
         var sb = new StringBuilder();
         sb.Append("<!DOCTYPE html><html><style>iframe{{display:none;width:0;height:0;}}</style><body>");
 
-        if (_result.FrontChannelLogoutUrls != null)
+        if (result.Result.FrontChannelLogoutUrls != null)
         {
-            foreach (var url in _result.FrontChannelLogoutUrls)
+            foreach (var url in result.Result.FrontChannelLogoutUrls)
             {
                 sb.AppendFormat("<iframe loading='eager' allow='' src='{0}'></iframe>", HtmlEncoder.Default.Encode(url));
                 sb.AppendLine();

--- a/src/IdentityServer/Endpoints/Results/EndSessionResult.cs
+++ b/src/IdentityServer/Endpoints/Results/EndSessionResult.cs
@@ -4,7 +4,6 @@
 
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.DependencyInjection;
 using Duende.IdentityServer.Extensions;
 using System;
 using Duende.IdentityServer.Configuration;
@@ -20,9 +19,12 @@ namespace Duende.IdentityServer.Endpoints.Results;
 /// Result for endsession
 /// </summary>
 /// <seealso cref="IEndpointResult" />
-public class EndSessionResult : IEndpointResult
+public class EndSessionResult : EndpointResult<EndSessionResult>
 {
-    private readonly EndSessionValidationResult _result;
+    /// <summary>
+    /// The result
+    /// </summary>
+    public EndSessionValidationResult Result { get; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="EndSessionResult"/> class.
@@ -31,16 +33,18 @@ public class EndSessionResult : IEndpointResult
     /// <exception cref="System.ArgumentNullException">result</exception>
     public EndSessionResult(EndSessionValidationResult result)
     {
-        _result = result ?? throw new ArgumentNullException(nameof(result));
+        Result = result ?? throw new ArgumentNullException(nameof(result));
     }
+}
 
-    internal EndSessionResult(
-        EndSessionValidationResult result,
+
+class EndSessionResultGenerator : IEndpointResultGenerator<EndSessionResult>
+{
+    public EndSessionResultGenerator(
         IdentityServerOptions options,
         IClock clock,
         IServerUrls urls,
         IMessageStore<LogoutMessage> logoutMessageStore)
-        : this(result)
     {
         _options = options;
         _clock = clock;
@@ -53,24 +57,9 @@ public class EndSessionResult : IEndpointResult
     private IServerUrls _urls;
     private IMessageStore<LogoutMessage> _logoutMessageStore;
 
-    private void Init(HttpContext context)
+    public async Task ExecuteAsync(EndSessionResult result, HttpContext context)
     {
-        _options = _options ?? context.RequestServices.GetRequiredService<IdentityServerOptions>();
-        _clock = _clock ?? context.RequestServices.GetRequiredService<IClock>();
-        _urls = _urls ?? context.RequestServices.GetRequiredService<IServerUrls>();
-        _logoutMessageStore = _logoutMessageStore ?? context.RequestServices.GetRequiredService<IMessageStore<LogoutMessage>>();
-    }
-
-    /// <summary>
-    /// Executes the result.
-    /// </summary>
-    /// <param name="context">The HTTP context.</param>
-    /// <returns></returns>
-    public async Task ExecuteAsync(HttpContext context)
-    {
-        Init(context);
-
-        var validatedRequest = _result.IsError ? null : _result.ValidatedRequest;
+        var validatedRequest = result.Result.IsError ? null : result.Result.ValidatedRequest;
 
         string id = null;
 

--- a/src/IdentityServer/Endpoints/Results/IntrospectionResult.cs
+++ b/src/IdentityServer/Endpoints/Results/IntrospectionResult.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 
@@ -15,7 +15,7 @@ namespace Duende.IdentityServer.Endpoints.Results;
 /// Result for introspection
 /// </summary>
 /// <seealso cref="IEndpointResult" />
-public class IntrospectionResult : IEndpointResult
+public class IntrospectionResult : EndpointResult<IntrospectionResult>
 {
     /// <summary>
     /// Gets the result.
@@ -34,16 +34,15 @@ public class IntrospectionResult : IEndpointResult
     {
         Entries = entries ?? throw new ArgumentNullException(nameof(entries));
     }
+}
 
-    /// <summary>
-    /// Executes the result.
-    /// </summary>
-    /// <param name="context">The HTTP context.</param>
-    /// <returns></returns>
-    public Task ExecuteAsync(HttpContext context)
+
+class IntrospectionResultGenerator : IEndpointResultGenerator<IntrospectionResult>
+{
+    public Task ExecuteAsync(IntrospectionResult result, HttpContext context)
     {
         context.Response.SetNoCache();
-            
-        return context.Response.WriteJsonAsync(Entries);
+
+        return context.Response.WriteJsonAsync(result.Entries);
     }
 }

--- a/src/IdentityServer/Endpoints/Results/JsonWebKeysResult.cs
+++ b/src/IdentityServer/Endpoints/Results/JsonWebKeysResult.cs
@@ -16,7 +16,7 @@ namespace Duende.IdentityServer.Endpoints.Results;
 /// Result for the jwks document
 /// </summary>
 /// <seealso cref="IEndpointResult" />
-public class JsonWebKeysResult : IEndpointResult
+public class JsonWebKeysResult : EndpointResult<JsonWebKeysResult>
 {
     /// <summary>
     /// Gets the web keys.
@@ -44,19 +44,17 @@ public class JsonWebKeysResult : IEndpointResult
         WebKeys = webKeys ?? throw new ArgumentNullException(nameof(webKeys));
         MaxAge = maxAge;
     }
+}
 
-    /// <summary>
-    /// Executes the result.
-    /// </summary>
-    /// <param name="context">The HTTP context.</param>
-    /// <returns></returns>
-    public Task ExecuteAsync(HttpContext context)
+class JsonWebKeysResultGenerator : IEndpointResultGenerator<JsonWebKeysResult>
+{
+    public Task ExecuteAsync(JsonWebKeysResult result, HttpContext context)
     {
-        if (MaxAge.HasValue && MaxAge.Value >= 0)
+        if (result.MaxAge.HasValue && result.MaxAge.Value >= 0)
         {
-            context.Response.SetCache(MaxAge.Value, "Origin");
+            context.Response.SetCache(result.MaxAge.Value, "Origin");
         }
 
-        return context.Response.WriteJsonAsync(new { keys = WebKeys }, "application/json; charset=UTF-8");
+        return context.Response.WriteJsonAsync(new { keys = result.WebKeys }, "application/json; charset=UTF-8");
     }
 }

--- a/src/IdentityServer/Endpoints/Results/ProtectedResourceErrorResult.cs
+++ b/src/IdentityServer/Endpoints/Results/ProtectedResourceErrorResult.cs
@@ -12,41 +12,61 @@ using IdentityModel;
 
 namespace Duende.IdentityServer.Endpoints.Results;
 
-internal class ProtectedResourceErrorResult : IEndpointResult
+/// <summary>
+/// Models result of a protected resource
+/// </summary>
+public class ProtectedResourceErrorResult : EndpointResult<ProtectedResourceErrorResult>
 {
-    public string Error;
-    public string ErrorDescription;
+    /// <summary>
+    /// The error
+    /// </summary>
+    public string Error { get; }
+    /// <summary>
+    /// The error description
+    /// </summary>
+    public string ErrorDescription { get; }
 
+    /// <summary>
+    /// Ctor
+    /// </summary>
+    /// <param name="error"></param>
+    /// <param name="errorDescription"></param>
     public ProtectedResourceErrorResult(string error, string errorDescription = null)
     {
         Error = error;
         ErrorDescription = errorDescription;
     }
+}
 
-    public Task ExecuteAsync(HttpContext context)
+internal class ProtectedResourceErrorResultGenerator : IEndpointResultGenerator<ProtectedResourceErrorResult>
+{
+    public Task ExecuteAsync(ProtectedResourceErrorResult result, HttpContext context)
     {
         context.Response.StatusCode = 401;
         context.Response.SetNoCache();
 
-        if (Constants.ProtectedResourceErrorStatusCodes.ContainsKey(Error))
+        var error = result.Error;
+        var errorDescription = result.ErrorDescription;
+
+        if (Constants.ProtectedResourceErrorStatusCodes.ContainsKey(error))
         {
-            context.Response.StatusCode = Constants.ProtectedResourceErrorStatusCodes[Error];
+            context.Response.StatusCode = Constants.ProtectedResourceErrorStatusCodes[error];
         }
 
-        if (Error == OidcConstants.ProtectedResourceErrors.ExpiredToken)
+        if (error == OidcConstants.ProtectedResourceErrors.ExpiredToken)
         {
-            Error = OidcConstants.ProtectedResourceErrors.InvalidToken;
-            ErrorDescription = "The access token expired";
+            error = OidcConstants.ProtectedResourceErrors.InvalidToken;
+            errorDescription = "The access token expired";
         }
 
-        var errorString = string.Format($"error=\"{Error}\"");
-        if (ErrorDescription.IsMissing())
+        var errorString = string.Format($"error=\"{error}\"");
+        if (errorDescription.IsMissing())
         {
             context.Response.Headers.Append(HeaderNames.WWWAuthenticate, new StringValues(new[] { "Bearer realm=\"IdentityServer\"", errorString }).ToString());
         }
         else
         {
-            var errorDescriptionString = string.Format($"error_description=\"{ErrorDescription}\"");
+            var errorDescriptionString = string.Format($"error_description=\"{errorDescription}\"");
             context.Response.Headers.Append(HeaderNames.WWWAuthenticate, new StringValues(new[] { "Bearer realm=\"IdentityServer\"", errorString, errorDescriptionString }).ToString());
         }
 

--- a/src/IdentityServer/Endpoints/Results/StatusCodeResult.cs
+++ b/src/IdentityServer/Endpoints/Results/StatusCodeResult.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 
@@ -13,7 +13,7 @@ namespace Duende.IdentityServer.Endpoints.Results;
 /// Result for a raw HTTP status code
 /// </summary>
 /// <seealso cref="IEndpointResult" />
-public class StatusCodeResult : IEndpointResult
+public class StatusCodeResult : EndpointResult<StatusCodeResult>
 {
     /// <summary>
     /// Gets the status code.
@@ -40,15 +40,13 @@ public class StatusCodeResult : IEndpointResult
     {
         StatusCode = statusCode;
     }
+}
 
-    /// <summary>
-    /// Executes the result.
-    /// </summary>
-    /// <param name="context">The HTTP context.</param>
-    /// <returns></returns>
-    public Task ExecuteAsync(HttpContext context)
+class StatusCodeResultGenerator : IEndpointResultGenerator<StatusCodeResult>
+{
+    public Task ExecuteAsync(StatusCodeResult result, HttpContext context)
     {
-        context.Response.StatusCode = StatusCode;
+        context.Response.StatusCode = result.StatusCode;
 
         return Task.CompletedTask;
     }

--- a/src/IdentityServer/Endpoints/Results/TokenErrorResult.cs
+++ b/src/IdentityServer/Endpoints/Results/TokenErrorResult.cs
@@ -14,33 +14,47 @@ using IdentityModel;
 
 namespace Duende.IdentityServer.Endpoints.Results;
 
-internal class TokenErrorResult : IEndpointResult
+/// <summary>
+/// Models a token error result
+/// </summary>
+public class TokenErrorResult : EndpointResult<TokenErrorResult>
 {
+    /// <summary>
+    /// The response
+    /// </summary>
     public TokenErrorResponse Response { get; }
 
+    /// <summary>
+    /// Ctor
+    /// </summary>
+    /// <param name="error"></param>
+    /// <exception cref="ArgumentNullException"></exception>
     public TokenErrorResult(TokenErrorResponse error)
     {
         if (error.Error.IsMissing()) throw new ArgumentNullException(nameof(error.Error), "Error must be set");
 
         Response = error;
     }
+}
 
-    public async Task ExecuteAsync(HttpContext context)
+internal class TokenErrorResultGenerator : IEndpointResultGenerator<TokenErrorResult>
+{
+    public async Task ExecuteAsync(TokenErrorResult result, HttpContext context)
     {
         context.Response.StatusCode = 400;
         context.Response.SetNoCache();
 
-        if (Response.DPoPNonce.IsPresent())
+        if (result.Response.DPoPNonce.IsPresent())
         {
-            context.Response.Headers[OidcConstants.HttpHeaders.DPoPNonce] = Response.DPoPNonce;
+            context.Response.Headers[OidcConstants.HttpHeaders.DPoPNonce] = result.Response.DPoPNonce;
         }
 
         var dto = new ResultDto
         {
-            error = Response.Error,
-            error_description = Response.ErrorDescription,
-                
-            custom = Response.Custom
+            error = result.Response.Error,
+            error_description = result.Response.ErrorDescription,
+
+            custom = result.Response.Custom
         };
 
         await context.Response.WriteJsonAsync(dto);
@@ -53,5 +67,5 @@ internal class TokenErrorResult : IEndpointResult
 
         [JsonExtensionData]
         public Dictionary<string, object> custom { get; set; }
-    }    
+    }
 }

--- a/src/IdentityServer/Endpoints/Results/TokenRevocationErrorResult.cs
+++ b/src/IdentityServer/Endpoints/Results/TokenRevocationErrorResult.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Http;
 using System.Net;
 using System.Threading.Tasks;
 using Duende.IdentityServer.Hosting;
+using System;
 
 namespace Duende.IdentityServer.Endpoints.Results;
 
@@ -14,7 +15,7 @@ namespace Duende.IdentityServer.Endpoints.Results;
 /// Result for revocation error
 /// </summary>
 /// <seealso cref="IEndpointResult" />
-public class TokenRevocationErrorResult : IEndpointResult
+public class TokenRevocationErrorResult : EndpointResult<TokenRevocationErrorResult>
 {
     /// <summary>
     /// Gets or sets the error.
@@ -22,7 +23,7 @@ public class TokenRevocationErrorResult : IEndpointResult
     /// <value>
     /// The error.
     /// </value>
-    public string Error { get; set; }
+    public string Error { get; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TokenRevocationErrorResult"/> class.
@@ -30,17 +31,15 @@ public class TokenRevocationErrorResult : IEndpointResult
     /// <param name="error">The error.</param>
     public TokenRevocationErrorResult(string error)
     {
-        Error = error;
+        Error = error ?? throw new ArgumentNullException(nameof(error));
     }
+}
 
-    /// <summary>
-    /// Executes the result.
-    /// </summary>
-    /// <param name="context">The HTTP context.</param>
-    /// <returns></returns>
-    public Task ExecuteAsync(HttpContext context)
+class TokenRevocationErrorResultGenerator : IEndpointResultGenerator<TokenRevocationErrorResult>
+{
+    public Task ExecuteAsync(TokenRevocationErrorResult result, HttpContext context)
     {
-        context.Response.StatusCode = (int)HttpStatusCode.BadRequest;
-        return context.Response.WriteJsonAsync(new { error = Error });
+        context.Response.StatusCode = (int) HttpStatusCode.BadRequest;
+        return context.Response.WriteJsonAsync(new { error = result.Error });
     }
 }

--- a/src/IdentityServer/Endpoints/Results/UserInfoResult.cs
+++ b/src/IdentityServer/Endpoints/Results/UserInfoResult.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 
@@ -7,21 +7,35 @@ using System.Threading.Tasks;
 using Duende.IdentityServer.Hosting;
 using Duende.IdentityServer.Extensions;
 using Microsoft.AspNetCore.Http;
+using System;
 
 namespace Duende.IdentityServer.Endpoints.Results;
 
-internal class UserInfoResult : IEndpointResult
+/// <summary>
+/// The result of userinfo 
+/// </summary>
+public class UserInfoResult : EndpointResult<UserInfoResult>
 {
-    public Dictionary<string, object> Claims;
+    /// <summary>
+    /// The claims
+    /// </summary>
+    public Dictionary<string, object> Claims { get; }
 
+    /// <summary>
+    /// Ctor
+    /// </summary>
+    /// <param name="claims"></param>
     public UserInfoResult(Dictionary<string, object> claims)
     {
-        Claims = claims;
+        Claims = claims ?? throw new ArgumentNullException(nameof(claims));
     }
+}
 
-    public async Task ExecuteAsync(HttpContext context)
+internal class UserInfoResultGenerator : IEndpointResultGenerator<UserInfoResult>
+{
+    public async Task ExecuteAsync(UserInfoResult result, HttpContext context)
     {
         context.Response.SetNoCache();
-        await context.Response.WriteJsonAsync(Claims);
+        await context.Response.WriteJsonAsync(result.Claims);
     }
 }

--- a/src/IdentityServer/Hosting/IEndpointResult.cs
+++ b/src/IdentityServer/Hosting/IEndpointResult.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 
@@ -19,3 +19,4 @@ public interface IEndpointResult
     /// <returns></returns>
     Task ExecuteAsync(HttpContext context);
 }
+

--- a/src/IdentityServer/Hosting/IEndpointResultGenerator.cs
+++ b/src/IdentityServer/Hosting/IEndpointResultGenerator.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+using Microsoft.AspNetCore.Http;
+using System.Threading.Tasks;
+
+namespace Duende.IdentityServer.Hosting;
+
+/// <summary>
+/// Endpoint result generator
+/// </summary>
+public interface IEndpointResultGenerator<in T>
+    where T : IEndpointResult
+{
+    /// <summary>
+    /// Writes the endpoint result to the HTTP response.
+    /// </summary>
+    Task ProcessAsync(T result, HttpContext context);
+}
+

--- a/src/IdentityServer/Hosting/IEndpointResultGenerator.cs
+++ b/src/IdentityServer/Hosting/IEndpointResultGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 
@@ -16,6 +16,6 @@ public interface IEndpointResultGenerator<in T>
     /// <summary>
     /// Writes the endpoint result to the HTTP response.
     /// </summary>
-    Task ProcessAsync(T result, HttpContext context);
+    Task ExecuteAsync(T result, HttpContext context);
 }
 

--- a/test/IdentityServer.UnitTests/Endpoints/EndSession/EndSessionCallbackResultTests.cs
+++ b/test/IdentityServer.UnitTests/Endpoints/EndSession/EndSessionCallbackResultTests.cs
@@ -19,7 +19,7 @@ public class EndSessionCallbackResultTests
 
     private readonly EndSessionCallbackValidationResult _validationResult;
     private readonly IdentityServerOptions _options;
-    private readonly EndSessionCallbackResult _subject;
+    private readonly EndSessionCallbackResultGenerator _subject;
 
     public EndSessionCallbackResultTests()
     {
@@ -28,7 +28,7 @@ public class EndSessionCallbackResultTests
             IsError = false,
         };
         _options = new IdentityServerOptions();
-        _subject = new EndSessionCallbackResult(_validationResult, _options);
+        _subject = new EndSessionCallbackResultGenerator(_options);
     }
 
     [Fact]
@@ -39,7 +39,7 @@ public class EndSessionCallbackResultTests
         var ctx = new DefaultHttpContext();
         ctx.Request.Method = "GET";
 
-        await _subject.ExecuteAsync(ctx);
+        await _subject.ExecuteAsync(new EndSessionCallbackResult(_validationResult), ctx);
 
         ctx.Response.Headers["Content-Security-Policy"].First().Should().Contain("frame-src http://foo");
     }
@@ -53,7 +53,7 @@ public class EndSessionCallbackResultTests
         var ctx = new DefaultHttpContext();
         ctx.Request.Method = "GET";
 
-        await _subject.ExecuteAsync(ctx);
+        await _subject.ExecuteAsync(new EndSessionCallbackResult(_validationResult), ctx);
 
         ctx.Response.Headers["Content-Security-Policy"].FirstOrDefault().Should().BeNull();
     }

--- a/test/IdentityServer.UnitTests/Endpoints/Results/AuthorizeResultTests.cs
+++ b/test/IdentityServer.UnitTests/Endpoints/Results/AuthorizeResultTests.cs
@@ -24,7 +24,7 @@ namespace UnitTests.Endpoints.Results;
 
 public class AuthorizeResultTests
 {
-    private AuthorizeResult _subject;
+    private AuthorizeResultGenerator _subject;
 
     private AuthorizeResponse _response = new AuthorizeResponse();
     private IdentityServerOptions _options = new IdentityServerOptions();
@@ -45,7 +45,7 @@ public class AuthorizeResultTests
         _options.UserInteraction.ErrorUrl = "~/error";
         _options.UserInteraction.ErrorIdParameter = "errorId";
 
-        _subject = new AuthorizeResult(_response, _options, _mockUserSession, _mockErrorMessageStore, _urls, new StubClock());
+        _subject = new AuthorizeResultGenerator(_options, _mockUserSession, _mockErrorMessageStore, _urls, new StubClock());
     }
 
     [Fact]
@@ -53,7 +53,7 @@ public class AuthorizeResultTests
     {
         _response.Error = "some_error";
 
-        await _subject.ExecuteAsync(_context);
+        await _subject.ExecuteAsync(new AuthorizeResult(_response), _context);
 
         _mockErrorMessageStore.Messages.Count.Should().Be(1);
         _context.Response.StatusCode.Should().Be(302);
@@ -78,7 +78,7 @@ public class AuthorizeResultTests
             PromptModes = new[] { "none" }
         };
 
-        await _subject.ExecuteAsync(_context);
+        await _subject.ExecuteAsync(new AuthorizeResult(_response), _context);
 
         _mockUserSession.Clients.Count.Should().Be(0);
         _context.Response.StatusCode.Should().Be(302);
@@ -102,7 +102,7 @@ public class AuthorizeResultTests
         };
         _response.SessionState = "some_session_state";
 
-        await _subject.ExecuteAsync(_context);
+        await _subject.ExecuteAsync(new AuthorizeResult(_response), _context);
 
         _mockUserSession.Clients.Count.Should().Be(0);
         _context.Response.StatusCode.Should().Be(302);
@@ -123,7 +123,7 @@ public class AuthorizeResultTests
             RedirectUri = "http://client/callback"
         };
 
-        await _subject.ExecuteAsync(_context);
+        await _subject.ExecuteAsync(new AuthorizeResult(_response), _context);
 
         _mockUserSession.Clients.Count.Should().Be(0);
         _context.Response.StatusCode.Should().Be(302);
@@ -147,7 +147,7 @@ public class AuthorizeResultTests
             RedirectUri = "http://client/callback"
         };
 
-        await _subject.ExecuteAsync(_context);
+        await _subject.ExecuteAsync(new AuthorizeResult(_response), _context);
 
         _mockUserSession.Clients.Should().Contain("client");
     }
@@ -163,7 +163,7 @@ public class AuthorizeResultTests
             State = "state"
         };
 
-        await _subject.ExecuteAsync(_context);
+        await _subject.ExecuteAsync(new AuthorizeResult(_response), _context);
 
         _context.Response.StatusCode.Should().Be(302);
         _context.Response.Headers["Cache-Control"].First().Should().Contain("no-store");
@@ -185,7 +185,7 @@ public class AuthorizeResultTests
             State = "state"
         };
 
-        await _subject.ExecuteAsync(_context);
+        await _subject.ExecuteAsync(new AuthorizeResult(_response), _context);
 
         _context.Response.StatusCode.Should().Be(302);
         _context.Response.Headers["Cache-Control"].First().Should().Contain("no-store");
@@ -207,7 +207,7 @@ public class AuthorizeResultTests
             State = "state"
         };
 
-        await _subject.ExecuteAsync(_context);
+        await _subject.ExecuteAsync(new AuthorizeResult(_response), _context);
 
         _context.Response.StatusCode.Should().Be(200);
         _context.Response.ContentType.Should().StartWith("text/html");
@@ -241,7 +241,7 @@ public class AuthorizeResultTests
 
         _options.Csp.Level = CspLevel.One;
 
-        await _subject.ExecuteAsync(_context);
+        await _subject.ExecuteAsync(new AuthorizeResult(_response), _context);
 
         _context.Response.Headers["Content-Security-Policy"].First().Should().Contain($"script-src 'unsafe-inline' '{IdentityServerConstants.ContentSecurityPolicyHashes.AuthorizeScript}'");
         _context.Response.Headers["X-Content-Security-Policy"].First().Should().Contain($"script-src 'unsafe-inline' '{IdentityServerConstants.ContentSecurityPolicyHashes.AuthorizeScript}'");
@@ -260,7 +260,7 @@ public class AuthorizeResultTests
 
         _options.Csp.AddDeprecatedHeader = false;
 
-        await _subject.ExecuteAsync(_context);
+        await _subject.ExecuteAsync(new AuthorizeResult(_response), _context);
 
         _context.Response.Headers["Content-Security-Policy"].First().Should().Contain($"script-src '{IdentityServerConstants.ContentSecurityPolicyHashes.AuthorizeScript}'");
         _context.Response.Headers["X-Content-Security-Policy"].Should().BeEmpty();

--- a/test/IdentityServer.UnitTests/Endpoints/Results/CheckSessionResultTests.cs
+++ b/test/IdentityServer.UnitTests/Endpoints/Results/CheckSessionResultTests.cs
@@ -17,7 +17,7 @@ namespace UnitTests.Endpoints.Results;
 
 public class CheckSessionResultTests
 {
-    private CheckSessionResult _subject;
+    private CheckSessionResultGenerator _subject;
 
     private IdentityServerOptions _options = new IdentityServerOptions();
 
@@ -31,13 +31,13 @@ public class CheckSessionResultTests
 
         _options.Authentication.CheckSessionCookieName = "foobar";
 
-        _subject = new CheckSessionResult(_options);
+        _subject = new CheckSessionResultGenerator(_options);
     }
 
     [Fact]
     public async Task should_pass_results_in_body()
     {
-        await _subject.ExecuteAsync(_context);
+        await _subject.ExecuteAsync(new CheckSessionResult(), _context);
 
         _context.Response.StatusCode.Should().Be(200);
         _context.Response.ContentType.Should().StartWith("text/html");
@@ -58,7 +58,7 @@ public class CheckSessionResultTests
     {
         _options.Csp.Level = CspLevel.One;
 
-        await _subject.ExecuteAsync(_context);
+        await _subject.ExecuteAsync(new CheckSessionResult(), _context);
 
         _context.Response.Headers["Content-Security-Policy"].First().Should().Contain($"script-src 'unsafe-inline' '{IdentityServerConstants.ContentSecurityPolicyHashes.CheckSessionScript}'");
         _context.Response.Headers["X-Content-Security-Policy"].First().Should().Contain($"script-src 'unsafe-inline' '{IdentityServerConstants.ContentSecurityPolicyHashes.CheckSessionScript}'");
@@ -69,7 +69,7 @@ public class CheckSessionResultTests
     {
         _options.Csp.AddDeprecatedHeader = false;
 
-        await _subject.ExecuteAsync(_context);
+        await _subject.ExecuteAsync(new CheckSessionResult(), _context);
 
         _context.Response.Headers["Content-Security-Policy"].First().Should().Contain($"script-src '{IdentityServerConstants.ContentSecurityPolicyHashes.CheckSessionScript}'");
         _context.Response.Headers["X-Content-Security-Policy"].Should().BeEmpty();
@@ -82,7 +82,7 @@ public class CheckSessionResultTests
     public async Task can_change_cached_cookiename(string cookieName)
     {
         _options.Authentication.CheckSessionCookieName = cookieName;
-        await _subject.ExecuteAsync(_context);
+        await _subject.ExecuteAsync(new CheckSessionResult(), _context);
         _context.Response.Body.Seek(0, SeekOrigin.Begin);
         using (var rdr = new StreamReader(_context.Response.Body))
         {

--- a/test/IdentityServer.UnitTests/Endpoints/Results/EndSessionCallbackResultTests.cs
+++ b/test/IdentityServer.UnitTests/Endpoints/Results/EndSessionCallbackResultTests.cs
@@ -18,7 +18,7 @@ namespace UnitTests.Endpoints.Results;
 
 public class EndSessionCallbackResultTests
 {
-    private EndSessionCallbackResult _subject;
+    private EndSessionCallbackResultGenerator _subject;
 
     private EndSessionCallbackValidationResult _result = new EndSessionCallbackValidationResult();
     private IdentityServerOptions _options = TestIdentityServerOptions.Create();
@@ -31,7 +31,7 @@ public class EndSessionCallbackResultTests
         _context.Request.Host = new HostString("server");
         _context.Response.Body = new MemoryStream();
 
-        _subject = new EndSessionCallbackResult(_result, _options);
+        _subject = new EndSessionCallbackResultGenerator(_options);
     }
 
     [Fact]
@@ -39,7 +39,7 @@ public class EndSessionCallbackResultTests
     {
         _result.IsError = true;
 
-        await _subject.ExecuteAsync(_context);
+        await _subject.ExecuteAsync(new EndSessionCallbackResult(_result), _context);
 
         _context.Response.StatusCode.Should().Be(400);
     }
@@ -50,7 +50,7 @@ public class EndSessionCallbackResultTests
         _result.IsError = false;
         _result.FrontChannelLogoutUrls = new string[] { "http://foo.com", "http://bar.com" };
 
-        await _subject.ExecuteAsync(_context);
+        await _subject.ExecuteAsync(new EndSessionCallbackResult(_result), _context);
 
         _context.Response.ContentType.Should().StartWith("text/html");
         _context.Response.Headers["Cache-Control"].First().Should().Contain("no-store");
@@ -78,7 +78,7 @@ public class EndSessionCallbackResultTests
 
         _options.Csp.Level = CspLevel.One;
 
-        await _subject.ExecuteAsync(_context);
+        await _subject.ExecuteAsync(new EndSessionCallbackResult(_result), _context);
 
         _context.Response.Headers["Content-Security-Policy"].First().Should().Contain("style-src 'unsafe-inline' 'sha256-e6FQZewefmod2S/5T11pTXjzE2vn3/8GRwWOs917YE4='");
         _context.Response.Headers["X-Content-Security-Policy"].First().Should().Contain("style-src 'unsafe-inline' 'sha256-e6FQZewefmod2S/5T11pTXjzE2vn3/8GRwWOs917YE4='");
@@ -91,7 +91,7 @@ public class EndSessionCallbackResultTests
 
         _options.Csp.AddDeprecatedHeader = false;
 
-        await _subject.ExecuteAsync(_context);
+        await _subject.ExecuteAsync(new EndSessionCallbackResult(_result), _context);
 
         _context.Response.Headers["Content-Security-Policy"].First().Should().Contain("style-src 'sha256-e6FQZewefmod2S/5T11pTXjzE2vn3/8GRwWOs917YE4='");
         _context.Response.Headers["X-Content-Security-Policy"].Should().BeEmpty();

--- a/test/IdentityServer.UnitTests/Endpoints/Results/EndSessionResultTests.cs
+++ b/test/IdentityServer.UnitTests/Endpoints/Results/EndSessionResultTests.cs
@@ -20,7 +20,7 @@ namespace UnitTests.Endpoints.Results;
 
 public class EndSessionResultTests
 {
-    private EndSessionResult _subject;
+    private EndSessionResultGenerator _subject;
 
     private EndSessionValidationResult _result = new EndSessionValidationResult();
     private IdentityServerOptions _options = new IdentityServerOptions();
@@ -39,7 +39,7 @@ public class EndSessionResultTests
         _options.UserInteraction.LogoutUrl = "~/logout";
         _options.UserInteraction.LogoutIdParameter = "logoutId";
 
-        _subject = new EndSessionResult(_result, _options, new StubClock(), _urls, _mockLogoutMessageStore);
+        _subject = new EndSessionResultGenerator(_options, new StubClock(), _urls, _mockLogoutMessageStore);
     }
 
     [Fact]
@@ -55,7 +55,7 @@ public class EndSessionResultTests
             PostLogOutUri = "http://client/post-logout-callback"
         };
 
-        await _subject.ExecuteAsync(_context);
+        await _subject.ExecuteAsync(new EndSessionResult(_result), _context);
 
         _mockLogoutMessageStore.Messages.Count.Should().Be(1);
         var location = _context.Response.Headers["Location"].Single();
@@ -70,7 +70,7 @@ public class EndSessionResultTests
     {
         _result.IsError = false;
 
-        await _subject.ExecuteAsync(_context);
+        await _subject.ExecuteAsync(new EndSessionResult(_result), _context);
 
         _mockLogoutMessageStore.Messages.Count.Should().Be(0);
         var location = _context.Response.Headers["Location"].Single();
@@ -93,7 +93,7 @@ public class EndSessionResultTests
             PostLogOutUri = "http://client/post-logout-callback"
         };
 
-        await _subject.ExecuteAsync(_context);
+        await _subject.ExecuteAsync(new EndSessionResult(_result), _context);
 
         _mockLogoutMessageStore.Messages.Count.Should().Be(0);
         var location = _context.Response.Headers["Location"].Single();


### PR DESCRIPTION
This PR introduces the `IEndpointResultGenerator<T>` type which is designed to render the `IEndpointResult` objects that are returned from the `IEndpointHandler` in our endpoint routing architecture.

Previously the `IEndpointResult` would render themselves, but was difficult for customers to override or change how they did this. Now our built in `IEndpointResult` classes use a new base class `EndpointResult` which will resolve a `IEndpointResultGenerator<T>` from DI to do the rendering. This allows customers to register their own `IEndpointResultGenerator<T>` and can change how they are rendered to the HTTP response.

This PR is also designed to be backwards compatible with the prior approach, such that any custom `IEndpointResult` or `IEndpointHandler` should still work the way they used to. 

Closes: https://github.com/DuendeSoftware/IdentityServer/issues/1129

Replaces: https://github.com/DuendeSoftware/IdentityServer/pull/1330