### PR TITLE
Fix log messages in backchannel user validator

### DIFF
--- a/src/IdentityServer/Validation/Default/BackchannelAuthenticationRequestValidator.cs
+++ b/src/IdentityServer/Validation/Default/BackchannelAuthenticationRequestValidator.cs
@@ -447,7 +447,7 @@ internal class BackchannelAuthenticationRequestValidator : IBackchannelAuthentic
             var payloadClientId = jwtRequestValidationResult.Payload.SingleOrDefault(x => x.Type == JwtClaimTypes.ClientId)?.Value;
             if (payloadClientId.IsPresent() && _validatedRequest.Client.ClientId != payloadClientId)
             {
-                LogError("client_id found in the JWT request object does not match client_id used to authenticate", new { invalidClientId = payloadClientId, clientId = _validatedRequest.Client.ClientId });
+                LogError("client_id found in the JWT request object does not match client_id used to authenticate, {@values}", new { invalidClientId = payloadClientId, clientId = _validatedRequest.Client.ClientId });
                 return (false, Invalid(OidcConstants.AuthorizeErrors.InvalidRequestObject, "Invalid client_id in JWT request"));
             }
 
@@ -509,7 +509,7 @@ internal class BackchannelAuthenticationRequestValidator : IBackchannelAuthentic
                 }
                 else
                 {
-                    _logger.Log(logLevel, message + "{@values}, details: {@details}", values, details);
+                    _logger.Log(logLevel, message + ", details: {@details}", values, details);
                 }
 
             }


### PR DESCRIPTION
This fixes #1345, which happened because the passed in log message contained a placeholder, and LogWithRequestDetails also added a placeholder for the values, resulting in too many placeholders.

The fix is to remove the extra placeholder from LogWithRequestDetails and review all calls to it to ensure the passed log message always contains placeholders for the values.

