### PR TITLE
Remove raw exception from unhandled exception event

### DIFF
--- a/src/IdentityServer/Events/UnhandledExceptionEvent.cs
+++ b/src/IdentityServer/Events/UnhandledExceptionEvent.cs
@@ -23,7 +23,6 @@ public class UnhandledExceptionEvent : Event
             EventIds.UnhandledException,
             ex.Message)
     {
-        Exception = ex;
         Details = ex.ToString();
     }
 
@@ -34,12 +33,4 @@ public class UnhandledExceptionEvent : Event
     /// The details.
     /// </value>
     public string Details { get; set; }
-
-    /// <summary>
-    /// Gets or sets the exception.
-    /// </summary>
-    /// <value>
-    /// The exception.
-    /// </value>
-    public Exception Exception { get; set; }
 }

--- a/test/IdentityServer.UnitTests/Events/EventTests.cs
+++ b/test/IdentityServer.UnitTests/Events/EventTests.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Duende.IdentityServer.Configuration;
+using Duende.IdentityServer.Endpoints.Results;
+using Duende.IdentityServer.Models;
+using Duende.IdentityServer.ResponseHandling;
+using Duende.IdentityServer.Validation;
+using FluentAssertions;
+using IdentityModel;
+using UnitTests.Common;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.WebUtilities;
+using Xunit;
+using Duende.IdentityServer.Services;
+using Duende.IdentityServer;
+using Duende.IdentityServer.Events;
+
+namespace UnitTests.Endpoints.Results;
+
+public class EventTests
+{
+
+    [Fact]
+    public void UnhandledExceptionEventCanCallToString()
+    {
+        try
+        {
+            throw new Exception();
+        }
+        catch (Exception ex)
+        {
+            var unhandledExceptionEvent = new UnhandledExceptionEvent(ex);
+
+            var s = unhandledExceptionEvent.ToString();
+
+            s.Should().NotBeNullOrEmpty();
+        }
+    }
+}

--- a/test/IdentityServer.UnitTests/Events/EventTests.cs
+++ b/test/IdentityServer.UnitTests/Events/EventTests.cs
@@ -31,7 +31,7 @@ public class EventTests
     {
         try
         {
-            throw new Exception();
+            throw new InvalidOperationException("Boom");
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
This would fix #1362. Seems a bit heavy-handed to just completely remove the exception, but it can't be serialized anyway so I don't think we're losing much.