### PR TITLE
Introducing Refresh Token Leakage Detection Event

### DIFF
--- a/src/IdentityServer/Configuration/DependencyInjection/Options/EventsOptions.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/Options/EventsOptions.cs
@@ -41,4 +41,12 @@ public class EventsOptions
     ///   <c>true</c> if error events should be raised; otherwise, <c>false</c>.
     /// </value>
     public bool RaiseErrorEvents { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to raise error events.
+    /// </summary>
+    /// <value>
+    ///   <c>true</c> if error events should be raised; otherwise, <c>false</c>.
+    /// </value>
+    public bool RaiseWarningEvents { get; set; } = false;
 }

--- a/src/IdentityServer/Events/Infrastructure/EventIds.cs
+++ b/src/IdentityServer/Events/Infrastructure/EventIds.cs
@@ -18,7 +18,7 @@ public static class EventIds
 
     public const int ClientAuthenticationSuccess = AuthenticationEventsStart + 10;
     public const int ClientAuthenticationFailure = AuthenticationEventsStart + 11;
-        
+
     public const int ApiAuthenticationSuccess = AuthenticationEventsStart + 20;
     public const int ApiAuthenticationFailure = AuthenticationEventsStart + 21;
 
@@ -34,7 +34,7 @@ public static class EventIds
 
     public const int TokenIntrospectionSuccess = TokenEventsStart + 20;
     public const int TokenIntrospectionFailure = TokenEventsStart + 21;
-        
+
     //////////////////////////////////////////////////////
     /// Error related events
     //////////////////////////////////////////////////////
@@ -68,4 +68,9 @@ public static class EventIds
 
     public const int BackchannelAuthenticationSuccess = BackchannelAuthenticationEventsStart + 0;
     public const int BackchannelAuthenticationFailure = BackchannelAuthenticationEventsStart + 1;
+
+    //////////////////////////////////////////////////////
+    /// Token usage related events
+    //////////////////////////////////////////////////////
+    public const int TokenMissuseEvent = 7000;
 }

--- a/src/IdentityServer/Events/Infrastructure/EventType.cs
+++ b/src/IdentityServer/Events/Infrastructure/EventType.cs
@@ -27,5 +27,10 @@ public enum EventTypes
     /// <summary>
     /// Error event
     /// </summary>
-    Error = 4
+    Error = 4,
+
+    /// <summary>
+    /// Warning event
+    /// </summary>
+    Warning = 5
 }

--- a/src/IdentityServer/Events/RefreshTokenDoubleSpentEvent.cs
+++ b/src/IdentityServer/Events/RefreshTokenDoubleSpentEvent.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+using Duende.IdentityServer.Models;
+
+namespace Duende.IdentityServer.Events;
+
+/// <summary>
+/// Event for double spent refresh token
+/// </summary>
+/// <seealso cref="Event" />
+public class RefreshTokenDoubleSpentEvent : Event
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConsentGrantedEvent" /> class.
+    /// </summary>
+    /// <param name="subjectId">The subject identifier.</param>
+    /// <param name="clientId">The client identifier.</param>
+    /// <param name="refreshTokenHandle">The consumed refresh token handle.</param>
+    public RefreshTokenDoubleSpentEvent(string subjectId, string refreshTokenHandle, string clientId)
+        : base(EventCategories.Error,
+            "Refresh token misused",
+            EventTypes.Error,
+            EventIds.TokenIssuedFailure)
+    {
+        SubjectId = subjectId;
+        ClientId = clientId;
+        RefreshTokenHandle = refreshTokenHandle;
+    }
+
+    /// <summary>
+    /// Gets or sets the subject identifier.
+    /// </summary>
+    /// <value>
+    /// The subject identifier.
+    /// </value>
+    public string SubjectId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the client ID.
+    /// </summary>
+    /// <value>
+    /// The client identifier.
+    /// </value>
+    public string ClientId { get; set; }
+
+
+    /// <summary>
+    /// Consumed Refresh Token Handle
+    /// </summary>
+    /// <value>
+    /// RefreshTokenHandle
+    /// </value>
+    public string RefreshTokenHandle { get; }
+}

--- a/src/IdentityServer/Events/RefreshTokenDoubleSpentEvent.cs
+++ b/src/IdentityServer/Events/RefreshTokenDoubleSpentEvent.cs
@@ -21,8 +21,8 @@ public class RefreshTokenDoubleSpentEvent : Event
     public RefreshTokenDoubleSpentEvent(string subjectId, string refreshTokenHandle, string clientId)
         : base(EventCategories.Error,
             "Refresh token misused",
-            EventTypes.Error,
-            EventIds.TokenIssuedFailure)
+            EventTypes.Warning,
+            EventIds.TokenMissuseEvent)
     {
         SubjectId = subjectId;
         ClientId = clientId;

--- a/src/IdentityServer/Services/Default/DefaultEventService.cs
+++ b/src/IdentityServer/Services/Default/DefaultEventService.cs
@@ -87,6 +87,8 @@ public class DefaultEventService : IEventService
                 return Options.Events.RaiseSuccessEvents;
             case EventTypes.Error:
                 return Options.Events.RaiseErrorEvents;
+            case EventTypes.Warning:
+                return Options.Events.RaiseWarningEvents;
             default:
                 throw new ArgumentOutOfRangeException(nameof(evtType));
         }

--- a/test/IdentityServer.UnitTests/Services/Default/DefaultRefreshTokenServiceTests.cs
+++ b/test/IdentityServer.UnitTests/Services/Default/DefaultRefreshTokenServiceTests.cs
@@ -20,6 +20,7 @@ namespace UnitTests.Services.Default;
 public class DefaultRefreshTokenServiceTests
 {
     private DefaultRefreshTokenService _subject;
+    private TestEventService _fakeEventService = new TestEventService();
     private DefaultRefreshTokenStore _store;
     private PersistentGrantOptions _options;
 
@@ -35,9 +36,10 @@ public class DefaultRefreshTokenServiceTests
             new PersistentGrantSerializer(),
             new DefaultHandleGenerationService(),
             TestLogger.Create<DefaultRefreshTokenStore>());
-
+        
         _subject = new DefaultRefreshTokenService(
             _store, 
+            _fakeEventService,
             new TestProfileService(),
             _clock,
             _options,


### PR DESCRIPTION
Hello there,

I am excited to contribute to Duende Identity Server by proposing some feature improvements. These enhancements aim to meet our specific requirements while also aligning with the OAuth 2.0 standard.

Problem:
One crucial area that requires attention is Refresh Token Protection. According to the OAuth standard (as mentioned in [this link](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics-13#section-4.12)), the leakage of a refresh token can have significant consequences, depending on the scale of the problem. However, Duende currently lacks a module or specific event dedicated to handling this issue or at least detecting that

Proposed Solution:
To address this gap, I suggest raising an event in case of refresh token misuse or double spend. This feature would focus on detection not prevention. By raising an event when double spending of a refresh token occurs, the developers gain flexibility in their codebase. Additionally, they can capture valuable information such as the IP address, communication channel, and subject concurrently with the event. The decision on how to handle this event can be delegated to the application, as it falls under our application's responsibility rather than Duende's.

Further Considerations:
I would like to clarify that double spending, in this context, does not pertain to whether or not we accept double consumed tokens. We have the option to either accept or reject multiple consumed refresh tokens, and we can keep a count of them for use in other decision-making processes.

I believe that by introducing this Refresh Token Leakage Detection and Prevention feature, developers can greatly enhance the security and flexibility of their codes and Duende Identity Server, while adhering to established standards.

Thank you for considering this contribution.