### PR TITLE
Consistent X-Frame-Options/CSP

### DIFF
--- a/hosts/AspNetIdentity/Pages/SecurityHeadersAttribute.cs
+++ b/hosts/AspNetIdentity/Pages/SecurityHeadersAttribute.cs
@@ -24,7 +24,7 @@ public sealed class SecurityHeadersAttribute : ActionFilterAttribute
             // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
             if (!context.HttpContext.Response.Headers.ContainsKey("X-Frame-Options"))
             {
-                context.HttpContext.Response.Headers.Append("X-Frame-Options", "SAMEORIGIN");
+                context.HttpContext.Response.Headers.Append("X-Frame-Options", "DENY");
             }
 
             // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy

--- a/hosts/Configuration/Pages/SecurityHeadersAttribute.cs
+++ b/hosts/Configuration/Pages/SecurityHeadersAttribute.cs
@@ -24,7 +24,7 @@ public sealed class SecurityHeadersAttribute : ActionFilterAttribute
             // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
             if (!context.HttpContext.Response.Headers.ContainsKey("X-Frame-Options"))
             {
-                context.HttpContext.Response.Headers.Append("X-Frame-Options", "SAMEORIGIN");
+                context.HttpContext.Response.Headers.Append("X-Frame-Options", "DENY");
             }
 
             // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy

--- a/hosts/EntityFramework/Pages/SecurityHeadersAttribute.cs
+++ b/hosts/EntityFramework/Pages/SecurityHeadersAttribute.cs
@@ -24,7 +24,7 @@ public sealed class SecurityHeadersAttribute : ActionFilterAttribute
             // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
             if (!context.HttpContext.Response.Headers.ContainsKey("X-Frame-Options"))
             {
-                context.HttpContext.Response.Headers.Append("X-Frame-Options", "SAMEORIGIN");
+                context.HttpContext.Response.Headers.Append("X-Frame-Options", "DENY");
             }
 
             // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy

--- a/hosts/main/Pages/SecurityHeadersAttribute.cs
+++ b/hosts/main/Pages/SecurityHeadersAttribute.cs
@@ -24,7 +24,7 @@ public sealed class SecurityHeadersAttribute : ActionFilterAttribute
             // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
             if (!context.HttpContext.Response.Headers.ContainsKey("X-Frame-Options"))
             {
-                context.HttpContext.Response.Headers.Append("X-Frame-Options", "SAMEORIGIN");
+                context.HttpContext.Response.Headers.Append("X-Frame-Options", "DENY");
             }
 
             // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy


### PR DESCRIPTION
- Use X-Frame-Options DENY to be consistent with csp frame-ancestors 'none'