### PR TITLE
Upgrade FluentAssertions from 5.10.1 to 6.5.1

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -32,7 +32,7 @@
         <PackageReference Update="Bullseye" Version="4.2.1"/>
 
         <!--tests -->
-        <PackageReference Update="FluentAssertions" Version="5.10.3"/>
+        <PackageReference Update="FluentAssertions" Version="6.5.1"/>
         <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
         <PackageReference Update="xunit" Version="2.5.0"/>
         <PackageReference Update="xunit.runner.visualstudio" Version="2.5.0" PrivateAssets="All"/>

--- a/test/EntityFramework.Storage.IntegrationTests/Stores/DeviceFlowStoreTests.cs
+++ b/test/EntityFramework.Storage.IntegrationTests/Stores/DeviceFlowStoreTests.cs
@@ -88,7 +88,7 @@ public class DeviceFlowStoreTests : IntegrationTest<DeviceFlowStoreTests, Persis
             foundDeviceFlowCodes.Should().NotBeNull();
             var deserializedData = new PersistentGrantSerializer().Deserialize<DeviceCode>(foundDeviceFlowCodes?.Data);
 
-            deserializedData.CreationTime.Should().BeCloseTo(data.CreationTime);
+            deserializedData.CreationTime.Should().BeCloseTo(data.CreationTime, TimeSpan.FromMicroseconds(1));
             deserializedData.ClientId.Should().Be(data.ClientId);
             deserializedData.Lifetime.Should().Be(data.Lifetime);
         }

--- a/test/IdentityServer.IntegrationTests/Endpoints/Authorize/AuthorizeTests.cs
+++ b/test/IdentityServer.IntegrationTests/Endpoints/Authorize/AuthorizeTests.cs
@@ -1159,7 +1159,7 @@ public class AuthorizeTests
             nonce: "123_nonce");
 
         Func<Task> a = () => _mockPipeline.BrowserClient.GetAsync(url);
-        a.Should().Throw<Exception>();
+        await a.Should().ThrowAsync<Exception>();
     }
 
     [Fact]

--- a/test/IdentityServer.IntegrationTests/TestFramework/GenericHost.cs
+++ b/test/IdentityServer.IntegrationTests/TestFramework/GenericHost.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Reflection;
 using System.Security.Claims;
@@ -132,7 +133,7 @@ public class GenericHost
     public async Task RevokeSessionCookieAsync()
     {
         var response = await BrowserClient.GetAsync(Url("__signout"));
-        response.StatusCode.Should().Be(204);
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
     }
 
 
@@ -166,7 +167,7 @@ public class GenericHost
     {
         _userToSignIn = new ClaimsPrincipal(new ClaimsIdentity(claims, "test", "name", "role"));
         var response = await BrowserClient.GetAsync(Url("__signin"));
-        response.StatusCode.Should().Be(204);
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
     }
     public Task IssueSessionCookieAsync(AuthenticationProperties props, params Claim[] claims)
     {

--- a/test/IdentityServer.IntegrationTests/TestFramework/TestBrowserClient.cs
+++ b/test/IdentityServer.IntegrationTests/TestFramework/TestBrowserClient.cs
@@ -92,7 +92,7 @@ public class TestBrowserClient : HttpClient
 
     public async Task FollowRedirectAsync()
     {
-        LastResponse.StatusCode.Should().Be(302);
+        LastResponse.StatusCode.Should().Be(HttpStatusCode.Found);
         var location = LastResponse.Headers.Location.ToString();
         await GetAsync(location);
     }

--- a/test/IdentityServer.UnitTests/Extensions/IResourceStoreExtensionsTests.cs
+++ b/test/IdentityServer.UnitTests/Extensions/IResourceStoreExtensionsTests.cs
@@ -16,7 +16,7 @@ namespace UnitTests.Extensions;
 public class IResourceStoreExtensionsTests
 {
     [Fact]
-    public void GetAllEnabledResourcesAsync_on_duplicate_identity_scopes_should_fail()
+    public async Task GetAllEnabledResourcesAsync_on_duplicate_identity_scopes_should_fail()
     {
         var store = new MockResourceStore()
         {
@@ -26,7 +26,7 @@ public class IResourceStoreExtensionsTests
         };
 
         Func<Task> a = () => store.GetAllEnabledResourcesAsync();
-        a.Should().Throw<Exception>().And.Message.ToLowerInvariant().Should().Contain("duplicate").And.Contain("identity scopes");
+        await a.Should().ThrowAsync<Exception>().WithMessage("duplicate identity scopes*");
     }
 
     [Fact]
@@ -43,7 +43,7 @@ public class IResourceStoreExtensionsTests
     }
 
     [Fact]
-    public void GetAllEnabledResourcesAsync_on_duplicate_api_resources_should_fail()
+    public async Task GetAllEnabledResourcesAsync_on_duplicate_api_resources_should_fail()
     {
         var store = new MockResourceStore()
         {
@@ -51,7 +51,7 @@ public class IResourceStoreExtensionsTests
         };
 
         Func<Task> a = () => store.GetAllEnabledResourcesAsync();
-        a.Should().Throw<Exception>().And.Message.ToLowerInvariant().Should().Contain("duplicate").And.Contain("api resources");
+        await a.Should().ThrowAsync<Exception>().WithMessage("duplicate api resources*");
     }
 
     [Fact]
@@ -66,7 +66,7 @@ public class IResourceStoreExtensionsTests
     }
 
     [Fact]
-    public void FindResourcesByScopeAsync_on_duplicate_identity_scopes_should_fail()
+    public async Task FindResourcesByScopeAsync_on_duplicate_identity_scopes_should_fail()
     {
         var store = new MockResourceStore()
         {
@@ -76,7 +76,7 @@ public class IResourceStoreExtensionsTests
         };
 
         Func<Task> a = () => store.FindResourcesByScopeAsync(new string[] { "A" });
-        a.Should().Throw<Exception>().And.Message.ToLowerInvariant().Should().Contain("duplicate").And.Contain("identity scopes");
+        await a.Should().ThrowAsync<Exception>().WithMessage("duplicate identity scopes*");
     }
 
     [Fact]

--- a/test/IdentityServer.UnitTests/ResponseHandling/AuthorizeInteractionResponseGenerator/AuthorizeInteractionResponseGeneratorTests_Consent.cs
+++ b/test/IdentityServer.UnitTests/ResponseHandling/AuthorizeInteractionResponseGenerator/AuthorizeInteractionResponseGeneratorTests_Consent.cs
@@ -108,11 +108,11 @@ public class AuthorizeInteractionResponseGeneratorTests_Consent
 
 
     [Fact]
-    public void ProcessConsentAsync_NullRequest_Throws()
+    public async Task ProcessConsentAsync_NullRequest_Throws()
     {
         Func<Task> act = () => _subject.ProcessConsentAsync(null, new ConsentResponse());
 
-        act.Should().Throw<ArgumentNullException>()
+        (await act.Should().ThrowAsync<ArgumentNullException>())
             .And.ParamName.Should().Be("request");
     }
         
@@ -132,7 +132,7 @@ public class AuthorizeInteractionResponseGeneratorTests_Consent
     }
 
     [Fact]
-    public void ProcessConsentAsync_PromptModeIsLogin_Throws()
+    public async Task ProcessConsentAsync_PromptModeIsLogin_Throws()
     {
         RequiresConsent(true);
         var request = new ValidatedAuthorizeRequest()
@@ -147,12 +147,12 @@ public class AuthorizeInteractionResponseGeneratorTests_Consent
 
         Func<Task> act = () => _subject.ProcessConsentAsync(request);
 
-        act.Should().Throw<ArgumentException>()
-            .And.Message.Should().Contain("PromptMode");
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*PromptMode*");
     }
 
     [Fact]
-    public void ProcessConsentAsync_PromptModeIsSelectAccount_Throws()
+    public async Task ProcessConsentAsync_PromptModeIsSelectAccount_Throws()
     {
         RequiresConsent(true);
         var request = new ValidatedAuthorizeRequest()
@@ -167,8 +167,8 @@ public class AuthorizeInteractionResponseGeneratorTests_Consent
 
         Func<Task> act = () => _subject.ProcessConsentAsync(request);
 
-        act.Should().Throw<ArgumentException>()
-            .And.Message.Should().Contain("PromptMode");
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*PromptMode*");
     }
 
 

--- a/test/IdentityServer.UnitTests/ResponseHandling/DeviceAuthorizationResponseGeneratorTests.cs
+++ b/test/IdentityServer.UnitTests/ResponseHandling/DeviceAuthorizationResponseGeneratorTests.cs
@@ -53,25 +53,25 @@ public class DeviceAuthorizationResponseGeneratorTests
     }
 
     [Fact]
-    public void ProcessAsync_when_valiationresult_null_exect_exception()
+    public async Task ProcessAsync_when_validationresult_null_expect_exception()
     {
         Func<Task> act = () => generator.ProcessAsync(null, TestBaseUrl);
-        act.Should().Throw<ArgumentNullException>();
+        await act.Should().ThrowAsync<ArgumentNullException>();
     }
 
     [Fact]
-    public void ProcessAsync_when_valiationresult_client_null_exect_exception()
+    public async Task ProcessAsync_when_validationresult_client_null_expect_exception()
     {
         var validationResult = new DeviceAuthorizationRequestValidationResult(new ValidatedDeviceAuthorizationRequest());
         Func <Task> act = () => generator.ProcessAsync(validationResult, TestBaseUrl);
-        act.Should().Throw<ArgumentNullException>();
+        await act.Should().ThrowAsync<ArgumentNullException>();
     }
 
     [Fact]
-    public void ProcessAsync_when_baseurl_null_exect_exception()
+    public async Task ProcessAsync_when_baseurl_null_expect_exception()
     {
         Func<Task> act = () => generator.ProcessAsync(testResult, null);
-        act.Should().Throw<ArgumentException>();
+        await act.Should().ThrowAsync<ArgumentException>();
     }
 
     [Fact]

--- a/test/IdentityServer.UnitTests/ResponseHandling/UserInfoResponseGeneratorTests.cs
+++ b/test/IdentityServer.UnitTests/ResponseHandling/UserInfoResponseGeneratorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 
@@ -190,7 +190,7 @@ public class UserInfoResponseGeneratorTests
     }
 
     [Fact]
-    public void ProcessAsync_should_throw_if_incorrect_sub_issued_by_profile_service()
+    public async Task ProcessAsync_should_throw_if_incorrect_sub_issued_by_profile_service()
     {
         _identityResources.Add(new IdentityResource("id1", new[] { "foo" }));
         _identityResources.Add(new IdentityResource("id2", new[] { "bar" }));
@@ -216,8 +216,8 @@ public class UserInfoResponseGeneratorTests
 
         Func<Task> act = () => _subject.ProcessAsync(result);
 
-        act.Should().Throw<InvalidOperationException>()
-            .And.Message.Should().Contain("subject");
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*subject*");
     }
 
 }

--- a/test/IdentityServer.UnitTests/Services/Default/DefaultBackchannelAuthenticationInteractionServiceTests.cs
+++ b/test/IdentityServer.UnitTests/Services/Default/DefaultBackchannelAuthenticationInteractionServiceTests.cs
@@ -141,7 +141,7 @@ public class DefaultBackchannelAuthenticationInteractionServiceTests
         var requestId = await _mockStore.CreateRequestAsync(req);
 
         Func<Task> f = async () => await _subject.CompleteLoginRequestAsync(null);
-        f.Should().Throw<ArgumentNullException>();
+        await f.Should().ThrowAsync<ArgumentNullException>();
     }
 
     [Fact]
@@ -170,7 +170,7 @@ public class DefaultBackchannelAuthenticationInteractionServiceTests
                 AuthenticationMethods = { "phone", "pin" }
             }.CreatePrincipal()
         });
-        f.Should().Throw<InvalidOperationException>().WithMessage("More scopes consented than originally requested.");
+        await f.Should().ThrowAsync<InvalidOperationException>().WithMessage("More scopes consented than originally requested.");
     }
 
     [Fact]
@@ -199,7 +199,7 @@ public class DefaultBackchannelAuthenticationInteractionServiceTests
                 AuthenticationMethods = { "phone", "pin" }
             }.CreatePrincipal()
         });
-        f.Should().Throw<InvalidOperationException>().WithMessage("User's subject id: 'invalid' does not match subject id for backchannel authentication request: '123'.");
+        await f.Should().ThrowAsync<InvalidOperationException>().WithMessage("User's subject id: 'invalid' does not match subject id for backchannel authentication request: '123'.");
     }
 
     [Fact]
@@ -227,7 +227,7 @@ public class DefaultBackchannelAuthenticationInteractionServiceTests
             //    AuthenticationMethods = { "phone", "pin" }
             //}.CreatePrincipal()
         });
-        f.Should().Throw<InvalidOperationException>().WithMessage("Invalid subject.");
+        await f.Should().ThrowAsync<InvalidOperationException>().WithMessage("Invalid subject.");
     }
 
     [Fact]
@@ -255,7 +255,7 @@ public class DefaultBackchannelAuthenticationInteractionServiceTests
                 AuthenticationMethods = { "phone", "pin" }
             }.CreatePrincipal()
         });
-        f.Should().Throw<InvalidOperationException>().WithMessage("Invalid backchannel authentication request id.");
+        await f.Should().ThrowAsync<InvalidOperationException>().WithMessage("Invalid backchannel authentication request id.");
     }
 
     [Fact]

--- a/test/IdentityServer.UnitTests/Services/Default/DefaultIdentityServerInteractionServiceTests.cs
+++ b/test/IdentityServer.UnitTests/Services/Default/DefaultIdentityServerInteractionServiceTests.cs
@@ -111,15 +111,15 @@ public class DefaultIdentityServerInteractionServiceTests
     }
 
     [Fact]
-    public void GrantConsentAsync_should_throw_if_granted_and_no_subject()
+    public async Task GrantConsentAsync_should_throw_if_granted_and_no_subject()
     {
         Func<Task> act = () => _subject.GrantConsentAsync(
             new AuthorizationRequest(), 
             new ConsentResponse() { ScopesValuesConsented = new[] { "openid" } }, 
             null);
-
-        act.Should().Throw<ArgumentNullException>()
-            .And.Message.Should().Contain("subject");
+        
+        await act.Should().ThrowAsync<ArgumentNullException>()
+            .WithMessage("*subject*");
     }
 
     [Fact]

--- a/test/IdentityServer.UnitTests/Services/Default/DistributedDeviceFlowThrottlingServiceTests.cs
+++ b/test/IdentityServer.UnitTests/Services/Default/DistributedDeviceFlowThrottlingServiceTests.cs
@@ -109,7 +109,7 @@ public class DistributedDeviceFlowThrottlingServiceTests
         var dateTime = DateTime.Parse(dateTimeAsString).ToUniversalTime();
         dateTime.Should().Be(testDate);
 
-        values?.Item2.AbsoluteExpiration.Should().BeCloseTo(testDate.AddSeconds(deviceCode.Lifetime));
+        values?.Item2.AbsoluteExpiration.Should().BeCloseTo(testDate.AddSeconds(deviceCode.Lifetime), TimeSpan.FromMicroseconds(1));
     }
 }
 

--- a/test/IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ProtocolValidation_Invalid.cs
+++ b/test/IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ProtocolValidation_Invalid.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 
@@ -19,13 +19,13 @@ public class Authorize_ProtocolValidation_Invalid
 
     [Fact]
     [Trait("Category", Category)]
-    public void Null_Parameter()
+    public async Task Null_Parameter()
     {
         var validator = Factory.CreateAuthorizeRequestValidator();
 
         Func<Task> act = () => validator.ValidateAsync(null);
 
-        act.Should().Throw<ArgumentNullException>();
+        await act.Should().ThrowAsync<ArgumentNullException>();
     }
 
     [Fact]

--- a/test/IdentityServer.UnitTests/Validation/DeviceAuthorizationRequestValidation.cs
+++ b/test/IdentityServer.UnitTests/Validation/DeviceAuthorizationRequestValidation.cs
@@ -31,13 +31,13 @@ public class DeviceAuthorizationRequestValidation
         
     [Fact]
     [Trait("Category", Category)]
-    public void Null_Parameter()
+    public async Task Null_Parameter()
     {
         var validator = Factory.CreateDeviceAuthorizationRequestValidator();
 
         Func<Task> act = () => validator.ValidateAsync(null, null);
 
-        act.Should().Throw<ArgumentNullException>();
+        await act.Should().ThrowAsync<ArgumentNullException>();
     }
 
     [Fact]

--- a/test/IdentityServer.UnitTests/Validation/Secrets/MutualTlsSecretValidation.cs
+++ b/test/IdentityServer.UnitTests/Validation/Secrets/MutualTlsSecretValidation.cs
@@ -64,7 +64,7 @@ public class MutualTlsSecretValidation
         };
 
         Func<Task> act = async () => await validator.ValidateAsync(client.ClientSecrets, secret);
-        act.Should().Throw<InvalidOperationException>();
+        await act.Should().ThrowAsync<InvalidOperationException>();
     }
 
     [Fact]
@@ -151,7 +151,7 @@ public class MutualTlsSecretValidation
         };
 
         Func<Task> act = async () => await validator.ValidateAsync(client.ClientSecrets, secret);
-        act.Should().Throw<InvalidOperationException>();
+        await act.Should().ThrowAsync<InvalidOperationException>();
     }
 
     [Fact]

--- a/test/IdentityServer.UnitTests/Validation/TokenRequest Validation/TokenRequestValidation_General_Invalid.cs
+++ b/test/IdentityServer.UnitTests/Validation/TokenRequest Validation/TokenRequestValidation_General_Invalid.cs
@@ -25,18 +25,18 @@ public class TokenRequestValidation_General_Invalid
 
     [Fact]
     [Trait("Category", Category)]
-    public void Parameters_Null()
+    public async Task Parameters_Null()
     {
         var validator = Factory.CreateTokenRequestValidator();
 
         Func<Task> act = () => validator.ValidateRequestAsync(null, null);
 
-        act.Should().Throw<ArgumentNullException>();
+        await act.Should().ThrowAsync<ArgumentNullException>();
     }
 
     [Fact]
     [Trait("Category", Category)]
-    public void Client_Null()
+    public async Task Client_Null()
     {
         var validator = Factory.CreateTokenRequestValidator();
 
@@ -47,7 +47,7 @@ public class TokenRequestValidation_General_Invalid
 
         Func<Task> act = () => validator.ValidateRequestAsync(parameters, null);
 
-        act.Should().Throw<ArgumentNullException>();
+        await act.Should().ThrowAsync<ArgumentNullException>();
     }
 
     [Fact]


### PR DESCRIPTION
Upgrading FluentAssertions is needed to add FluentAssertions.Web, which I'd like to start using.

Breaking changes that impacted us:
- Async code that throws must now await ThrowAsync
- Enums must now be used in a type safe manner
- Dates are compared with a mandatory precision
