### PR TITLE
Joe/6.3 bugfix/error event serialization

### DIFF
--- a/src/IdentityServer/Events/UnhandledExceptionEvent.cs
+++ b/src/IdentityServer/Events/UnhandledExceptionEvent.cs
@@ -3,6 +3,7 @@
 
 
 using System;
+using System.Text.Json.Serialization;
 
 namespace Duende.IdentityServer.Events;
 
@@ -41,5 +42,6 @@ public class UnhandledExceptionEvent : Event
     /// <value>
     /// The exception.
     /// </value>
+    [JsonIgnore] // Don't try to serialize exceptions, because System.Text.Json will fail (it doesn't support the pointers inside a call stack)
     public Exception Exception { get; set; }
 }

--- a/test/IdentityServer.UnitTests/Events/EventTests.cs
+++ b/test/IdentityServer.UnitTests/Events/EventTests.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Duende.IdentityServer.Configuration;
+using Duende.IdentityServer.Endpoints.Results;
+using Duende.IdentityServer.Models;
+using Duende.IdentityServer.ResponseHandling;
+using Duende.IdentityServer.Validation;
+using FluentAssertions;
+using IdentityModel;
+using UnitTests.Common;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.WebUtilities;
+using Xunit;
+using Duende.IdentityServer.Services;
+using Duende.IdentityServer;
+using Duende.IdentityServer.Events;
+
+namespace UnitTests.Endpoints.Results;
+
+public class EventTests
+{
+
+    [Fact]
+    public void UnhandledExceptionEventCanCallToString()
+    {
+        try
+        {
+            throw new Exception();
+        }
+        catch (Exception ex)
+        {
+            var unhandledExceptionEvent = new UnhandledExceptionEvent(ex);
+
+            var s = unhandledExceptionEvent.ToString();
+
+            s.Should().NotBeNullOrEmpty();
+        }
+    }
+}

--- a/test/IdentityServer.UnitTests/Events/EventTests.cs
+++ b/test/IdentityServer.UnitTests/Events/EventTests.cs
@@ -31,7 +31,7 @@ public class EventTests
     {
         try
         {
-            throw new Exception();
+            throw new InvalidOperationException("Boom");
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
This backports #1363 into the 6.3 release.

The issue is that thrown exceptions can't be serialized by System.Text.Json, because they contain pointers that it won't allow. 

This fix (suppressing serialization) is specific to the 6.3 release, to avoid a breaking change to the event type.

In 7.0, we will remove the property entirely.