### PR TITLE
Reduces PersistedGrantStore DB roundtrips

### DIFF
--- a/src/EntityFramework.Storage/Stores/PersistedGrantStore.cs
+++ b/src/EntityFramework.Storage/Stores/PersistedGrantStore.cs
@@ -120,24 +120,10 @@ public class PersistedGrantStore : Duende.IdentityServer.Stores.IPersistedGrantS
     public virtual async Task RemoveAsync(string key)
     {
         using var activity = Tracing.StoreActivitySource.StartActivity("PersistedGrantStore.Remove");
-        
-        var persistedGrant = (await Context.PersistedGrants.Where(x => x.Key == key)
-                .ToArrayAsync(CancellationTokenProvider.CancellationToken))
-            .SingleOrDefault(x => x.Key == key);
-        if (persistedGrant!= null)
+
+        if (await Context.PersistedGrants.ExecuteDeleteAsync(x => x.Key == key) > 0)
         {
-            Logger.LogDebug("removing {persistedGrantKey} persisted grant from database", key);
-
-            Context.PersistedGrants.Remove(persistedGrant);
-
-            try
-            {
-                await Context.SaveChangesAsync(CancellationTokenProvider.CancellationToken);
-            }
-            catch(DbUpdateConcurrencyException ex)
-            {
-                Logger.LogInformation("exception removing {persistedGrantKey} persisted grant from database: {error}", key, ex.Message);
-            }
+            Logger.LogDebug("removed {persistedGrantKey} persisted grant from database", key);
         }
         else
         {

--- a/src/EntityFramework.Storage/Stores/PersistedGrantStore.cs
+++ b/src/EntityFramework.Storage/Stores/PersistedGrantStore.cs
@@ -64,16 +64,16 @@ public class PersistedGrantStore : Duende.IdentityServer.Stores.IPersistedGrantS
             await Context.SaveChangesAsync(CancellationTokenProvider.CancellationToken);
             Logger.LogDebug("{persistedGrantKey} not found in database", token.Key);
         }
+        catch (DbUpdateConcurrencyException ex)
+        {
+            Logger.LogWarning("exception inserting or updating {persistedGrantKey} persisted grant in database: {error}", token.Key, ex.Message);
+        }
         catch (DbUpdateException)
         {
             Logger.LogDebug("{persistedGrantKey} found in database", token.Key);
             await Context.PersistedGrants.Where(x => x.Key == key).ExecuteDeleteAsync(CancellationTokenProvider.CancellationToken);
             Logger.LogDebug("removed {persistedGrantKey} persisted grant from database", key);
             await Context.SaveChangesAsync(CancellationTokenProvider.CancellationToken);
-        }
-        catch (DbUpdateConcurrencyException ex)
-        {
-            Logger.LogWarning("exception inserting or updating {persistedGrantKey} persisted grant in database: {error}", token.Key, ex.Message);
         }
     }
 

--- a/src/EntityFramework.Storage/Stores/PersistedGrantStore.cs
+++ b/src/EntityFramework.Storage/Stores/PersistedGrantStore.cs
@@ -71,8 +71,8 @@ public class PersistedGrantStore : Duende.IdentityServer.Stores.IPersistedGrantS
         catch (DbUpdateException)
         {
             Logger.LogDebug("{persistedGrantKey} found in database", token.Key);
-            await Context.PersistedGrants.Where(x => x.Key == key).ExecuteDeleteAsync(CancellationTokenProvider.CancellationToken);
-            Logger.LogDebug("removed {persistedGrantKey} persisted grant from database", key);
+            await Context.PersistedGrants.Where(x => x.Key == token.Key).ExecuteDeleteAsync(CancellationTokenProvider.CancellationToken);
+            Logger.LogDebug("removed {persistedGrantKey} persisted grant from database", token.Key);
             await Context.SaveChangesAsync(CancellationTokenProvider.CancellationToken);
         }
     }

--- a/src/EntityFramework.Storage/Stores/PersistedGrantStore.cs
+++ b/src/EntityFramework.Storage/Stores/PersistedGrantStore.cs
@@ -71,6 +71,10 @@ public class PersistedGrantStore : Duende.IdentityServer.Stores.IPersistedGrantS
             Logger.LogDebug("removed {persistedGrantKey} persisted grant from database", key);
             await Context.SaveChangesAsync(CancellationTokenProvider.CancellationToken);
         }
+        catch (DbUpdateConcurrencyException ex)
+        {
+            Logger.LogWarning("exception inserting or updating {persistedGrantKey} persisted grant in database: {error}", token.Key, ex.Message);
+        }
     }
 
     /// <inheritdoc/>

--- a/test/EntityFramework.Storage.IntegrationTests/IntegrationTest.cs
+++ b/test/EntityFramework.Storage.IntegrationTests/IntegrationTest.cs
@@ -37,8 +37,8 @@ public class IntegrationTest<TClass, TDbContext, TStoreOption> : IClassFixture<D
 
             TestDatabaseProviders = new TheoryData<DbContextOptions<TDbContext>>
             {
-                DatabaseProviderBuilder.BuildInMemory<TDbContext, TStoreOption>(typeof(TClass).Name, StoreOptions),
-                //DatabaseProviderBuilder.BuildSqlite<TDbContext>(typeof(TClass).Name),
+                //DatabaseProviderBuilder.BuildInMemory<TDbContext, TStoreOption>(typeof(TClass).Name, StoreOptions),
+                DatabaseProviderBuilder.BuildSqlite<TDbContext, TStoreOption>(typeof(TClass).Name, StoreOptions),
                 //DatabaseProviderBuilder.BuildLocalDb<TDbContext>(typeof(TClass).Name)
             };
         }
@@ -46,8 +46,8 @@ public class IntegrationTest<TClass, TDbContext, TStoreOption> : IClassFixture<D
         {
             TestDatabaseProviders = new TheoryData<DbContextOptions<TDbContext>>
             {
-                DatabaseProviderBuilder.BuildInMemory<TDbContext, TStoreOption>(typeof(TClass).Name, StoreOptions),
-                //DatabaseProviderBuilder.BuildSqlite<TDbContext, TStoreOption>(typeof(TClass).Name, StoreOptions)
+                //DatabaseProviderBuilder.BuildInMemory<TDbContext, TStoreOption>(typeof(TClass).Name, StoreOptions),
+                DatabaseProviderBuilder.BuildSqlite<TDbContext, TStoreOption>(typeof(TClass).Name, StoreOptions)
             };
             Console.WriteLine("Skipping DB integration tests on non-Windows");
         }


### PR DESCRIPTION
**What issue does this PR address?**

We are running a HA setup of IdentityServer across multiple continents and experience significant latency during logins in sites that are geographically distant to the DB. We analysed the queries being sent to the DB during logins and found the following queries affecting PersistedGrants. 

```SQL
SELECT p."Id", p."ClientId", p."ConsumedTime", p."CreationTime", p."Data", p."Description", p."Expiration", p."Key", p."SessionId", p."SubjectId", p."Type"
FROM "PersistedGrants" AS p
WHERE p."Key" = @__token_Key_0

INSERT INTO "PersistedGrants" ("ClientId", "ConsumedTime", "CreationTime", "Data", "Description", "Expiration", "Key", "SessionId", "SubjectId", "Type")
VALUES (@p0, @p1, @p2, @p3, @p4, @p5, @p6, @p7, @p8, @p9)
RETURNING "Id";

SELECT p."Id", p."ClientId", p."ConsumedTime", p."CreationTime", p."Data", p."Description", p."Expiration", p."Key", p."SessionId", p."SubjectId", p."Type"
FROM "PersistedGrants" AS p
WHERE p."Key" = @__key_0

SELECT p."Id", p."ClientId", p."ConsumedTime", p."CreationTime", p."Data", p."Description", p."Expiration", p."Key", p."SessionId", p."SubjectId", p."Type"
FROM "PersistedGrants" AS p
WHERE p."Key" = @__key_0

DELETE FROM "PersistedGrants"
WHERE "Id" = @p0;
```
After:
```SQL
INSERT INTO "PersistedGrants" ("ClientId", "ConsumedTime", "CreationTime", "Data", "Description", "Expiration", "Key", "SessionId", "SubjectId", "Type")
VALUES (@p0, @p1, @p2, @p3, @p4, @p5, @p6, @p7, @p8, @p9)
RETURNING "Id";

SELECT p."Id", p."ClientId", p."ConsumedTime", p."CreationTime", p."Data", p."Description", p."Expiration", p."Key", p."SessionId", p."SubjectId", p."Type"
FROM "PersistedGrants" AS p
WHERE p."Key" = @__key_0

DELETE FROM "PersistedGrants"
WHERE "Id" = @p0;
```

This PR removes the need for the first SELECT (to verify if a persisted grant already exists) in the optimistic case. It does make the situation of the persisted grant already existing worse as it now needs 3 roundtrips instead of 2. But this should generally be rare as they are usually deleted as part of cleanup. This could potentially be improve further when EF Core gets around to adding an UpsertAsync API.

This PR also addresses the need for a SELECT in order to do a DELETE and replaces Remove/SaveChanges with ExecuteDelete
