### PR TITLE
Revert "Bump WilsonVersion from 7.0.0 to 7.0.1"

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -18,7 +18,7 @@
         <FrameworkVersion>8.0.0-rc.1.23421.29</FrameworkVersion>
         <ExtensionsVersion>8.0.0-rc.1.23419.4</ExtensionsVersion>
         <EntityFrameworkVersion>8.0.0-rc.1.23419.6</EntityFrameworkVersion>
-        <WilsonVersion>7.0.1</WilsonVersion>
+        <WilsonVersion>7.0.0</WilsonVersion>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This reverts commit 18d53869141a650e91b76beefa6232959aca75a9.

Keeps dependencies as permissive as possible to avoid dependency issues.
