### PR TITLE
Adds GetAndDelete behaviour to TokenRequestValidator

### DIFF
--- a/src/EntityFramework.Storage/Interfaces/IPersistedGrantDbContext.cs
+++ b/src/EntityFramework.Storage/Interfaces/IPersistedGrantDbContext.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Duende.IdentityServer.EntityFramework.Entities;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 
 namespace Duende.IdentityServer.EntityFramework.Interfaces;
 
@@ -50,6 +51,11 @@ public interface IPersistedGrantDbContext : IDisposable
     /// </value>
     DbSet<ServerSideSession> ServerSideSessions { get; set; }
 
+    /// <summary>
+    /// Gets the database facade
+    /// </summary>
+    DatabaseFacade Database { get; }
+    
     /// <summary>
     /// Saves the changes.
     /// </summary>

--- a/src/EntityFramework.Storage/Stores/PersistedGrantStore.cs
+++ b/src/EntityFramework.Storage/Stores/PersistedGrantStore.cs
@@ -120,24 +120,10 @@ public class PersistedGrantStore : Duende.IdentityServer.Stores.IPersistedGrantS
     public virtual async Task RemoveAsync(string key)
     {
         using var activity = Tracing.StoreActivitySource.StartActivity("PersistedGrantStore.Remove");
-        
-        var persistedGrant = (await Context.PersistedGrants.Where(x => x.Key == key)
-                .ToArrayAsync(CancellationTokenProvider.CancellationToken))
-            .SingleOrDefault(x => x.Key == key);
-        if (persistedGrant!= null)
+
+        if (await Context.PersistedGrants.ExecuteDeleteAsync(x => x.Key == key) > 0)
         {
-            Logger.LogDebug("removing {persistedGrantKey} persisted grant from database", key);
-
-            Context.PersistedGrants.Remove(persistedGrant);
-
-            try
-            {
-                await Context.SaveChangesAsync(CancellationTokenProvider.CancellationToken);
-            }
-            catch(DbUpdateConcurrencyException ex)
-            {
-                Logger.LogInformation("exception removing {persistedGrantKey} persisted grant from database: {error}", key, ex.Message);
-            }
+            Logger.LogDebug("removed {persistedGrantKey} persisted grant from database", key);
         }
         else
         {

--- a/src/EntityFramework.Storage/Stores/PersistedGrantStore.cs
+++ b/src/EntityFramework.Storage/Stores/PersistedGrantStore.cs
@@ -126,6 +126,18 @@ public class PersistedGrantStore : Duende.IdentityServer.Stores.IPersistedGrantS
     }
 
     /// <inheritdoc/>
+    public virtual async Task<Models.PersistedGrant> GetAndRemoveAsync(string key)
+    {
+        using var activity = Tracing.StoreActivitySource.StartActivity("PersistedGrantStore.Remove");
+        using var transaction = Context.Database.BeginTransactionAsync();
+
+        var result = await GetAsync(key);
+        await RemoveAsync(key);
+        await Context.Database.CommitTransactionAsync();
+        return result;
+    }
+
+    /// <inheritdoc/>
     public virtual async Task RemoveAllAsync(PersistedGrantFilter filter)
     {
         using var activity = Tracing.StoreActivitySource.StartActivity("PersistedGrantStore.RemoveAll");

--- a/src/EntityFramework.Storage/Stores/PersistedGrantStore.cs
+++ b/src/EntityFramework.Storage/Stores/PersistedGrantStore.cs
@@ -64,16 +64,16 @@ public class PersistedGrantStore : Duende.IdentityServer.Stores.IPersistedGrantS
             await Context.SaveChangesAsync(CancellationTokenProvider.CancellationToken);
             Logger.LogDebug("{persistedGrantKey} not found in database", token.Key);
         }
+        catch (DbUpdateConcurrencyException ex)
+        {
+            Logger.LogWarning("exception inserting or updating {persistedGrantKey} persisted grant in database: {error}", token.Key, ex.Message);
+        }
         catch (DbUpdateException)
         {
             Logger.LogDebug("{persistedGrantKey} found in database", token.Key);
             await Context.PersistedGrants.Where(x => x.Key == key).ExecuteDeleteAsync(CancellationTokenProvider.CancellationToken);
             Logger.LogDebug("removed {persistedGrantKey} persisted grant from database", key);
             await Context.SaveChangesAsync(CancellationTokenProvider.CancellationToken);
-        }
-        catch (DbUpdateConcurrencyException ex)
-        {
-            Logger.LogWarning("exception inserting or updating {persistedGrantKey} persisted grant in database: {error}", token.Key, ex.Message);
         }
     }
 

--- a/src/EntityFramework.Storage/Stores/PersistedGrantStore.cs
+++ b/src/EntityFramework.Storage/Stores/PersistedGrantStore.cs
@@ -71,8 +71,8 @@ public class PersistedGrantStore : Duende.IdentityServer.Stores.IPersistedGrantS
         catch (DbUpdateException)
         {
             Logger.LogDebug("{persistedGrantKey} found in database", token.Key);
-            await Context.PersistedGrants.Where(x => x.Key == key).ExecuteDeleteAsync(CancellationTokenProvider.CancellationToken);
-            Logger.LogDebug("removed {persistedGrantKey} persisted grant from database", key);
+            await Context.PersistedGrants.Where(x => x.Key == token.Key).ExecuteDeleteAsync(CancellationTokenProvider.CancellationToken);
+            Logger.LogDebug("removed {persistedGrantKey} persisted grant from database", token.Key);
             await Context.SaveChangesAsync(CancellationTokenProvider.CancellationToken);
         }
     }

--- a/src/EntityFramework.Storage/Stores/PersistedGrantStore.cs
+++ b/src/EntityFramework.Storage/Stores/PersistedGrantStore.cs
@@ -71,6 +71,10 @@ public class PersistedGrantStore : Duende.IdentityServer.Stores.IPersistedGrantS
             Logger.LogDebug("removed {persistedGrantKey} persisted grant from database", key);
             await Context.SaveChangesAsync(CancellationTokenProvider.CancellationToken);
         }
+        catch (DbUpdateConcurrencyException ex)
+        {
+            Logger.LogWarning("exception inserting or updating {persistedGrantKey} persisted grant in database: {error}", token.Key, ex.Message);
+        }
     }
 
     /// <inheritdoc/>

--- a/src/IdentityServer/Stores/Default/DefaultAuthorizationCodeStore.cs
+++ b/src/IdentityServer/Stores/Default/DefaultAuthorizationCodeStore.cs
@@ -57,6 +57,18 @@ public class DefaultAuthorizationCodeStore : DefaultGrantStore<AuthorizationCode
     }
 
     /// <summary>
+    /// Gets and deletes authorization code.
+    /// </summary>
+    /// <param name="code">The code.</param>
+    /// <returns></returns>
+    public async Task<AuthorizationCode> GetAndDeleteAuthorizationCodeAsync(string code)
+    {
+        using var activity = Tracing.StoreActivitySource.StartActivity("DefaultAuthorizationCodeStore.GetAndDeleteAuthorizationCode");
+
+        return await GetAndRemoveItemAsync(code);
+    }
+
+    /// <summary>
     /// Removes the authorization code asynchronous.
     /// </summary>
     /// <param name="code">The code.</param>

--- a/src/IdentityServer/Validation/Default/TokenRequestValidator.cs
+++ b/src/IdentityServer/Validation/Default/TokenRequestValidator.cs
@@ -335,7 +335,7 @@ internal class TokenRequestValidator : ITokenRequestValidator
 
         _validatedRequest.AuthorizationCodeHandle = code;
 
-        var authZcode = await _authorizationCodeStore.GetAuthorizationCodeAsync(code);
+        var authZcode = await _authorizationCodeStore.GetAndDeleteAuthorizationCodeAsync(code);
         if (authZcode == null)
         {
             LogError("Invalid authorization code", new { code });
@@ -368,10 +368,6 @@ internal class TokenRequestValidator : ITokenRequestValidator
                 return Invalid(OidcConstants.TokenErrors.InvalidDPoPProof, "The DPoP proof token used on the token endpoint does not match the original used on the authorize endpoint.");
             }
         }
-
-        // remove code from store
-        // todo: set to consumed in the future?
-        await _authorizationCodeStore.RemoveAuthorizationCodeAsync(code);
 
         if (authZcode.CreationTime.HasExceeded(authZcode.Lifetime, _clock.UtcNow.UtcDateTime))
         {

--- a/src/Storage/Stores/IAuthorizationCodeStore.cs
+++ b/src/Storage/Stores/IAuthorizationCodeStore.cs
@@ -27,6 +27,21 @@ public interface IAuthorizationCodeStore
     /// <param name="code">The code.</param>
     /// <returns></returns>
     Task<AuthorizationCode?> GetAuthorizationCodeAsync(string code);
+    
+    /// <summary>
+    /// Gets and deletes authorization code.
+    /// </summary>
+    /// <param name="code">The code.</param>
+    /// <returns></returns>
+    async Task<AuthorizationCode?> GetAndDeleteAuthorizationCodeAsync(string code)
+    {
+        if (await GetAuthorizationCodeAsync(code) is { } authCode)
+        {
+            await RemoveAuthorizationCodeAsync(code);
+            return authCode;
+        }
+        return null;
+    }
 
     /// <summary>
     /// Removes the authorization code.

--- a/src/Storage/Stores/IPersistedGrantStore.cs
+++ b/src/Storage/Stores/IPersistedGrantStore.cs
@@ -44,6 +44,21 @@ public interface IPersistedGrantStore
     Task RemoveAsync(string key);
 
     /// <summary>
+    /// Removes the grant by key.
+    /// </summary>
+    /// <param name="key">The key.</param>
+    /// <returns></returns>
+    async Task<PersistedGrant?> GetAndRemoveAsync(string key)
+    {
+        if (await GetAsync(key) is { } authCode)
+        {
+            await RemoveAsync(key);
+            return authCode;
+        }
+        return null;
+    }
+
+    /// <summary>
     /// Removes all grants based on the filter.
     /// </summary>
     /// <param name="filter">The filter.</param>

--- a/test/EntityFramework.Storage.IntegrationTests/IntegrationTest.cs
+++ b/test/EntityFramework.Storage.IntegrationTests/IntegrationTest.cs
@@ -37,8 +37,8 @@ public class IntegrationTest<TClass, TDbContext, TStoreOption> : IClassFixture<D
 
             TestDatabaseProviders = new TheoryData<DbContextOptions<TDbContext>>
             {
-                DatabaseProviderBuilder.BuildInMemory<TDbContext, TStoreOption>(typeof(TClass).Name, StoreOptions),
-                //DatabaseProviderBuilder.BuildSqlite<TDbContext>(typeof(TClass).Name),
+                //DatabaseProviderBuilder.BuildInMemory<TDbContext, TStoreOption>(typeof(TClass).Name, StoreOptions),
+                DatabaseProviderBuilder.BuildSqlite<TDbContext, TStoreOption>(typeof(TClass).Name, StoreOptions),
                 //DatabaseProviderBuilder.BuildLocalDb<TDbContext>(typeof(TClass).Name)
             };
         }
@@ -46,8 +46,8 @@ public class IntegrationTest<TClass, TDbContext, TStoreOption> : IClassFixture<D
         {
             TestDatabaseProviders = new TheoryData<DbContextOptions<TDbContext>>
             {
-                DatabaseProviderBuilder.BuildInMemory<TDbContext, TStoreOption>(typeof(TClass).Name, StoreOptions),
-                //DatabaseProviderBuilder.BuildSqlite<TDbContext, TStoreOption>(typeof(TClass).Name, StoreOptions)
+                //DatabaseProviderBuilder.BuildInMemory<TDbContext, TStoreOption>(typeof(TClass).Name, StoreOptions),
+                DatabaseProviderBuilder.BuildSqlite<TDbContext, TStoreOption>(typeof(TClass).Name, StoreOptions)
             };
             Console.WriteLine("Skipping DB integration tests on non-Windows");
         }


### PR DESCRIPTION
Reduces database roundtrips for login from 3 to 2

Transaction 1
```
INSERT INTO "PersistedGrants" ("ClientId", "ConsumedTime", "CreationTime", "Data", "Description", "Expiration", "Key", "SessionId", "SubjectId", "Type")
VALUES (@p0, @p1, @p2, @p3, @p4, @p5, @p6, @p7, @p8, @p9)
RETURNING "Id";
```
Transaction 2
```
SELECT p."Id", p."ClientId", p."ConsumedTime", p."CreationTime", p."Data", p."Description", p."Expiration", p."Key", p."SessionId", p."SubjectId", p."Type"
FROM "PersistedGrants" AS p
WHERE p."Key" = @__key_0

DELETE FROM "PersistedGrants"
WHERE "Id" = @p0;
```