### PR TITLE
Rename result generators

### DIFF
--- a/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -125,37 +125,36 @@ public static class IdentityServerBuilderExtensionsCore
         builder.AddEndpoint<TokenEndpoint>(EndpointNames.Token, ProtocolRoutePaths.Token.EnsureLeadingSlash());
         builder.AddEndpoint<UserInfoEndpoint>(EndpointNames.UserInfo, ProtocolRoutePaths.UserInfo.EnsureLeadingSlash());
 
-        builder.AddEndpointResultGenerator<AuthorizeInteractionPageResult, AuthorizeInteractionPageResultGenerator>();
-        builder.AddEndpointResultGenerator<AuthorizeResult, AuthorizeResultGenerator>();
-        builder.AddEndpointResultGenerator<BackchannelAuthenticationResult, BackchannelAuthenticationResultGenerator>();
-        builder.AddEndpointResultGenerator<BadRequestResult, BadRequestResultGenerator>();
-        builder.AddEndpointResultGenerator<CheckSessionResult, CheckSessionResultGenerator>();
-        builder.AddEndpointResultGenerator<DeviceAuthorizationResult, DeviceAuthorizationResultGenerator>();
-        builder.AddEndpointResultGenerator<DiscoveryDocumentResult, DiscoveryDocumentResultGenerator>();
-        builder.AddEndpointResultGenerator<EndSessionCallbackResult, EndSessionCallbackResultGenerator>();
-        builder.AddEndpointResultGenerator<EndSessionResult, EndSessionResultGenerator>();
-        builder.AddEndpointResultGenerator<IntrospectionResult, IntrospectionResultGenerator>();
-        builder.AddEndpointResultGenerator<JsonWebKeysResult, JsonWebKeysResultGenerator>();
-        builder.AddEndpointResultGenerator<ProtectedResourceErrorResult, ProtectedResourceErrorResultGenerator>();
-        builder.AddEndpointResultGenerator<PushedAuthorizationResult, PushedAuthorizationResultGenerator>();
-        builder.AddEndpointResultGenerator<PushedAuthorizationErrorResult, PushedAuthorizationErrorResultGenerator>();
-        builder.AddEndpointResultGenerator<StatusCodeResult, StatusCodeResultGenerator>();
-        builder.AddEndpointResultGenerator<TokenErrorResult, TokenErrorResultGenerator>();
-        builder.AddEndpointResultGenerator<TokenResult, TokenResultGenerator>();
-        builder.AddEndpointResultGenerator<TokenRevocationErrorResult, TokenRevocationErrorResultGenerator>();
-        builder.AddEndpointResultGenerator<UserInfoResult, UserInfoResultGenerator>();
+        builder.AddHttpWriter<AuthorizeInteractionPageResult, AuthorizeInteractionPageHttpWriter>();
+        builder.AddHttpWriter<AuthorizeResult, AuthorizeHttpWriter>();
+        builder.AddHttpWriter<BackchannelAuthenticationResult, BackchannelAuthenticationHttpWriter>();
+        builder.AddHttpWriter<BadRequestResult, BadRequestHttpWriter>();
+        builder.AddHttpWriter<CheckSessionResult, CheckSessionHttpWriter>();
+        builder.AddHttpWriter<DeviceAuthorizationResult, DeviceAuthorizationHttpWriter>();
+        builder.AddHttpWriter<DiscoveryDocumentResult, DiscoveryDocumentHttpWriter>();
+        builder.AddHttpWriter<EndSessionCallbackResult, EndSessionCallbackHttpWriter>();
+        builder.AddHttpWriter<EndSessionResult, EndSessionHttpWriter>();
+        builder.AddHttpWriter<IntrospectionResult, IntrospectionHttpWriter>();
+        builder.AddHttpWriter<JsonWebKeysResult, JsonWebKeysHttpWriter>();
+        builder.AddHttpWriter<ProtectedResourceErrorResult, ProtectedResourceErrorHttpWriter>();
+        builder.AddHttpWriter<PushedAuthorizationResult, PushedAuthorizationHttpWriter>();
+        builder.AddHttpWriter<PushedAuthorizationErrorResult, PushedAuthorizationErrorHttpWriter>();
+        builder.AddHttpWriter<StatusCodeResult, StatusCodeHttpWriter>();
+        builder.AddHttpWriter<TokenErrorResult, TokenErrorHttpWriter>();
+        builder.AddHttpWriter<TokenResult, TokenHttpWriter>();
+        builder.AddHttpWriter<TokenRevocationErrorResult, TokenRevocationErrorHttpWriter>();
+        builder.AddHttpWriter<UserInfoResult, UserInfoHttpWriter>();
 
         return builder;
     }
 
     /// <summary>
-    /// Adds the endpoint.
+    /// Adds an endpoint.
     /// </summary>
     /// <typeparam name="TEndpoint"></typeparam>
     /// <param name="builder">The builder.</param>
     /// <param name="name">The name.</param>
     /// <param name="path">The path.</param>
-    /// <returns></returns>
     public static IIdentityServerBuilder AddEndpoint<TEndpoint>(this IIdentityServerBuilder builder, string name, PathString path)
         where TEndpoint : class, IEndpointHandler
     {
@@ -166,13 +165,13 @@ public static class IdentityServerBuilderExtensionsCore
     }
 
     /// <summary>
-    /// Adds the endpoint.
+    /// Adds an <see cref="IHttpResponseWriter{T}"/> for an <see cref="IEndpointResult"/>.
     /// </summary>
-    public static IIdentityServerBuilder AddEndpointResultGenerator<TResult, TResultGenerator>(this IIdentityServerBuilder builder)
+    public static IIdentityServerBuilder AddHttpWriter<TResult, TWriter>(this IIdentityServerBuilder builder)
         where TResult : class, IEndpointResult
-        where TResultGenerator : class, Duende.IdentityServer.Hosting.IEndpointResultGenerator<TResult>
+        where TWriter : class, IHttpResponseWriter<TResult>
     {
-        builder.Services.AddTransient<Duende.IdentityServer.Hosting.IEndpointResultGenerator<TResult>, TResultGenerator>();
+        builder.Services.AddTransient<IHttpResponseWriter<TResult>, TWriter>();
         return builder;
     }
 
@@ -180,7 +179,6 @@ public static class IdentityServerBuilderExtensionsCore
     /// Adds the core services.
     /// </summary>
     /// <param name="builder">The builder.</param>
-    /// <returns></returns>
     public static IIdentityServerBuilder AddCoreServices(this IIdentityServerBuilder builder)
     {
         builder.Services.AddTransient<IServerUrls, DefaultServerUrls>();

--- a/src/IdentityServer/Endpoints/Results/AuthorizeInteractionPageResult.cs
+++ b/src/IdentityServer/Endpoints/Results/AuthorizeInteractionPageResult.cs
@@ -53,7 +53,7 @@ public abstract class AuthorizeInteractionPageResult : EndpointResult<AuthorizeI
     public string ReturnUrlParameterName { get; }
 }
 
-class AuthorizeInteractionPageResultGenerator : IEndpointResultGenerator<AuthorizeInteractionPageResult>
+class AuthorizeInteractionPageHttpWriter : IHttpResponseWriter<AuthorizeInteractionPageResult>
 {
     private readonly IServerUrls _urls;
     private readonly IAuthorizationParametersMessageStore _authorizationParametersMessageStore;
@@ -61,7 +61,7 @@ class AuthorizeInteractionPageResultGenerator : IEndpointResultGenerator<Authori
     /// <summary>
     /// Initializes a new instance of the <see cref="AuthorizeInteractionPageResult"/> class.
     /// </summary>
-    public AuthorizeInteractionPageResultGenerator(
+    public AuthorizeInteractionPageHttpWriter(
         IServerUrls urls,
         IAuthorizationParametersMessageStore authorizationParametersMessageStore = null)
     {
@@ -70,7 +70,7 @@ class AuthorizeInteractionPageResultGenerator : IEndpointResultGenerator<Authori
     }
 
     /// <inheritdoc/>
-    public async Task ExecuteAsync(AuthorizeInteractionPageResult result, HttpContext context)
+    public async Task WriteHttpResponse(AuthorizeInteractionPageResult result, HttpContext context)
     {
         var returnUrl = _urls.BasePath.EnsureTrailingSlash() + ProtocolRoutePaths.AuthorizeCallback;
 

--- a/src/IdentityServer/Endpoints/Results/AuthorizeResult.cs
+++ b/src/IdentityServer/Endpoints/Results/AuthorizeResult.cs
@@ -38,9 +38,9 @@ public class AuthorizeResult : EndpointResult<AuthorizeResult>
     }
 }
 
-internal class AuthorizeResultGenerator : IEndpointResultGenerator<AuthorizeResult>
+internal class AuthorizeHttpWriter : IHttpResponseWriter<AuthorizeResult>
 {
-    public AuthorizeResultGenerator(
+    public AuthorizeHttpWriter(
         IdentityServerOptions options,
         IUserSession userSession,
         IPushedAuthorizationService pushedAuthorizationService,
@@ -63,7 +63,7 @@ internal class AuthorizeResultGenerator : IEndpointResultGenerator<AuthorizeResu
     private readonly IServerUrls _urls;
     private readonly IClock _clock;
 
-    public async Task ExecuteAsync(AuthorizeResult result, HttpContext context)
+    public async Task WriteHttpResponse(AuthorizeResult result, HttpContext context)
     {
         await ConsumePushedAuthorizationRequest(result);
 

--- a/src/IdentityServer/Endpoints/Results/AuthorizeResult.cs
+++ b/src/IdentityServer/Endpoints/Results/AuthorizeResult.cs
@@ -38,8 +38,14 @@ public class AuthorizeResult : EndpointResult<AuthorizeResult>
     }
 }
 
-internal class AuthorizeHttpWriter : IHttpResponseWriter<AuthorizeResult>
+/// <summary>
+/// Writes http responses for <see cref="AuthorizeResult"/>s.
+/// </summary>
+public class AuthorizeHttpWriter : IHttpResponseWriter<AuthorizeResult>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AuthorizeHttpWriter"/> class.
+    /// </summary>
     public AuthorizeHttpWriter(
         IdentityServerOptions options,
         IUserSession userSession,
@@ -63,6 +69,7 @@ internal class AuthorizeHttpWriter : IHttpResponseWriter<AuthorizeResult>
     private readonly IServerUrls _urls;
     private readonly IClock _clock;
 
+    /// <inheritdoc />
     public async Task WriteHttpResponse(AuthorizeResult result, HttpContext context)
     {
         await ConsumePushedAuthorizationRequest(result);
@@ -85,7 +92,6 @@ internal class AuthorizeHttpWriter : IHttpResponseWriter<AuthorizeResult>
             await _pushedAuthorizationService.ConsumeAsync(referenceValue);
         }
     }
-
 
     private async Task ProcessErrorAsync(AuthorizeResponse response, HttpContext context)
     {
@@ -111,7 +117,7 @@ internal class AuthorizeHttpWriter : IHttpResponseWriter<AuthorizeResult>
         }
     }
 
-    protected async Task ProcessResponseAsync(AuthorizeResponse response, HttpContext context)
+    private async Task ProcessResponseAsync(AuthorizeResponse response, HttpContext context)
     {
         if (!response.IsError)
         {
@@ -178,11 +184,31 @@ internal class AuthorizeHttpWriter : IHttpResponseWriter<AuthorizeResult>
         return uri;
     }
 
-    private const string FormPostHtml = "<html><head><meta http-equiv='X-UA-Compatible' content='IE=edge' /><base target='_self'/></head><body><form method='post' action='{uri}'>{body}<noscript><button>Click to continue</button></noscript></form><script>window.addEventListener('load', function(){document.forms[0].submit();});</script></body></html>";
+    private const string DefaultFormPostHeadTags = "<head><meta http-equiv='X-UA-Compatible' content='IE=edge' /><base target='_self'/></head>";
+    private const string DefaultFormPostBodyTags = "<body><form method='post' action='{uri}'>{body}<noscript><button>Click to continue</button></noscript></form><script>window.addEventListener('load', function(){document.forms[0].submit();});</script></body>";
 
-    private string GetFormPostHtml(AuthorizeResponse response)
+    /// <summary>
+    /// Gets the header tags that will be included in the response when
+    /// response_mode is form_post.
+    /// </summary>
+    protected virtual string FormPostHeader => DefaultFormPostHeadTags;
+    
+    /// <summary>
+    /// Gets the body tags that will be included in the response when
+    /// response_mode is form_post. The string "{body}" (including the curly
+    /// braces) within this string will be replaced with the response
+    /// parameters, serialized as form data.
+    /// </summary>
+    protected virtual string FormPostBody => DefaultFormPostBodyTags;
+
+    /// <summary>
+    /// Gets the html that will set as the response when response_mode is
+    /// form_post. 
+    /// </summary>
+    /// <param name="response"></param>
+    protected virtual string GetFormPostHtml(AuthorizeResponse response)
     {
-        var html = FormPostHtml;
+        var html = $"<html>{FormPostHeader}{FormPostBody}</html>";
 
         var url = response.Request.RedirectUri;
         url = HtmlEncoder.Default.Encode(url);

--- a/src/IdentityServer/Endpoints/Results/BackchannelAuthenticationResult.cs
+++ b/src/IdentityServer/Endpoints/Results/BackchannelAuthenticationResult.cs
@@ -33,9 +33,9 @@ public class BackchannelAuthenticationResult : EndpointResult<BackchannelAuthent
     }
 }
 
-internal class BackchannelAuthenticationResultGenerator : IEndpointResultGenerator<BackchannelAuthenticationResult>
+internal class BackchannelAuthenticationHttpWriter : IHttpResponseWriter<BackchannelAuthenticationResult>
 {
-    public async Task ExecuteAsync(BackchannelAuthenticationResult result, HttpContext context)
+    public async Task WriteHttpResponse(BackchannelAuthenticationResult result, HttpContext context)
     {
         context.Response.SetNoCache();
 

--- a/src/IdentityServer/Endpoints/Results/BadRequestResult.cs
+++ b/src/IdentityServer/Endpoints/Results/BadRequestResult.cs
@@ -35,9 +35,9 @@ public class BadRequestResult : EndpointResult<BadRequestResult>
     }
 }
 
-internal class BadRequestResultGenerator : IEndpointResultGenerator<BadRequestResult>
+internal class BadRequestHttpWriter : IHttpResponseWriter<BadRequestResult>
 {
-    public async Task ExecuteAsync(BadRequestResult result, HttpContext context)
+    public async Task WriteHttpResponse(BadRequestResult result, HttpContext context)
     {
         context.Response.StatusCode = 400;
         context.Response.SetNoCache();

--- a/src/IdentityServer/Endpoints/Results/CheckSessionResult.cs
+++ b/src/IdentityServer/Endpoints/Results/CheckSessionResult.cs
@@ -18,9 +18,9 @@ public class CheckSessionResult : EndpointResult<CheckSessionResult>
 }
 
 
-internal class CheckSessionResultGenerator : IEndpointResultGenerator<CheckSessionResult>
+internal class CheckSessionHttpWriter : IHttpResponseWriter<CheckSessionResult>
 {
-    public CheckSessionResultGenerator(IdentityServerOptions options)
+    public CheckSessionHttpWriter(IdentityServerOptions options)
     {
         _options = options;
     }
@@ -30,7 +30,7 @@ internal class CheckSessionResultGenerator : IEndpointResultGenerator<CheckSessi
     private static readonly object Lock = new object();
     private static volatile string LastCheckSessionCookieName;
 
-    public async Task ExecuteAsync(CheckSessionResult result, HttpContext context)
+    public async Task WriteHttpResponse(CheckSessionResult result, HttpContext context)
     {
         AddCspHeaders(context);
 

--- a/src/IdentityServer/Endpoints/Results/DeviceAuthorizationResult.cs
+++ b/src/IdentityServer/Endpoints/Results/DeviceAuthorizationResult.cs
@@ -32,9 +32,9 @@ public class DeviceAuthorizationResult : EndpointResult<DeviceAuthorizationResul
     }
 }
 
-internal class DeviceAuthorizationResultGenerator : IEndpointResultGenerator<DeviceAuthorizationResult>
+internal class DeviceAuthorizationHttpWriter : IHttpResponseWriter<DeviceAuthorizationResult>
 {
-    public async Task ExecuteAsync(DeviceAuthorizationResult result, HttpContext context)
+    public async Task WriteHttpResponse(DeviceAuthorizationResult result, HttpContext context)
     {
         context.Response.SetNoCache();
 

--- a/src/IdentityServer/Endpoints/Results/DiscoveryDocumentResult.cs
+++ b/src/IdentityServer/Endpoints/Results/DiscoveryDocumentResult.cs
@@ -46,10 +46,10 @@ public class DiscoveryDocumentResult : EndpointResult<DiscoveryDocumentResult>
     }
 }
 
-class DiscoveryDocumentResultGenerator : IEndpointResultGenerator<DiscoveryDocumentResult>
+class DiscoveryDocumentHttpWriter : IHttpResponseWriter<DiscoveryDocumentResult>
 {
     /// <inheritdoc/>
-    public Task ExecuteAsync(DiscoveryDocumentResult result, HttpContext context)
+    public Task WriteHttpResponse(DiscoveryDocumentResult result, HttpContext context)
     {
         if (result.MaxAge.HasValue && result.MaxAge.Value >= 0)
         {

--- a/src/IdentityServer/Endpoints/Results/EndPointResult.cs
+++ b/src/IdentityServer/Endpoints/Results/EndPointResult.cs
@@ -11,7 +11,9 @@ using Duende.IdentityServer.Hosting;
 namespace Duende.IdentityServer.Endpoints.Results;
 
 /// <summary>
-/// Provides the base implementation of IEndpointResult that invokes the corresponding IEndpointResultGenerator<typeparamref name="T"/>.
+/// Provides the base implementation of <see cref="IEndpointResult"/> that
+/// invokes the corresponding <see cref="IHttpResponseWriter{T}"/> to write the
+/// result as an http response.
 /// </summary>
 /// <typeparam name="T"></typeparam>
 public abstract class EndpointResult<T> : IEndpointResult
@@ -20,16 +22,16 @@ public abstract class EndpointResult<T> : IEndpointResult
     /// <inheritdoc/>
     public async Task ExecuteAsync(HttpContext context)
     {
-        var generator = context.RequestServices.GetService<IEndpointResultGenerator<T>>();
-        if (generator != null)
+        var writer = context.RequestServices.GetService<IHttpResponseWriter<T>>();
+        if (writer != null)
         {
             T target = this as T;
             if (target == null)
             {
-                throw new Exception($"Type paramter {typeof(T)} must be the class derived from 'EndPointResult<T>'.");
+                throw new Exception($"Type parameter {typeof(T)} must be the class derived from 'EndpointResult<T>'.");
             }
 
-            await generator.ExecuteAsync(target, context);
+            await writer.WriteHttpResponse(target, context);
         }
         else
         {

--- a/src/IdentityServer/Endpoints/Results/EndSessionCallbackResult.cs
+++ b/src/IdentityServer/Endpoints/Results/EndSessionCallbackResult.cs
@@ -37,16 +37,16 @@ public class EndSessionCallbackResult : EndpointResult<EndSessionCallbackResult>
     }
 }
 
-class EndSessionCallbackResultGenerator : IEndpointResultGenerator<EndSessionCallbackResult>
+class EndSessionCallbackHttpWriter : IHttpResponseWriter<EndSessionCallbackResult>
 {
-    public EndSessionCallbackResultGenerator(IdentityServerOptions options)
+    public EndSessionCallbackHttpWriter(IdentityServerOptions options)
     {
         _options = options;
     }
 
     private IdentityServerOptions _options;
 
-    public async Task ExecuteAsync(EndSessionCallbackResult result, HttpContext context)
+    public async Task WriteHttpResponse(EndSessionCallbackResult result, HttpContext context)
     {
         if (result.Result.IsError)
         {

--- a/src/IdentityServer/Endpoints/Results/EndSessionResult.cs
+++ b/src/IdentityServer/Endpoints/Results/EndSessionResult.cs
@@ -38,9 +38,9 @@ public class EndSessionResult : EndpointResult<EndSessionResult>
 }
 
 
-class EndSessionResultGenerator : IEndpointResultGenerator<EndSessionResult>
+class EndSessionHttpWriter : IHttpResponseWriter<EndSessionResult>
 {
-    public EndSessionResultGenerator(
+    public EndSessionHttpWriter(
         IdentityServerOptions options,
         IClock clock,
         IServerUrls urls,
@@ -57,7 +57,7 @@ class EndSessionResultGenerator : IEndpointResultGenerator<EndSessionResult>
     private IServerUrls _urls;
     private IMessageStore<LogoutMessage> _logoutMessageStore;
 
-    public async Task ExecuteAsync(EndSessionResult result, HttpContext context)
+    public async Task WriteHttpResponse(EndSessionResult result, HttpContext context)
     {
         var validatedRequest = result.Result.IsError ? null : result.Result.ValidatedRequest;
 

--- a/src/IdentityServer/Endpoints/Results/IntrospectionResult.cs
+++ b/src/IdentityServer/Endpoints/Results/IntrospectionResult.cs
@@ -37,9 +37,9 @@ public class IntrospectionResult : EndpointResult<IntrospectionResult>
 }
 
 
-class IntrospectionResultGenerator : IEndpointResultGenerator<IntrospectionResult>
+class IntrospectionHttpWriter : IHttpResponseWriter<IntrospectionResult>
 {
-    public Task ExecuteAsync(IntrospectionResult result, HttpContext context)
+    public Task WriteHttpResponse(IntrospectionResult result, HttpContext context)
     {
         context.Response.SetNoCache();
 

--- a/src/IdentityServer/Endpoints/Results/JsonWebKeysResult.cs
+++ b/src/IdentityServer/Endpoints/Results/JsonWebKeysResult.cs
@@ -46,9 +46,9 @@ public class JsonWebKeysResult : EndpointResult<JsonWebKeysResult>
     }
 }
 
-class JsonWebKeysResultGenerator : IEndpointResultGenerator<JsonWebKeysResult>
+class JsonWebKeysHttpWriter : IHttpResponseWriter<JsonWebKeysResult>
 {
-    public Task ExecuteAsync(JsonWebKeysResult result, HttpContext context)
+    public Task WriteHttpResponse(JsonWebKeysResult result, HttpContext context)
     {
         if (result.MaxAge.HasValue && result.MaxAge.Value >= 0)
         {

--- a/src/IdentityServer/Endpoints/Results/ProtectedResourceErrorResult.cs
+++ b/src/IdentityServer/Endpoints/Results/ProtectedResourceErrorResult.cs
@@ -38,9 +38,9 @@ public class ProtectedResourceErrorResult : EndpointResult<ProtectedResourceErro
     }
 }
 
-internal class ProtectedResourceErrorResultGenerator : IEndpointResultGenerator<ProtectedResourceErrorResult>
+internal class ProtectedResourceErrorHttpWriter : IHttpResponseWriter<ProtectedResourceErrorResult>
 {
-    public Task ExecuteAsync(ProtectedResourceErrorResult result, HttpContext context)
+    public Task WriteHttpResponse(ProtectedResourceErrorResult result, HttpContext context)
     {
         context.Response.StatusCode = 401;
         context.Response.SetNoCache();

--- a/src/IdentityServer/Endpoints/Results/PushedAuthorizationErrorResult.cs
+++ b/src/IdentityServer/Endpoints/Results/PushedAuthorizationErrorResult.cs
@@ -33,9 +33,9 @@ public class PushedAuthorizationErrorResult : EndpointResult<PushedAuthorization
     }
 }
 
-internal class PushedAuthorizationErrorResultGenerator : IEndpointResultGenerator<PushedAuthorizationErrorResult>
+internal class PushedAuthorizationErrorHttpWriter : IHttpResponseWriter<PushedAuthorizationErrorResult>
 {
-    public async Task ExecuteAsync(PushedAuthorizationErrorResult result, HttpContext context)
+    public async Task WriteHttpResponse(PushedAuthorizationErrorResult result, HttpContext context)
     {
         context.Response.SetNoCache();
         context.Response.StatusCode = (int) HttpStatusCode.BadRequest;

--- a/src/IdentityServer/Endpoints/Results/PushedAuthorizationResult.cs
+++ b/src/IdentityServer/Endpoints/Results/PushedAuthorizationResult.cs
@@ -33,9 +33,9 @@ public class PushedAuthorizationResult : EndpointResult<PushedAuthorizationResul
     }
 }
 
-internal class PushedAuthorizationResultGenerator : IEndpointResultGenerator<PushedAuthorizationResult>
+internal class PushedAuthorizationHttpWriter : IHttpResponseWriter<PushedAuthorizationResult>
 {
-    public async Task ExecuteAsync(PushedAuthorizationResult result, HttpContext context)
+    public async Task WriteHttpResponse(PushedAuthorizationResult result, HttpContext context)
     {
         context.Response.SetNoCache();
         context.Response.StatusCode = (int) HttpStatusCode.Created;

--- a/src/IdentityServer/Endpoints/Results/StatusCodeResult.cs
+++ b/src/IdentityServer/Endpoints/Results/StatusCodeResult.cs
@@ -42,9 +42,9 @@ public class StatusCodeResult : EndpointResult<StatusCodeResult>
     }
 }
 
-class StatusCodeResultGenerator : IEndpointResultGenerator<StatusCodeResult>
+class StatusCodeHttpWriter : IHttpResponseWriter<StatusCodeResult>
 {
-    public Task ExecuteAsync(StatusCodeResult result, HttpContext context)
+    public Task WriteHttpResponse(StatusCodeResult result, HttpContext context)
     {
         context.Response.StatusCode = result.StatusCode;
 

--- a/src/IdentityServer/Endpoints/Results/TokenErrorResult.cs
+++ b/src/IdentityServer/Endpoints/Results/TokenErrorResult.cs
@@ -37,9 +37,9 @@ public class TokenErrorResult : EndpointResult<TokenErrorResult>
     }
 }
 
-internal class TokenErrorResultGenerator : IEndpointResultGenerator<TokenErrorResult>
+internal class TokenErrorHttpWriter : IHttpResponseWriter<TokenErrorResult>
 {
-    public async Task ExecuteAsync(TokenErrorResult result, HttpContext context)
+    public async Task WriteHttpResponse(TokenErrorResult result, HttpContext context)
     {
         context.Response.StatusCode = 400;
         context.Response.SetNoCache();

--- a/src/IdentityServer/Endpoints/Results/TokenResult.cs
+++ b/src/IdentityServer/Endpoints/Results/TokenResult.cs
@@ -35,9 +35,9 @@ public class TokenResult : EndpointResult<TokenResult>
     }
 }
 
-internal class TokenResultGenerator : IEndpointResultGenerator<TokenResult>
+internal class TokenHttpWriter : IHttpResponseWriter<TokenResult>
 {
-    public async Task ExecuteAsync(TokenResult result, HttpContext context)
+    public async Task WriteHttpResponse(TokenResult result, HttpContext context)
     {
         context.Response.SetNoCache();
 

--- a/src/IdentityServer/Endpoints/Results/TokenRevocationErrorResult.cs
+++ b/src/IdentityServer/Endpoints/Results/TokenRevocationErrorResult.cs
@@ -35,9 +35,9 @@ public class TokenRevocationErrorResult : EndpointResult<TokenRevocationErrorRes
     }
 }
 
-class TokenRevocationErrorResultGenerator : IEndpointResultGenerator<TokenRevocationErrorResult>
+class TokenRevocationErrorHttpWriter : IHttpResponseWriter<TokenRevocationErrorResult>
 {
-    public Task ExecuteAsync(TokenRevocationErrorResult result, HttpContext context)
+    public Task WriteHttpResponse(TokenRevocationErrorResult result, HttpContext context)
     {
         context.Response.StatusCode = (int) HttpStatusCode.BadRequest;
         return context.Response.WriteJsonAsync(new { error = result.Error });

--- a/src/IdentityServer/Endpoints/Results/UserInfoResult.cs
+++ b/src/IdentityServer/Endpoints/Results/UserInfoResult.cs
@@ -31,9 +31,9 @@ public class UserInfoResult : EndpointResult<UserInfoResult>
     }
 }
 
-internal class UserInfoResultGenerator : IEndpointResultGenerator<UserInfoResult>
+internal class UserInfoHttpWriter : IHttpResponseWriter<UserInfoResult>
 {
-    public async Task ExecuteAsync(UserInfoResult result, HttpContext context)
+    public async Task WriteHttpResponse(UserInfoResult result, HttpContext context)
     {
         context.Response.SetNoCache();
         await context.Response.WriteJsonAsync(result.Claims);

--- a/src/IdentityServer/Hosting/IEndpointResult.cs
+++ b/src/IdentityServer/Hosting/IEndpointResult.cs
@@ -8,15 +8,16 @@ using System.Threading.Tasks;
 namespace Duende.IdentityServer.Hosting;
 
 /// <summary>
-/// Endpoint result
+/// An <see cref="IEndpointResult"/> is the object model that describes the
+/// results that will returned by one of the protocol endpoints provided by
+/// IdentityServer, and can be executed to produce an HTTP response.
 /// </summary>
 public interface IEndpointResult
 {
     /// <summary>
-    /// Executes the result.
+    /// Executes the result to write an http response.
     /// </summary>
     /// <param name="context">The HTTP context.</param>
-    /// <returns></returns>
     Task ExecuteAsync(HttpContext context);
 }
 

--- a/src/IdentityServer/Hosting/IEndpointRouter.cs
+++ b/src/IdentityServer/Hosting/IEndpointRouter.cs
@@ -9,14 +9,18 @@ using Microsoft.AspNetCore.Http;
 namespace Duende.IdentityServer.Hosting;
 
 /// <summary>
-/// The endpoint router
+/// The endpoint router is responsible for mapping incoming http requests onto
+/// <see cref="IEndpointHandler"/>s, for the protocol endpoints that
+/// IdentityServer supports.
 /// </summary>
 public interface IEndpointRouter
 {
     /// <summary>
-    /// Finds a matching endpoint.
+    /// Finds a matching <see cref="IEndpointHandler"/> for an incoming http
+    /// request.
     /// </summary>
     /// <param name="context">The HTTP context.</param>
-    /// <returns></returns>
+    /// <returns>The handler to process a protocol request, or null, if the
+    /// incoming http request is not a protocol request.</returns>
     IEndpointHandler? Find(HttpContext context);
 }

--- a/src/IdentityServer/Hosting/IHttpResponseWriter.cs
+++ b/src/IdentityServer/Hosting/IHttpResponseWriter.cs
@@ -8,14 +8,15 @@ using System.Threading.Tasks;
 namespace Duende.IdentityServer.Hosting;
 
 /// <summary>
-/// Endpoint result generator
+/// Contract for a service that writes appropriate http responses for <see
+/// cref="IEndpointResult"/> objects.
 /// </summary>
-public interface IEndpointResultGenerator<in T>
+public interface IHttpResponseWriter<in T>
     where T : IEndpointResult
 {
     /// <summary>
     /// Writes the endpoint result to the HTTP response.
     /// </summary>
-    Task ExecuteAsync(T result, HttpContext context);
+    Task WriteHttpResponse(T result, HttpContext context);
 }
 

--- a/src/IdentityServer/Services/IPushedAuthorizationSerializer.cs
+++ b/src/IdentityServer/Services/IPushedAuthorizationSerializer.cs
@@ -7,7 +7,8 @@ using System.Collections.Specialized;
 namespace Duende.IdentityServer.Services;
 
 /// <summary>
-/// A service that can serialize and deserialize pushed authorization requests.
+/// Contract for a service that can serialize and deserialize pushed
+/// authorization requests.
 /// </summary>
 public interface IPushedAuthorizationSerializer
 {

--- a/src/IdentityServer/Services/IPushedAuthorizationService.cs
+++ b/src/IdentityServer/Services/IPushedAuthorizationService.cs
@@ -9,7 +9,8 @@ using System.Threading.Tasks;
 namespace Duende.IdentityServer.Services;
 
 /// <summary>
-/// Contract for a service that performs logical operations on pushed authorization requests.
+/// Contract for a service that performs high-level operations on pushed
+/// authorization requests. 
 /// </summary>
 public interface IPushedAuthorizationService
 {

--- a/test/IdentityServer.UnitTests/Endpoints/EndSession/EndSessionCallbackResultTests.cs
+++ b/test/IdentityServer.UnitTests/Endpoints/EndSession/EndSessionCallbackResultTests.cs
@@ -19,7 +19,7 @@ public class EndSessionCallbackResultTests
 
     private readonly EndSessionCallbackValidationResult _validationResult;
     private readonly IdentityServerOptions _options;
-    private readonly EndSessionCallbackResultGenerator _subject;
+    private readonly EndSessionCallbackHttpWriter _subject;
 
     public EndSessionCallbackResultTests()
     {
@@ -28,7 +28,7 @@ public class EndSessionCallbackResultTests
             IsError = false,
         };
         _options = new IdentityServerOptions();
-        _subject = new EndSessionCallbackResultGenerator(_options);
+        _subject = new EndSessionCallbackHttpWriter(_options);
     }
 
     [Fact]
@@ -39,7 +39,7 @@ public class EndSessionCallbackResultTests
         var ctx = new DefaultHttpContext();
         ctx.Request.Method = "GET";
 
-        await _subject.ExecuteAsync(new EndSessionCallbackResult(_validationResult), ctx);
+        await _subject.WriteHttpResponse(new EndSessionCallbackResult(_validationResult), ctx);
 
         ctx.Response.Headers["Content-Security-Policy"].First().Should().Contain("frame-src http://foo");
     }
@@ -53,7 +53,7 @@ public class EndSessionCallbackResultTests
         var ctx = new DefaultHttpContext();
         ctx.Request.Method = "GET";
 
-        await _subject.ExecuteAsync(new EndSessionCallbackResult(_validationResult), ctx);
+        await _subject.WriteHttpResponse(new EndSessionCallbackResult(_validationResult), ctx);
 
         ctx.Response.Headers["Content-Security-Policy"].FirstOrDefault().Should().BeNull();
     }

--- a/test/IdentityServer.UnitTests/Endpoints/Results/AuthorizeResultTests.cs
+++ b/test/IdentityServer.UnitTests/Endpoints/Results/AuthorizeResultTests.cs
@@ -26,7 +26,7 @@ namespace UnitTests.Endpoints.Results;
 
 public class AuthorizeResultTests
 {
-    private AuthorizeResultGenerator _subject;
+    private AuthorizeHttpWriter _subject;
 
     private AuthorizeResponse _response = new AuthorizeResponse();
     private IdentityServerOptions _options = new IdentityServerOptions();
@@ -47,7 +47,7 @@ public class AuthorizeResultTests
         _options.UserInteraction.ErrorUrl = "~/error";
         _options.UserInteraction.ErrorIdParameter = "errorId";
 
-        _subject = new AuthorizeResultGenerator(_options, _mockUserSession, new TestPushedAuthorizationService(), _mockErrorMessageStore, _urls, new StubClock());
+        _subject = new AuthorizeHttpWriter(_options, _mockUserSession, new TestPushedAuthorizationService(), _mockErrorMessageStore, _urls, new StubClock());
     }
 
     [Fact]
@@ -55,7 +55,7 @@ public class AuthorizeResultTests
     {
         _response.Error = "some_error";
 
-        await _subject.ExecuteAsync(new AuthorizeResult(_response), _context);
+        await _subject.WriteHttpResponse(new AuthorizeResult(_response), _context);
 
         _mockErrorMessageStore.Messages.Count.Should().Be(1);
         _context.Response.StatusCode.Should().Be(302);
@@ -80,7 +80,7 @@ public class AuthorizeResultTests
             PromptModes = new[] { "none" }
         };
 
-        await _subject.ExecuteAsync(new AuthorizeResult(_response), _context);
+        await _subject.WriteHttpResponse(new AuthorizeResult(_response), _context);
 
         _mockUserSession.Clients.Count.Should().Be(0);
         _context.Response.StatusCode.Should().Be(302);
@@ -104,7 +104,7 @@ public class AuthorizeResultTests
         };
         _response.SessionState = "some_session_state";
 
-        await _subject.ExecuteAsync(new AuthorizeResult(_response), _context);
+        await _subject.WriteHttpResponse(new AuthorizeResult(_response), _context);
 
         _mockUserSession.Clients.Count.Should().Be(0);
         _context.Response.StatusCode.Should().Be(302);
@@ -125,7 +125,7 @@ public class AuthorizeResultTests
             RedirectUri = "http://client/callback"
         };
 
-        await _subject.ExecuteAsync(new AuthorizeResult(_response), _context);
+        await _subject.WriteHttpResponse(new AuthorizeResult(_response), _context);
 
         _mockUserSession.Clients.Count.Should().Be(0);
         _context.Response.StatusCode.Should().Be(302);
@@ -149,7 +149,7 @@ public class AuthorizeResultTests
             RedirectUri = "http://client/callback"
         };
 
-        await _subject.ExecuteAsync(new AuthorizeResult(_response), _context);
+        await _subject.WriteHttpResponse(new AuthorizeResult(_response), _context);
 
         _mockUserSession.Clients.Should().Contain("client");
     }
@@ -165,7 +165,7 @@ public class AuthorizeResultTests
             State = "state"
         };
 
-        await _subject.ExecuteAsync(new AuthorizeResult(_response), _context);
+        await _subject.WriteHttpResponse(new AuthorizeResult(_response), _context);
 
         _context.Response.StatusCode.Should().Be(302);
         _context.Response.Headers["Cache-Control"].First().Should().Contain("no-store");
@@ -187,7 +187,7 @@ public class AuthorizeResultTests
             State = "state"
         };
 
-        await _subject.ExecuteAsync(new AuthorizeResult(_response), _context);
+        await _subject.WriteHttpResponse(new AuthorizeResult(_response), _context);
 
         _context.Response.StatusCode.Should().Be(302);
         _context.Response.Headers["Cache-Control"].First().Should().Contain("no-store");
@@ -209,7 +209,7 @@ public class AuthorizeResultTests
             State = "state"
         };
 
-        await _subject.ExecuteAsync(new AuthorizeResult(_response), _context);
+        await _subject.WriteHttpResponse(new AuthorizeResult(_response), _context);
 
         _context.Response.StatusCode.Should().Be(200);
         _context.Response.ContentType.Should().StartWith("text/html");
@@ -243,7 +243,7 @@ public class AuthorizeResultTests
 
         _options.Csp.Level = CspLevel.One;
 
-        await _subject.ExecuteAsync(new AuthorizeResult(_response), _context);
+        await _subject.WriteHttpResponse(new AuthorizeResult(_response), _context);
 
         _context.Response.Headers["Content-Security-Policy"].First().Should().Contain($"script-src 'unsafe-inline' '{IdentityServerConstants.ContentSecurityPolicyHashes.AuthorizeScript}'");
         _context.Response.Headers["X-Content-Security-Policy"].First().Should().Contain($"script-src 'unsafe-inline' '{IdentityServerConstants.ContentSecurityPolicyHashes.AuthorizeScript}'");
@@ -262,7 +262,7 @@ public class AuthorizeResultTests
 
         _options.Csp.AddDeprecatedHeader = false;
 
-        await _subject.ExecuteAsync(new AuthorizeResult(_response), _context);
+        await _subject.WriteHttpResponse(new AuthorizeResult(_response), _context);
 
         _context.Response.Headers["Content-Security-Policy"].First().Should().Contain($"script-src '{IdentityServerConstants.ContentSecurityPolicyHashes.AuthorizeScript}'");
         _context.Response.Headers["X-Content-Security-Policy"].Should().BeEmpty();

--- a/test/IdentityServer.UnitTests/Endpoints/Results/CheckSessionResultTests.cs
+++ b/test/IdentityServer.UnitTests/Endpoints/Results/CheckSessionResultTests.cs
@@ -17,7 +17,7 @@ namespace UnitTests.Endpoints.Results;
 
 public class CheckSessionResultTests
 {
-    private CheckSessionResultGenerator _subject;
+    private CheckSessionHttpWriter _subject;
 
     private IdentityServerOptions _options = new IdentityServerOptions();
 
@@ -31,13 +31,13 @@ public class CheckSessionResultTests
 
         _options.Authentication.CheckSessionCookieName = "foobar";
 
-        _subject = new CheckSessionResultGenerator(_options);
+        _subject = new CheckSessionHttpWriter(_options);
     }
 
     [Fact]
     public async Task should_pass_results_in_body()
     {
-        await _subject.ExecuteAsync(new CheckSessionResult(), _context);
+        await _subject.WriteHttpResponse(new CheckSessionResult(), _context);
 
         _context.Response.StatusCode.Should().Be(200);
         _context.Response.ContentType.Should().StartWith("text/html");
@@ -58,7 +58,7 @@ public class CheckSessionResultTests
     {
         _options.Csp.Level = CspLevel.One;
 
-        await _subject.ExecuteAsync(new CheckSessionResult(), _context);
+        await _subject.WriteHttpResponse(new CheckSessionResult(), _context);
 
         _context.Response.Headers["Content-Security-Policy"].First().Should().Contain($"script-src 'unsafe-inline' '{IdentityServerConstants.ContentSecurityPolicyHashes.CheckSessionScript}'");
         _context.Response.Headers["X-Content-Security-Policy"].First().Should().Contain($"script-src 'unsafe-inline' '{IdentityServerConstants.ContentSecurityPolicyHashes.CheckSessionScript}'");
@@ -69,7 +69,7 @@ public class CheckSessionResultTests
     {
         _options.Csp.AddDeprecatedHeader = false;
 
-        await _subject.ExecuteAsync(new CheckSessionResult(), _context);
+        await _subject.WriteHttpResponse(new CheckSessionResult(), _context);
 
         _context.Response.Headers["Content-Security-Policy"].First().Should().Contain($"script-src '{IdentityServerConstants.ContentSecurityPolicyHashes.CheckSessionScript}'");
         _context.Response.Headers["X-Content-Security-Policy"].Should().BeEmpty();
@@ -82,7 +82,7 @@ public class CheckSessionResultTests
     public async Task can_change_cached_cookiename(string cookieName)
     {
         _options.Authentication.CheckSessionCookieName = cookieName;
-        await _subject.ExecuteAsync(new CheckSessionResult(), _context);
+        await _subject.WriteHttpResponse(new CheckSessionResult(), _context);
         _context.Response.Body.Seek(0, SeekOrigin.Begin);
         using (var rdr = new StreamReader(_context.Response.Body))
         {

--- a/test/IdentityServer.UnitTests/Endpoints/Results/EndSessionCallbackResultTests.cs
+++ b/test/IdentityServer.UnitTests/Endpoints/Results/EndSessionCallbackResultTests.cs
@@ -18,7 +18,7 @@ namespace UnitTests.Endpoints.Results;
 
 public class EndSessionCallbackResultTests
 {
-    private EndSessionCallbackResultGenerator _subject;
+    private EndSessionCallbackHttpWriter _subject;
 
     private EndSessionCallbackValidationResult _result = new EndSessionCallbackValidationResult();
     private IdentityServerOptions _options = TestIdentityServerOptions.Create();
@@ -31,7 +31,7 @@ public class EndSessionCallbackResultTests
         _context.Request.Host = new HostString("server");
         _context.Response.Body = new MemoryStream();
 
-        _subject = new EndSessionCallbackResultGenerator(_options);
+        _subject = new EndSessionCallbackHttpWriter(_options);
     }
 
     [Fact]
@@ -39,7 +39,7 @@ public class EndSessionCallbackResultTests
     {
         _result.IsError = true;
 
-        await _subject.ExecuteAsync(new EndSessionCallbackResult(_result), _context);
+        await _subject.WriteHttpResponse(new EndSessionCallbackResult(_result), _context);
 
         _context.Response.StatusCode.Should().Be(400);
     }
@@ -50,7 +50,7 @@ public class EndSessionCallbackResultTests
         _result.IsError = false;
         _result.FrontChannelLogoutUrls = new string[] { "http://foo.com", "http://bar.com" };
 
-        await _subject.ExecuteAsync(new EndSessionCallbackResult(_result), _context);
+        await _subject.WriteHttpResponse(new EndSessionCallbackResult(_result), _context);
 
         _context.Response.ContentType.Should().StartWith("text/html");
         _context.Response.Headers["Cache-Control"].First().Should().Contain("no-store");
@@ -78,7 +78,7 @@ public class EndSessionCallbackResultTests
 
         _options.Csp.Level = CspLevel.One;
 
-        await _subject.ExecuteAsync(new EndSessionCallbackResult(_result), _context);
+        await _subject.WriteHttpResponse(new EndSessionCallbackResult(_result), _context);
 
         _context.Response.Headers["Content-Security-Policy"].First().Should().Contain("style-src 'unsafe-inline' 'sha256-e6FQZewefmod2S/5T11pTXjzE2vn3/8GRwWOs917YE4='");
         _context.Response.Headers["X-Content-Security-Policy"].First().Should().Contain("style-src 'unsafe-inline' 'sha256-e6FQZewefmod2S/5T11pTXjzE2vn3/8GRwWOs917YE4='");
@@ -91,7 +91,7 @@ public class EndSessionCallbackResultTests
 
         _options.Csp.AddDeprecatedHeader = false;
 
-        await _subject.ExecuteAsync(new EndSessionCallbackResult(_result), _context);
+        await _subject.WriteHttpResponse(new EndSessionCallbackResult(_result), _context);
 
         _context.Response.Headers["Content-Security-Policy"].First().Should().Contain("style-src 'sha256-e6FQZewefmod2S/5T11pTXjzE2vn3/8GRwWOs917YE4='");
         _context.Response.Headers["X-Content-Security-Policy"].Should().BeEmpty();

--- a/test/IdentityServer.UnitTests/Endpoints/Results/EndSessionResultTests.cs
+++ b/test/IdentityServer.UnitTests/Endpoints/Results/EndSessionResultTests.cs
@@ -20,7 +20,7 @@ namespace UnitTests.Endpoints.Results;
 
 public class EndSessionResultTests
 {
-    private EndSessionResultGenerator _subject;
+    private EndSessionHttpWriter _subject;
 
     private EndSessionValidationResult _result = new EndSessionValidationResult();
     private IdentityServerOptions _options = new IdentityServerOptions();
@@ -39,7 +39,7 @@ public class EndSessionResultTests
         _options.UserInteraction.LogoutUrl = "~/logout";
         _options.UserInteraction.LogoutIdParameter = "logoutId";
 
-        _subject = new EndSessionResultGenerator(_options, new StubClock(), _urls, _mockLogoutMessageStore);
+        _subject = new EndSessionHttpWriter(_options, new StubClock(), _urls, _mockLogoutMessageStore);
     }
 
     [Fact]
@@ -55,7 +55,7 @@ public class EndSessionResultTests
             PostLogOutUri = "http://client/post-logout-callback"
         };
 
-        await _subject.ExecuteAsync(new EndSessionResult(_result), _context);
+        await _subject.WriteHttpResponse(new EndSessionResult(_result), _context);
 
         _mockLogoutMessageStore.Messages.Count.Should().Be(1);
         var location = _context.Response.Headers["Location"].Single();
@@ -70,7 +70,7 @@ public class EndSessionResultTests
     {
         _result.IsError = false;
 
-        await _subject.ExecuteAsync(new EndSessionResult(_result), _context);
+        await _subject.WriteHttpResponse(new EndSessionResult(_result), _context);
 
         _mockLogoutMessageStore.Messages.Count.Should().Be(0);
         var location = _context.Response.Headers["Location"].Single();
@@ -93,7 +93,7 @@ public class EndSessionResultTests
             PostLogOutUri = "http://client/post-logout-callback"
         };
 
-        await _subject.ExecuteAsync(new EndSessionResult(_result), _context);
+        await _subject.WriteHttpResponse(new EndSessionResult(_result), _context);
 
         _mockLogoutMessageStore.Messages.Count.Should().Be(0);
         var location = _context.Response.Headers["Location"].Single();


### PR DESCRIPTION
## #1425 (Rename result generator)
- Rename `IEndpointResultGenerator `-> `IHttpResponseWriter` (this is an un-released interface, so not a breaking change!)
- `IEndpointResultGenerator.ExecuteAsync` -> `WriteHttpResponse`
- Rename implementations of `IEndpointResultGenerator`, e.g., `TokenResultGenerator `-> `TokenHttpWriter`
## #1446 (Allow for customization of /connect/authorize's html response)
- Make `AuthorizeHttpWriter` public and add virtual methods to control its form post html output

