### PR TITLE
Provide abstraction for IdentityServerTools

### DIFF
--- a/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -190,7 +190,13 @@ public static class IdentityServerBuilderExtensionsCore
         builder.Services.AddTransient<IJwtRequestValidator, JwtRequestValidator>();
 
         builder.Services.AddTransient<ReturnUrlParser>();
+
+#pragma warning disable CS0618 // Type or member is obsolete
         builder.Services.AddTransient<IIdentityServerTools, IdentityServerTools>();
+        // We've added the IIdentityServerTools interface to allow mocking, but keep the old
+        // direct class registration around if anyone has a dependency on it.
+        builder.Services.AddTransient<IdentityServerTools>();
+#pragma warning restore CS0618 // Type or member is obsolete
 
         builder.Services.AddTransient<IReturnUrlParser, OidcReturnUrlParser>();
         builder.Services.AddScoped<IUserSession, DefaultUserSession>();

--- a/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -190,7 +190,7 @@ public static class IdentityServerBuilderExtensionsCore
         builder.Services.AddTransient<IJwtRequestValidator, JwtRequestValidator>();
 
         builder.Services.AddTransient<ReturnUrlParser>();
-        builder.Services.AddTransient<IdentityServerTools>();
+        builder.Services.AddTransient<IIdentityServerTools, IdentityServerTools>();
 
         builder.Services.AddTransient<IReturnUrlParser, OidcReturnUrlParser>();
         builder.Services.AddScoped<IUserSession, DefaultUserSession>();

--- a/src/IdentityServer/Extensions/IdentityServerToolsExtensions.cs
+++ b/src/IdentityServer/Extensions/IdentityServerToolsExtensions.cs
@@ -13,9 +13,9 @@ using System.Threading.Tasks;
 namespace Duende.IdentityServer;
 
 /// <summary>
-/// Extensions for IdentityServerTools
+/// Extensions for IIdentityServerTools
 /// </summary>
-public static class IdentityServerToolsExtensions
+public static class IIdentityServerToolsExtensions
 {
     /// <summary>
     /// Issues the client JWT.
@@ -27,7 +27,7 @@ public static class IdentityServerToolsExtensions
     /// <param name="audiences">The audiences.</param>
     /// <param name="additionalClaims">Additional claims</param>
     /// <returns></returns>
-    public static async Task<string> IssueClientJwtAsync(this IdentityServerTools tools,
+    public static async Task<string> IssueClientJwtAsync(this IIdentityServerTools tools,
         string clientId,
         int lifetime,
         IEnumerable<string> scopes = null,

--- a/src/IdentityServer/IdentityServerTools.cs
+++ b/src/IdentityServer/IdentityServerTools.cs
@@ -17,7 +17,44 @@ namespace Duende.IdentityServer;
 /// <summary>
 /// Class for useful helpers for interacting with IdentityServer
 /// </summary>
-public class IdentityServerTools
+public interface IIdentityServerTools
+{
+
+    /// <summary>
+    /// Issues a JWT.
+    /// </summary>
+    /// <param name="lifetime">The lifetime.</param>
+    /// <param name="claims">The claims.</param>
+    /// <returns></returns>
+    /// <exception cref="System.ArgumentNullException">claims</exception>
+    Task<string> IssueJwtAsync(int lifetime, IEnumerable<Claim> claims);
+
+    /// <summary>
+    /// Issues a JWT.
+    /// </summary>
+    /// <param name="lifetime">The lifetime.</param>
+    /// <param name="issuer">The issuer.</param>
+    /// <param name="claims">The claims.</param>
+    /// <returns></returns>
+    /// <exception cref="System.ArgumentNullException">claims</exception>
+    Task<string> IssueJwtAsync(int lifetime, string issuer, IEnumerable<Claim> claims);
+
+    /// <summary>
+    /// Issues a JWT.
+    /// </summary>
+    /// <param name="lifetime">The lifetime.</param>
+    /// <param name="issuer">The issuer.</param>
+    /// <param name="tokenType"></param>
+    /// <param name="claims">The claims.</param>
+    /// <returns></returns>
+    /// <exception cref="System.ArgumentNullException">claims</exception>
+    Task<string> IssueJwtAsync(int lifetime, string issuer, string tokenType, IEnumerable<Claim> claims);
+}
+
+/// <summary>
+/// Class for useful helpers for interacting with IdentityServer
+/// </summary>
+public class IdentityServerTools : IIdentityServerTools
 {
     internal readonly IServiceProvider ServiceProvider;
     internal readonly IIssuerNameService IssuerNameService;

--- a/src/IdentityServer/IdentityServerTools.cs
+++ b/src/IdentityServer/IdentityServerTools.cs
@@ -15,7 +15,7 @@ using System.Threading.Tasks;
 namespace Duende.IdentityServer;
 
 /// <summary>
-/// Class for useful helpers for interacting with IdentityServer
+/// Useful helpers for interacting with IdentityServer.
 /// </summary>
 public interface IIdentityServerTools
 {
@@ -61,13 +61,7 @@ public class IdentityServerTools : IIdentityServerTools
     private readonly ITokenCreationService _tokenCreation;
     private readonly IClock _clock;
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="IdentityServerTools" /> class.
-    /// </summary>
-    /// <param name="serviceProvider">The provider.</param>
-    /// <param name="issuerNameService">The issuer name service</param>
-    /// <param name="tokenCreation">The token creation service.</param>
-    /// <param name="clock">The clock.</param>
+    /// <inheritdoc/>
     public IdentityServerTools(IServiceProvider serviceProvider, IIssuerNameService issuerNameService, ITokenCreationService tokenCreation, IClock clock)
     {
         ServiceProvider = serviceProvider;
@@ -76,42 +70,21 @@ public class IdentityServerTools : IIdentityServerTools
         _clock = clock;
     }
 
-    /// <summary>
-    /// Issues a JWT.
-    /// </summary>
-    /// <param name="lifetime">The lifetime.</param>
-    /// <param name="claims">The claims.</param>
-    /// <returns></returns>
-    /// <exception cref="System.ArgumentNullException">claims</exception>
+    /// <inheritdoc/>
     public virtual async Task<string> IssueJwtAsync(int lifetime, IEnumerable<Claim> claims)
     {
         var issuer = await IssuerNameService.GetCurrentAsync();
         return await IssueJwtAsync(lifetime, issuer, claims);
     }
 
-    /// <summary>
-    /// Issues a JWT.
-    /// </summary>
-    /// <param name="lifetime">The lifetime.</param>
-    /// <param name="issuer">The issuer.</param>
-    /// <param name="claims">The claims.</param>
-    /// <returns></returns>
-    /// <exception cref="System.ArgumentNullException">claims</exception>
+    /// <inheritdoc/>
     public virtual Task<string> IssueJwtAsync(int lifetime, string issuer, IEnumerable<Claim> claims)
     {
         var tokenType = OidcConstants.TokenTypes.AccessToken;
         return IssueJwtAsync(lifetime, issuer, tokenType, claims);
     }
 
-    /// <summary>
-    /// Issues a JWT.
-    /// </summary>
-    /// <param name="lifetime">The lifetime.</param>
-    /// <param name="issuer">The issuer.</param>
-    /// <param name="tokenType"></param>
-    /// <param name="claims">The claims.</param>
-    /// <returns></returns>
-    /// <exception cref="System.ArgumentNullException">claims</exception>
+    /// <inheritdoc/>
     public virtual async Task<string> IssueJwtAsync(int lifetime, string issuer, string tokenType, IEnumerable<Claim> claims)
     {
         if (String.IsNullOrWhiteSpace(issuer)) throw new ArgumentNullException(nameof(issuer));

--- a/src/IdentityServer/IdentityServerTools.cs
+++ b/src/IdentityServer/IdentityServerTools.cs
@@ -49,15 +49,30 @@ public interface IIdentityServerTools
     /// <returns></returns>
     /// <exception cref="System.ArgumentNullException">claims</exception>
     Task<string> IssueJwtAsync(int lifetime, string issuer, string tokenType, IEnumerable<Claim> claims);
+
+    /// <summary>
+    /// Service Provider to resolve services.
+    /// </summary>
+    public IServiceProvider ServiceProvider { get; }
+
+    /// <summary>
+    /// Issuer name service
+    /// </summary>
+    public IIssuerNameService IssuerNameService { get; }
 }
 
 /// <summary>
 /// Class for useful helpers for interacting with IdentityServer
 /// </summary>
+[Obsolete("Do not reference the IdentityServerTools implementation directly, use the IIdentityServerTools interface")]
 public class IdentityServerTools : IIdentityServerTools
 {
-    internal readonly IServiceProvider ServiceProvider;
-    internal readonly IIssuerNameService IssuerNameService;
+    /// <inheritdoc/>
+    public IServiceProvider ServiceProvider { get; }
+
+    /// <inheritdoc/>
+    public IIssuerNameService IssuerNameService { get; }
+
     private readonly ITokenCreationService _tokenCreation;
     private readonly IClock _clock;
 

--- a/src/IdentityServer/Services/Default/DefaultBackChannelLogoutService.cs
+++ b/src/IdentityServer/Services/Default/DefaultBackChannelLogoutService.cs
@@ -31,7 +31,7 @@ public class DefaultBackChannelLogoutService : IBackChannelLogoutService
     /// <summary>
     /// The IdentityServerTools used to create and the JWT.
     /// </summary>
-    protected IdentityServerTools Tools { get; }
+    protected IIdentityServerTools Tools { get; }
 
     /// <summary>
     /// The ILogoutNotificationService to build the back channel logout requests.
@@ -58,7 +58,7 @@ public class DefaultBackChannelLogoutService : IBackChannelLogoutService
     /// <param name="logger"></param>
     public DefaultBackChannelLogoutService(
         IClock clock,
-        IdentityServerTools tools,
+        IIdentityServerTools tools,
         ILogoutNotificationService logoutNotificationService,
         IBackChannelLogoutHttpClient backChannelLogoutHttpClient,
         ILogger<IBackChannelLogoutService> logger)

--- a/test/IdentityServer.IntegrationTests/Endpoints/Ciba/CibaTests.cs
+++ b/test/IdentityServer.IntegrationTests/Endpoints/Ciba/CibaTests.cs
@@ -1428,7 +1428,7 @@ public class CibaTests
     {
         _mockPipeline.Options.IssuerUri = IdentityServerPipeline.BaseUrl;
 
-        var tokenService = _mockPipeline.Resolve<IdentityServerTools>();
+        var tokenService = _mockPipeline.Resolve<IIdentityServerTools>();
         var id_token = await tokenService.IssueJwtAsync(600, new Claim[] {
             new Claim("sub", _user.SubjectId),
             new Claim("aud", _cibaClient.ClientId),


### PR DESCRIPTION
**What issue does this PR address?**
`IdentityServerTools` is useful and I expect used in a lot of places. However as it's a concrete class it is difficult to test services that depend on it. This PR creates an abstraction `IIdentityServerTools` which can be injected instead, and can therefore be mocked easily for tests. This is important for testing services that depend upon `IdentityServerTools` but don't explicitly need it for testing purposes.

**Note:** This would be a breaking change. Personally I think that's ok, but if you wanted to maintain backward compatibility, we could keep both registrations:

```csharp
builder.Services.AddTransient<IIdentityServerTools, IdentityServerTools>();
builder.Services.AddTransient<IdentityServerTools>();
```


**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
