### PR TITLE
Relax handling of DCR license issues

### DIFF
--- a/src/Configuration/Licensing/ConfigurationLicenseValidator.cs
+++ b/src/Configuration/Licensing/ConfigurationLicenseValidator.cs
@@ -30,7 +30,7 @@ internal class ConfigurationLicenseValidator : LicenseValidator<ConfigurationLic
         
         if (!License.ConfigApiFeature)
         {
-            throw new Exception($"You are using the IdentityServer Configuration API feature. Your license for Duende IdentityServer does not include that feature. This feature requires the Business or Enterprise Edition tier of license.");
+            errors.Add($"You are using the IdentityServer Configuration API feature. Your license for Duende IdentityServer does not include that feature. This feature requires the Business or Enterprise Edition tier of license.");
         }
     }
 


### PR DESCRIPTION
Instead of shutting down if the license is wrong, warn. This makes DCR behave the same as e.g., automatic key management.

