### PR TITLE
Discourage IAuthorizationParametersMessageStore

### DIFF
--- a/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Additional.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Additional.cs
@@ -492,6 +492,7 @@ public static class IdentityServerBuilderExtensionsAdditional
     /// <typeparam name="T"></typeparam>
     /// <param name="builder">The builder.</param>
     /// <returns></returns>
+    [Obsolete("This feature is deprecated. Consider using Pushed Authorization Requests instead.")]
     public static IIdentityServerBuilder AddAuthorizationParametersMessageStore<T>(this IIdentityServerBuilder builder)
         where T : class, IAuthorizationParametersMessageStore
     {

--- a/src/IdentityServer/Endpoints/Results/AuthorizeInteractionPageResult.cs
+++ b/src/IdentityServer/Endpoints/Results/AuthorizeInteractionPageResult.cs
@@ -74,9 +74,12 @@ class AuthorizeInteractionPageHttpWriter : IHttpResponseWriter<AuthorizeInteract
     {
         var returnUrl = _urls.BasePath.EnsureTrailingSlash() + ProtocolRoutePaths.AuthorizeCallback;
 
+        // IAuthorizationParametersMessageStore is deprecated and will be removed someday
         if (_authorizationParametersMessageStore != null)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             var msg = new Message<IDictionary<string, string[]>>(result.Request.ToOptimizedFullDictionary());
+#pragma warning restore CS0618 // Type or member is obsolete
             var id = await _authorizationParametersMessageStore.WriteAsync(msg);
             returnUrl = returnUrl.AddQueryString(Constants.AuthorizationParamsStore.MessageStoreIdParameterName, id);
         }

--- a/src/IdentityServer/Extensions/ValidatedAuthorizeRequestExtensions.cs
+++ b/src/IdentityServer/Extensions/ValidatedAuthorizeRequestExtensions.cs
@@ -187,6 +187,7 @@ public static class ValidatedAuthorizeRequestExtensions
         return request.ToOptimizedRawValues().ToQueryString();
     }
 
+    [Obsolete("This method is obsolete and will be removed in a future version.")]
     public static IDictionary<string, string[]> ToOptimizedFullDictionary(this ValidatedAuthorizeRequest request)
     {
         return request.ToOptimizedRawValues().ToFullDictionary();

--- a/test/IdentityServer.UnitTests/Extensions/ValidatedAuthorizeRequestExtensionsTests.cs
+++ b/test/IdentityServer.UnitTests/Extensions/ValidatedAuthorizeRequestExtensionsTests.cs
@@ -2,6 +2,7 @@
 // See LICENSE in the project root for license information.
 
 
+using System;
 using Duende.IdentityServer.Validation;
 using IdentityModel;
 using Xunit;
@@ -29,6 +30,7 @@ public class ValidatedAuthorizeRequestExtensionsTests
     }
 
     [Fact]
+    [Obsolete]
     public void ToOptimizedFullDictionary_should_return_dictionary_with_array_for_repeated_keys_when_request_objects_are_used()
     {
         var request = new ValidatedAuthorizeRequest()


### PR DESCRIPTION
PAR is a more robust/standardized approach to get similar benefits

This PR obsoletes the extension method that registers the default `IAuthorizationParametersMessageStore` as well as the `ToOptimizedFullDictionary` method, which is only used when that store is used. There are more types that could in theory be obsoleted - notably the `IAuthorizationParametersMessageStore` itself, but that gets used in many places, and would add quite a bit of clutter.

This closes #1444