### PR TITLE
Remove [Obsolete] from IdentityServerTools

### DIFF
--- a/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -188,16 +188,8 @@ public static class IdentityServerBuilderExtensionsCore
         builder.Services.AddTransient<ExtensionGrantValidator>();
         builder.Services.AddTransient<BearerTokenUsageValidator>();
         builder.Services.AddTransient<IJwtRequestValidator, JwtRequestValidator>();
-
         builder.Services.AddTransient<ReturnUrlParser>();
-
-#pragma warning disable CS0618 // Type or member is obsolete
         builder.Services.AddTransient<IIdentityServerTools, IdentityServerTools>();
-        // We've added the IIdentityServerTools interface to allow mocking, but keep the old
-        // direct class registration around if anyone has a dependency on it.
-        builder.Services.AddTransient<IdentityServerTools>();
-#pragma warning restore CS0618 // Type or member is obsolete
-
         builder.Services.AddTransient<IReturnUrlParser, OidcReturnUrlParser>();
         builder.Services.AddScoped<IUserSession, DefaultUserSession>();
         builder.Services.AddTransient(typeof(MessageCookie<>));

--- a/src/IdentityServer/IdentityServerTools.cs
+++ b/src/IdentityServer/IdentityServerTools.cs
@@ -63,7 +63,6 @@ public interface IIdentityServerTools
 /// <summary>
 /// Class for useful helpers for interacting with IdentityServer
 /// </summary>
-[Obsolete("Do not reference the IdentityServerTools implementation directly, use the IIdentityServerTools interface")]
 public class IdentityServerTools : IIdentityServerTools
 {
     /// <inheritdoc/>

--- a/test/IdentityServer.UnitTests/Services/Default/DefaultBackChannelLogoutServiceTests.cs
+++ b/test/IdentityServer.UnitTests/Services/Default/DefaultBackChannelLogoutServiceTests.cs
@@ -55,14 +55,12 @@ public class DefaultBackChannelLogoutServiceTests
         var tokenCreation = new DefaultTokenCreationService(new MockClock(), mockKeyMaterialService, TestIdentityServerOptions.Create(), TestLogger.Create<DefaultTokenCreationService>());
 
         var issuerNameService = new TestIssuerNameService(expected);
-#pragma warning disable CS0618 // Type or member is obsolete
         var tools = new IdentityServerTools(
             null, // service provider is unused 
             issuerNameService,
             tokenCreation,
             new MockClock()
         );
-#pragma warning restore CS0618 // Type or member is obsolete
 
         var subject = new ServiceTestHarness(null, tools, null, null, issuerNameService, null);
         var rawToken = await subject.ExerciseCreateTokenAsync(new BackChannelLogoutRequest


### PR DESCRIPTION
`[Obsolete]` was added to the `IdentityServerTools` class when we introduced the `IIdentityServerTools` interface. This was added to try to alert users that they may need to change their DI registrations.

Users can customize `IdentityServerTools` today by deriving from the class, and then registering the custom version like this:
```cs
builder.Services.AddTransient<IdentityServerTools, CustomIdentityServerTools>
```

Pre-v7, this works because our code depends on an `IdentityServerTools`, which resolves to `CustomIdentityServerTools`. In v7, this fails because our code depends on an `IIdentityerServerTools`, which resolves to `IdentityServerTools`.

Users need to change to 
```cs
builder.Services.AddTransient<IIdentityerServerTools, CustomIdentityServerTools>
```

Marking `IdentityServerTools` as `[Obsolete]` provides a compiler warning to draw attention to this issue.

However, the downside to this is that now `CustomIdentityServerTools` will complain that its base class is obsolete, even though it is still valid to derive from `IdentityServerTools` and override its virtual methods. 

Either way can cause confusion, but I think its better to treat this as a documentation/release notes problem, rather than trying to use the bend the semantics of this compiler warning this far.