### PR TITLE
CIBA Customization Extensibility Points

### DIFF
--- a/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Additional.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Additional.cs
@@ -346,6 +346,20 @@ public static class IdentityServerBuilderExtensionsAdditional
     }
 
     /// <summary>
+    /// Adds the custom backchannel authentication request validator.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="builder">The builder.</param>
+    /// <returns></returns>
+    public static IIdentityServerBuilder AddCustomBackchannelAuthenticationRequestValidator<T>(this IIdentityServerBuilder builder)
+        where T : class, ICustomBackchannelAuthenticationValidator
+    {
+        builder.Services.AddTransient<ICustomBackchannelAuthenticationValidator, T>();
+
+        return builder;
+    }
+
+    /// <summary>
     /// Adds support for client authentication using JWT bearer assertions.
     /// </summary>
     /// <param name="builder">The builder.</param>

--- a/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -341,6 +341,7 @@ public static class IdentityServerBuilderExtensionsCore
         // optional
         builder.Services.TryAddTransient<ICustomTokenValidator, DefaultCustomTokenValidator>();
         builder.Services.TryAddTransient<ICustomAuthorizeRequestValidator, DefaultCustomAuthorizeRequestValidator>();
+        builder.Services.TryAddTransient<ICustomBackchannelAuthenticationValidator, DefaultCustomBackchannelAuthenticationValidator>();
             
         return builder;
     }

--- a/src/IdentityServer/Endpoints/Results/BackchannelAuthenticationResult.cs
+++ b/src/IdentityServer/Endpoints/Results/BackchannelAuthenticationResult.cs
@@ -71,7 +71,7 @@ internal class BackchannelAuthenticationHttpWriter : IHttpResponseWriter<Backcha
                 expires_in = result.Response.ExpiresIn,
                 interval = result.Response.Interval,
                 
-                Custom = result.Response.Custom
+                Custom = result.Response.Context
             });
         }
     }

--- a/src/IdentityServer/Endpoints/Results/BackchannelAuthenticationResult.cs
+++ b/src/IdentityServer/Endpoints/Results/BackchannelAuthenticationResult.cs
@@ -71,7 +71,7 @@ internal class BackchannelAuthenticationHttpWriter : IHttpResponseWriter<Backcha
                 expires_in = result.Response.ExpiresIn,
                 interval = result.Response.Interval,
                 
-                Custom = result.Response.Context
+                Properties = result.Response.Properties
             });
         }
     }
@@ -84,7 +84,7 @@ internal class BackchannelAuthenticationHttpWriter : IHttpResponseWriter<Backcha
         public int interval { get; set; }
 
         [JsonExtensionData]
-        public Dictionary<string, object> Custom { get; set; }
+        public Dictionary<string, object> Properties { get; set; }
 #pragma warning restore IDE1006 // Naming Styles
     }
 

--- a/src/IdentityServer/Endpoints/Results/BackchannelAuthenticationResult.cs
+++ b/src/IdentityServer/Endpoints/Results/BackchannelAuthenticationResult.cs
@@ -5,6 +5,8 @@
 using Duende.IdentityServer.Extensions;
 using Microsoft.AspNetCore.Http;
 using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Duende.IdentityServer.Hosting;
 using Duende.IdentityServer.ResponseHandling;
@@ -67,7 +69,9 @@ internal class BackchannelAuthenticationHttpWriter : IHttpResponseWriter<Backcha
             {
                 auth_req_id = result.Response.AuthenticationRequestId,
                 expires_in = result.Response.ExpiresIn,
-                interval = result.Response.Interval
+                interval = result.Response.Interval,
+                
+                Custom = result.Response.Custom
             });
         }
     }
@@ -78,6 +82,9 @@ internal class BackchannelAuthenticationHttpWriter : IHttpResponseWriter<Backcha
         public string auth_req_id { get; set; }
         public int expires_in { get; set; }
         public int interval { get; set; }
+
+        [JsonExtensionData]
+        public Dictionary<string, object> Custom { get; set; }
 #pragma warning restore IDE1006 // Naming Styles
     }
 

--- a/src/IdentityServer/Models/BackchannelUserLoginRequest.cs
+++ b/src/IdentityServer/Models/BackchannelUserLoginRequest.cs
@@ -62,8 +62,8 @@ public class BackchannelUserLoginRequest
     public ResourceValidationResult ValidatedResources { get; set; } = default!;
 
     /// <summary> 
-    /// Gets or sets a dictionary of custom properties that can pass extra state
-    /// to the notification process.
+    /// Gets or sets a dictionary of custom properties that can pass additional
+    /// state to the notification process.
     /// </summary>
-    public Dictionary<string, object> Context { get; set; } = new();
+    public Dictionary<string, object> Properties { get; set; } = new();
 }

--- a/src/IdentityServer/Models/BackchannelUserLoginRequest.cs
+++ b/src/IdentityServer/Models/BackchannelUserLoginRequest.cs
@@ -61,8 +61,9 @@ public class BackchannelUserLoginRequest
     /// </summary>
     public ResourceValidationResult ValidatedResources { get; set; } = default!;
 
-    /// <summary>
-    /// The response that will be sent to the client
+    /// <summary> 
+    /// Gets or sets a dictionary of custom properties that can pass extra state
+    /// to the notification process.
     /// </summary>
-    public BackchannelAuthenticationResponse Response { get; set; } = default!;
+    public Dictionary<string, object> Context { get; set; } = new();
 }

--- a/src/IdentityServer/Models/BackchannelUserLoginRequest.cs
+++ b/src/IdentityServer/Models/BackchannelUserLoginRequest.cs
@@ -7,6 +7,7 @@
 using Duende.IdentityServer.Validation;
 using System.Collections.Generic;
 using System.Security.Claims;
+using Duende.IdentityServer.ResponseHandling;
 
 namespace Duende.IdentityServer.Models;
 
@@ -59,4 +60,9 @@ public class BackchannelUserLoginRequest
     /// Gets or sets the validated resources.
     /// </summary>
     public ResourceValidationResult ValidatedResources { get; set; } = default!;
+
+    /// <summary>
+    /// The response that will be sent to the client
+    /// </summary>
+    public BackchannelAuthenticationResponse Response { get; set; } = default!;
 }

--- a/src/IdentityServer/ResponseHandling/Default/BackchannelAuthenticationResponseGenerator.cs
+++ b/src/IdentityServer/ResponseHandling/Default/BackchannelAuthenticationResponseGenerator.cs
@@ -111,6 +111,7 @@ public class BackchannelAuthenticationResponseGenerator : IBackchannelAuthentica
             AuthenticationContextReferenceClasses = validationResult.ValidatedRequest.AuthenticationContextReferenceClasses,
             Tenant = validationResult.ValidatedRequest.Tenant,
             IdP = validationResult.ValidatedRequest.IdP,
+            Response = response
         });
 
         return response;

--- a/src/IdentityServer/ResponseHandling/Default/BackchannelAuthenticationResponseGenerator.cs
+++ b/src/IdentityServer/ResponseHandling/Default/BackchannelAuthenticationResponseGenerator.cs
@@ -88,6 +88,7 @@ public class BackchannelAuthenticationResponseGenerator : IBackchannelAuthentica
             Tenant = validationResult.ValidatedRequest.Tenant,
             IdP = validationResult.ValidatedRequest.IdP,
             BindingMessage = validationResult.ValidatedRequest.BindingMessage,
+            Context = validationResult.ValidatedRequest.Context,
         };
 
         var requestId = await BackChannelAuthenticationRequestStore.CreateRequestAsync(request);
@@ -98,6 +99,7 @@ public class BackchannelAuthenticationResponseGenerator : IBackchannelAuthentica
             AuthenticationRequestId = requestId,
             ExpiresIn = request.Lifetime,
             Interval = interval,
+            Context = validationResult.ValidatedRequest.Context
         };
 
         await UserLoginService.SendLoginRequestAsync(new BackchannelUserLoginRequest
@@ -111,7 +113,7 @@ public class BackchannelAuthenticationResponseGenerator : IBackchannelAuthentica
             AuthenticationContextReferenceClasses = validationResult.ValidatedRequest.AuthenticationContextReferenceClasses,
             Tenant = validationResult.ValidatedRequest.Tenant,
             IdP = validationResult.ValidatedRequest.IdP,
-            Response = response
+            Context = validationResult.ValidatedRequest.Context,
         });
 
         return response;

--- a/src/IdentityServer/ResponseHandling/Default/BackchannelAuthenticationResponseGenerator.cs
+++ b/src/IdentityServer/ResponseHandling/Default/BackchannelAuthenticationResponseGenerator.cs
@@ -88,7 +88,7 @@ public class BackchannelAuthenticationResponseGenerator : IBackchannelAuthentica
             Tenant = validationResult.ValidatedRequest.Tenant,
             IdP = validationResult.ValidatedRequest.IdP,
             BindingMessage = validationResult.ValidatedRequest.BindingMessage,
-            Context = validationResult.ValidatedRequest.Context,
+            Properties = validationResult.ValidatedRequest.Properties,
         };
 
         var requestId = await BackChannelAuthenticationRequestStore.CreateRequestAsync(request);
@@ -99,7 +99,7 @@ public class BackchannelAuthenticationResponseGenerator : IBackchannelAuthentica
             AuthenticationRequestId = requestId,
             ExpiresIn = request.Lifetime,
             Interval = interval,
-            Context = validationResult.ValidatedRequest.Context
+            Properties = validationResult.ValidatedRequest.Properties
         };
 
         await UserLoginService.SendLoginRequestAsync(new BackchannelUserLoginRequest
@@ -113,7 +113,7 @@ public class BackchannelAuthenticationResponseGenerator : IBackchannelAuthentica
             AuthenticationContextReferenceClasses = validationResult.ValidatedRequest.AuthenticationContextReferenceClasses,
             Tenant = validationResult.ValidatedRequest.Tenant,
             IdP = validationResult.ValidatedRequest.IdP,
-            Context = validationResult.ValidatedRequest.Context,
+            Properties = validationResult.ValidatedRequest.Properties,
         });
 
         return response;

--- a/src/IdentityServer/ResponseHandling/Models/BackchannelAuthenticationResponse.cs
+++ b/src/IdentityServer/ResponseHandling/Models/BackchannelAuthenticationResponse.cs
@@ -61,8 +61,8 @@ public class BackchannelAuthenticationResponse
     public int Interval { get; set; }
     
     /// <summary> 
-    /// Gets or sets a dictionary of custom properties that can pass extra state
-    /// in the response to the client application.
+    /// Gets or sets a dictionary of custom properties that can pass additional
+    /// state in the response to the client application.
     /// </summary>
-    public Dictionary<string, object> Context { get; set; } = new();
+    public Dictionary<string, object> Properties { get; set; } = new();
 }

--- a/src/IdentityServer/ResponseHandling/Models/BackchannelAuthenticationResponse.cs
+++ b/src/IdentityServer/ResponseHandling/Models/BackchannelAuthenticationResponse.cs
@@ -60,11 +60,9 @@ public class BackchannelAuthenticationResponse
     /// </summary>
     public int Interval { get; set; }
     
-    /// <summary>
-    /// Gets or sets the custom entries.
+    /// <summary> 
+    /// Gets or sets a dictionary of custom properties that can pass extra state
+    /// in the response to the client application.
     /// </summary>
-    /// <value>
-    /// The custom entries.
-    /// </value>
-    public Dictionary<string, object> Custom { get; set; } = new Dictionary<string, object>();
+    public Dictionary<string, object> Context { get; set; } = new();
 }

--- a/src/IdentityServer/ResponseHandling/Models/BackchannelAuthenticationResponse.cs
+++ b/src/IdentityServer/ResponseHandling/Models/BackchannelAuthenticationResponse.cs
@@ -3,6 +3,7 @@
 
 
 using System;
+using System.Collections.Generic;
 
 namespace Duende.IdentityServer.ResponseHandling;
 
@@ -58,4 +59,12 @@ public class BackchannelAuthenticationResponse
     /// Gets or sets the interval.
     /// </summary>
     public int Interval { get; set; }
+    
+    /// <summary>
+    /// Gets or sets the custom entries.
+    /// </summary>
+    /// <value>
+    /// The custom entries.
+    /// </value>
+    public Dictionary<string, object> Custom { get; set; } = new Dictionary<string, object>();
 }

--- a/src/IdentityServer/Services/Default/DefaultBackchannelAuthenticationInteractionService.cs
+++ b/src/IdentityServer/Services/Default/DefaultBackchannelAuthenticationInteractionService.cs
@@ -77,7 +77,7 @@ public class DefaultBackchannelAuthenticationInteractionService : IBackchannelAu
             RequestedResourceIndicators = request.RequestedResourceIndicators,
             AuthenticationContextReferenceClasses = request.AuthenticationContextReferenceClasses,
             BindingMessage = request.BindingMessage,
-            Context = request.Context
+            Properties = request.Properties
         };
     }
 

--- a/src/IdentityServer/Services/Default/DefaultBackchannelAuthenticationInteractionService.cs
+++ b/src/IdentityServer/Services/Default/DefaultBackchannelAuthenticationInteractionService.cs
@@ -77,6 +77,7 @@ public class DefaultBackchannelAuthenticationInteractionService : IBackchannelAu
             RequestedResourceIndicators = request.RequestedResourceIndicators,
             AuthenticationContextReferenceClasses = request.AuthenticationContextReferenceClasses,
             BindingMessage = request.BindingMessage,
+            Context = request.Context
         };
     }
 

--- a/src/IdentityServer/Validation/Contexts/CustomBackchannelAuthenticationRequestValidationContext.cs
+++ b/src/IdentityServer/Validation/Contexts/CustomBackchannelAuthenticationRequestValidationContext.cs
@@ -11,12 +11,12 @@ public class CustomBackchannelAuthenticationRequestValidationContext
     /// <summary>
     /// Creates a new instance of the <see cref="CustomBackchannelAuthenticationRequestValidationContext"/> 
     /// </summary>
-    public CustomBackchannelAuthenticationRequestValidationContext(BackchannelAuthenticationRequestValidationResult result)
+    public CustomBackchannelAuthenticationRequestValidationContext(BackchannelAuthenticationRequestValidationResult validatedRequest)
     {
-        Result = result;
+        ValidationResult = validatedRequest;
     }
     /// <summary>
     /// Gets or sets the CIBA validation result.
     /// </summary>
-    public BackchannelAuthenticationRequestValidationResult Result { get; set; }
+    public BackchannelAuthenticationRequestValidationResult ValidationResult { get; set; }
 }

--- a/src/IdentityServer/Validation/Contexts/CustomBackchannelAuthenticationRequestValidationContext.cs
+++ b/src/IdentityServer/Validation/Contexts/CustomBackchannelAuthenticationRequestValidationContext.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+namespace Duende.IdentityServer.Validation;
+
+/// <summary>
+/// The validation context for a custom CIBA validator.
+/// </summary>
+public class CustomBackchannelAuthenticationRequestValidationContext
+{
+    /// <summary>
+    /// Creates a new instance of the <see cref="CustomBackchannelAuthenticationRequestValidationContext"/> 
+    /// </summary>
+    public CustomBackchannelAuthenticationRequestValidationContext(BackchannelAuthenticationRequestValidationResult result)
+    {
+        Result = result;
+    }
+    /// <summary>
+    /// Gets or sets the CIBA validation result.
+    /// </summary>
+    public BackchannelAuthenticationRequestValidationResult Result { get; set; }
+}

--- a/src/IdentityServer/Validation/Default/BackchannelAuthenticationRequestValidator.cs
+++ b/src/IdentityServer/Validation/Default/BackchannelAuthenticationRequestValidator.cs
@@ -25,6 +25,7 @@ internal class BackchannelAuthenticationRequestValidator : IBackchannelAuthentic
     private readonly IBackchannelAuthenticationUserValidator _backchannelAuthenticationUserValidator;
     private readonly IJwtRequestValidator _jwtRequestValidator;
     private readonly IJwtRequestUriHttpClient _jwtRequestUriHttpClient;
+    private readonly ICustomBackchannelAuthenticationValidator _customValidator;
     private readonly ILogger<BackchannelAuthenticationRequestValidator> _logger;
 
     private ValidatedBackchannelAuthenticationRequest _validatedRequest;
@@ -36,6 +37,7 @@ internal class BackchannelAuthenticationRequestValidator : IBackchannelAuthentic
         IBackchannelAuthenticationUserValidator backchannelAuthenticationUserValidator,
         IJwtRequestValidator jwtRequestValidator,
         IJwtRequestUriHttpClient jwtRequestUriHttpClient,
+        ICustomBackchannelAuthenticationValidator customValidator,
         ILogger<BackchannelAuthenticationRequestValidator> logger)
     {
         _options = options;
@@ -44,6 +46,7 @@ internal class BackchannelAuthenticationRequestValidator : IBackchannelAuthentic
         _backchannelAuthenticationUserValidator = backchannelAuthenticationUserValidator;
         _jwtRequestValidator = jwtRequestValidator;
         _jwtRequestUriHttpClient = jwtRequestUriHttpClient;
+        _customValidator = customValidator;
         _logger = logger;
     }
 
@@ -418,9 +421,18 @@ internal class BackchannelAuthenticationRequestValidator : IBackchannelAuthentic
         }
 
         _validatedRequest.Subject = userResult.Subject;
+        var result = new BackchannelAuthenticationRequestValidationResult(_validatedRequest);
+        
+        var customValidationContext = new CustomBackchannelAuthenticationRequestValidationContext(result);
+        await _customValidator.ValidateAsync(customValidationContext);
+        if(customValidationContext.Result.IsError)
+        {
+            LogError("Custom validation of backchannel authorize request failed");
+            return Invalid(OidcConstants.BackchannelAuthenticationRequestErrors.InvalidRequest);
+        }
 
         LogSuccess();
-        return new BackchannelAuthenticationRequestValidationResult(_validatedRequest);
+        return result;
     }
 
     private async Task<(bool Success, BackchannelAuthenticationRequestValidationResult ErrorResult)> TryValidateRequestObjectAsync()

--- a/src/IdentityServer/Validation/Default/BackchannelAuthenticationRequestValidator.cs
+++ b/src/IdentityServer/Validation/Default/BackchannelAuthenticationRequestValidator.cs
@@ -24,7 +24,6 @@ internal class BackchannelAuthenticationRequestValidator : IBackchannelAuthentic
     private readonly ITokenValidator _tokenValidator;
     private readonly IBackchannelAuthenticationUserValidator _backchannelAuthenticationUserValidator;
     private readonly IJwtRequestValidator _jwtRequestValidator;
-    private readonly IJwtRequestUriHttpClient _jwtRequestUriHttpClient;
     private readonly ICustomBackchannelAuthenticationValidator _customValidator;
     private readonly ILogger<BackchannelAuthenticationRequestValidator> _logger;
 
@@ -36,7 +35,6 @@ internal class BackchannelAuthenticationRequestValidator : IBackchannelAuthentic
         ITokenValidator tokenValidator,
         IBackchannelAuthenticationUserValidator backchannelAuthenticationUserValidator,
         IJwtRequestValidator jwtRequestValidator,
-        IJwtRequestUriHttpClient jwtRequestUriHttpClient,
         ICustomBackchannelAuthenticationValidator customValidator,
         ILogger<BackchannelAuthenticationRequestValidator> logger)
     {
@@ -45,7 +43,6 @@ internal class BackchannelAuthenticationRequestValidator : IBackchannelAuthentic
         _tokenValidator = tokenValidator;
         _backchannelAuthenticationUserValidator = backchannelAuthenticationUserValidator;
         _jwtRequestValidator = jwtRequestValidator;
-        _jwtRequestUriHttpClient = jwtRequestUriHttpClient;
         _customValidator = customValidator;
         _logger = logger;
     }
@@ -425,7 +422,7 @@ internal class BackchannelAuthenticationRequestValidator : IBackchannelAuthentic
         
         var customValidationContext = new CustomBackchannelAuthenticationRequestValidationContext(result);
         await _customValidator.ValidateAsync(customValidationContext);
-        if(customValidationContext.Result.IsError)
+        if(customValidationContext.ValidationResult.IsError)
         {
             LogError("Custom validation of backchannel authorize request failed");
             return Invalid(OidcConstants.BackchannelAuthenticationRequestErrors.InvalidRequest);

--- a/src/IdentityServer/Validation/Default/DefaultCustomBackchannelAuthenticationValidator.cs
+++ b/src/IdentityServer/Validation/Default/DefaultCustomBackchannelAuthenticationValidator.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+using System.Threading.Tasks;
+
+namespace Duende.IdentityServer.Validation;
+
+/// <summary>
+/// Default implementation of the CIBA validator extensibility point. This
+/// validator deliberately does nothing.
+/// </summary>
+public class DefaultCustomBackchannelAuthenticationValidator : ICustomBackchannelAuthenticationValidator
+{
+    /// <inheritdoc/>
+    public Task ValidateAsync(CustomBackchannelAuthenticationRequestValidationContext customValidationContext)
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/src/IdentityServer/Validation/ICustomBackchannelAuthenticationValidator.cs
+++ b/src/IdentityServer/Validation/ICustomBackchannelAuthenticationValidator.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+using System.Threading.Tasks;
+
+namespace Duende.IdentityServer.Validation;
+
+/// <summary>
+/// Extensibility point for CIBA authentication request validation.
+/// </summary>
+public interface ICustomBackchannelAuthenticationValidator
+{
+    /// <summary>
+    /// Validates a CIBA authentication request.
+    /// </summary>
+    /// <param name="customValidationContext"></param>
+    /// <returns></returns>
+    Task ValidateAsync(CustomBackchannelAuthenticationRequestValidationContext customValidationContext);
+}

--- a/src/IdentityServer/Validation/Models/ValidatedBackchannelAuthenticationRequest.cs
+++ b/src/IdentityServer/Validation/Models/ValidatedBackchannelAuthenticationRequest.cs
@@ -83,4 +83,10 @@ public class ValidatedBackchannelAuthenticationRequest : ValidatedRequest
     /// Gets or sets the request object (either passed by value or retrieved by reference)
     /// </summary>
     public string? RequestObject { get; set; }
+
+    /// <summary>
+    /// Gets or sets a dictionary of custom properites that can store
+    /// additional state during the back channel authentication process.
+    /// </summary>
+    public Dictionary<string, object> Context { get; set; } = new();
 }

--- a/src/IdentityServer/Validation/Models/ValidatedBackchannelAuthenticationRequest.cs
+++ b/src/IdentityServer/Validation/Models/ValidatedBackchannelAuthenticationRequest.cs
@@ -85,8 +85,8 @@ public class ValidatedBackchannelAuthenticationRequest : ValidatedRequest
     public string? RequestObject { get; set; }
 
     /// <summary>
-    /// Gets or sets a dictionary of custom properites that can store
-    /// additional state during the back channel authentication process.
+    /// Gets or sets a dictionary of custom properties that can pass
+    /// additional state to the back channel authentication process.
     /// </summary>
-    public Dictionary<string, object> Context { get; set; } = new();
+    public Dictionary<string, object> Properties { get; set; } = new();
 }

--- a/src/Storage/Models/BackChannelAuthenticationRequest.cs
+++ b/src/Storage/Models/BackChannelAuthenticationRequest.cs
@@ -94,5 +94,5 @@ public class BackChannelAuthenticationRequest
     /// <summary>
     /// Gets or sets a dictionary of custom properties associated with this instance.
     /// </summary>
-    public Dictionary<string, object> Context { get; set; } = new();
+    public Dictionary<string, object> Properties { get; set; } = new();
 }

--- a/src/Storage/Models/BackChannelAuthenticationRequest.cs
+++ b/src/Storage/Models/BackChannelAuthenticationRequest.cs
@@ -87,7 +87,12 @@ public class BackChannelAuthenticationRequest
     public string? SessionId { get; set; }
 
     /// <summary>
-    /// Gets the description the user assigned to the client being authorized.
+    /// Gets or sets the description the user assigned to the client being authorized.
     /// </summary>
     public string? Description { get; set; }
+
+    /// <summary>
+    /// Gets or sets a dictionary of custom properties associated with this instance.
+    /// </summary>
+    public Dictionary<string, object> Context { get; set; } = new();
 }

--- a/test/IdentityServer.IntegrationTests/Common/MockCustomBackchannelAuthenticationValidator.cs
+++ b/test/IdentityServer.IntegrationTests/Common/MockCustomBackchannelAuthenticationValidator.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+using Duende.IdentityServer.Validation;
+using System;
+using System.Threading.Tasks;
+
+namespace IntegrationTests.Common;
+
+internal class MockCustomBackchannelAuthenticationValidator : ICustomBackchannelAuthenticationValidator
+{
+    public CustomBackchannelAuthenticationRequestValidationContext Context { get; set; }
+
+
+    /// <summary>
+    /// An action that will be performed by the mock custom validator.
+    /// </summary>
+    public Action<CustomBackchannelAuthenticationRequestValidationContext> Thunk { get; set; } = delegate { };
+
+    public Task ValidateAsync(CustomBackchannelAuthenticationRequestValidationContext customValidationContext)
+    {
+        Thunk(customValidationContext);
+        Context = customValidationContext;
+        return Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
This adds extensibility points to CIBA to allow for custom request and response parameters.

- Adds a new custom backchannel authentication request validator hook, similar to `AddCustomAuthorizeRequestValidator` and `AddCustomTokenRequestValidator`
- Adds a context dictionary to the ciba validation result, which then feeds into similar context dictionaries in the response to the client, notification to the user, and record in the database
