### PR TITLE
Update Wilson

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -18,7 +18,7 @@
         <FrameworkVersion>8.0.0</FrameworkVersion>
         <ExtensionsVersion>8.0.0</ExtensionsVersion>
         <EntityFrameworkVersion>8.0.0</EntityFrameworkVersion>
-        <WilsonVersion>7.0.3</WilsonVersion>
+        <WilsonVersion>7.1.2</WilsonVersion>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Microsoft.IdentityModel.JsonWebTokens and System.IdentityModel.Tokens.Jwt 7.0.3 both contain a DoS vulnerability, and referencing them causes warnings that fail the build because we treat warnings as errors.

See https://github.com/advisories/GHSA-59j7-ghrg-fj52 for details about the vulnerability.

