### PR TITLE
Filter subject token from TokenRequest log

### DIFF
--- a/src/IdentityServer/Configuration/DependencyInjection/Options/LoggingOptions.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/Options/LoggingOptions.cs
@@ -41,7 +41,8 @@ public class LoggingOptions
             OidcConstants.TokenRequest.ClientAssertion,
             OidcConstants.TokenRequest.RefreshToken,
             OidcConstants.TokenRequest.DeviceCode,
-            OidcConstants.TokenRequest.Code
+            OidcConstants.TokenRequest.Code,
+            OidcConstants.TokenRequest.SubjectToken
         };
 
     /// <summary>


### PR DESCRIPTION
Treat the Subject Token as sensitive because it could be an access token or an identity token that contains PII.

See https://github.com/DuendeSoftware/IdentityServer/issues/1522
