### PR TITLE
Rework license validator to not use ConcurrentDictionary

### DIFF
--- a/src/IdentityServer/Licensing/IdentityServerLicenseValidator.cs
+++ b/src/IdentityServer/Licensing/IdentityServerLicenseValidator.cs
@@ -93,25 +93,28 @@ internal class IdentityServerLicenseValidator : LicenseValidator<IdentityServerL
         }
     }
 
+    public void ValidateClient(string clientId) => ValidateClient(clientId, License);
+
     HashSet<string> _clientIds = new();
     object _clientIdLock = new();
     bool _validateClientWarned = false;
-    public void ValidateClient(string clientId)
+    // Internal method that takes license as parameter to allow testing
+    internal void ValidateClient(string clientId, IdentityServerLicense license)
     {
-        if (License != null && !License.ClientLimit.HasValue)
+        if (license != null && !license.ClientLimit.HasValue)
         {
             return;
         }
 
         EnsureAdded(ref _clientIds, _clientIdLock, clientId);
 
-        if (License != null)
+        if (license != null)
         {
-            if (_clientIds.Count > License.ClientLimit)
+            if (_clientIds.Count > license.ClientLimit)
             {
                 ErrorLog.Invoke(
                     "Your license for Duende IdentityServer only permits {clientLimit} number of clients. You have processed requests for {clientCount}. The clients used were: {clients}.",
-                    [License.ClientLimit, _clientIds.Count, _clientIds.ToArray()]);
+                    [license.ClientLimit, _clientIds.Count, _clientIds.ToArray()]);
             }
         }
         else

--- a/src/IdentityServer/Licensing/LicenseValidator.cs
+++ b/src/IdentityServer/Licensing/LicenseValidator.cs
@@ -31,7 +31,7 @@ internal class LicenseValidator<T>
     protected Action<string, object[]> WarningLog;
     protected Action<string, object[]> DebugLog;
 
-    protected T License { get; private set; }
+    protected T License { get; set; }
     
     // cloned copy meant to be accessible in DI
     T _copy;

--- a/src/IdentityServer/Licensing/LicenseValidator.cs
+++ b/src/IdentityServer/Licensing/LicenseValidator.cs
@@ -31,7 +31,7 @@ internal class LicenseValidator<T>
     protected Action<string, object[]> WarningLog;
     protected Action<string, object[]> DebugLog;
 
-    protected T License { get; set; }
+    protected T License { get; private set; }
     
     // cloned copy meant to be accessible in DI
     T _copy;

--- a/test/IdentityServer.UnitTests/Licensing/IdentityServerLicenseValidatorTests.cs
+++ b/test/IdentityServer.UnitTests/Licensing/IdentityServerLicenseValidatorTests.cs
@@ -383,9 +383,8 @@ public class IdentityServerLicenseValidatorTests
 
     private class MockLicenseValidator : IdentityServerLicenseValidator
     {
-        public MockLicenseValidator(IdentityServerLicense license)
+        public MockLicenseValidator()
         {
-            License = license;
             ErrorLog = (str, obj) => { ErrorLogCount++; };
             WarningLog = (str, obj) => { WarningLogCount++; };
         }
@@ -401,11 +400,11 @@ public class IdentityServerLicenseValidatorTests
     public void client_count_exceeded_should_warn(bool hasLicense, int allowedClients)
     {
         var license = hasLicense ? new IdentityServerLicense(new Claim("edition", "business")) : null;
-        var subject = new MockLicenseValidator(license);
+        var subject = new MockLicenseValidator();
 
         for (int i = 0; i < allowedClients; i++)
         {
-            subject.ValidateClient("client" + i);
+            subject.ValidateClient("client" + i, license);
         }
 
         // Adding the allowed number of clients shouldn't log.
@@ -413,12 +412,12 @@ public class IdentityServerLicenseValidatorTests
         subject.WarningLogCount.Should().Be(0);
 
         // Validating same client again shouldn't log.
-        subject.ValidateClient("client3");
+        subject.ValidateClient("client3", license);
         subject.ErrorLogCount.Should().Be(0);
         subject.WarningLogCount.Should().Be(0);
 
-        subject.ValidateClient("extra1");
-        subject.ValidateClient("extra2");
+        subject.ValidateClient("extra1", license);
+        subject.ValidateClient("extra2", license);
 
         if (hasLicense)
         {

--- a/test/IdentityServer.UnitTests/Licensing/IdentityServerLicenseValidatorTests.cs
+++ b/test/IdentityServer.UnitTests/Licensing/IdentityServerLicenseValidatorTests.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Security.Claims;
+using Duende;
 using Duende.IdentityServer;
 using FluentAssertions;
 using Xunit;
@@ -377,6 +378,57 @@ public class IdentityServerLicenseValidatorTests
         {
             Action func = () => new IdentityServerLicense(new Claim("edition", ""));
             func.Should().Throw<Exception>();
+        }
+    }
+
+    private class MockLicenseValidator : IdentityServerLicenseValidator
+    {
+        public MockLicenseValidator(IdentityServerLicense license)
+        {
+            License = license;
+            ErrorLog = (str, obj) => { ErrorLogCount++; };
+            WarningLog = (str, obj) => { WarningLogCount++; };
+        }
+
+        public int ErrorLogCount { get; set; }
+        public int WarningLogCount { get; set; }
+    }
+
+    [Theory]
+    [Trait("Category", Category)]
+    [InlineData(false, 5)]
+    [InlineData(true, 15)]
+    public void client_count_exceeded_should_warn(bool hasLicense, int allowedClients)
+    {
+        var license = hasLicense ? new IdentityServerLicense(new Claim("edition", "business")) : null;
+        var subject = new MockLicenseValidator(license);
+
+        for (int i = 0; i < allowedClients; i++)
+        {
+            subject.ValidateClient("client" + i);
+        }
+
+        // Adding the allowed number of clients shouldn't log.
+        subject.ErrorLogCount.Should().Be(0);
+        subject.WarningLogCount.Should().Be(0);
+
+        // Validating same client again shouldn't log.
+        subject.ValidateClient("client3");
+        subject.ErrorLogCount.Should().Be(0);
+        subject.WarningLogCount.Should().Be(0);
+
+        subject.ValidateClient("extra1");
+        subject.ValidateClient("extra2");
+
+        if (hasLicense)
+        {
+            subject.ErrorLogCount.Should().Be(2);
+            subject.WarningLogCount.Should().Be(0);
+        }
+        else
+        {
+            subject.ErrorLogCount.Should().Be(0);
+            subject.WarningLogCount.Should().Be(1);
         }
     }
 }


### PR DESCRIPTION
- ConcurrentDictionary has excellent concurrency performance for reading/writing invidivual key/values. But the locking pattern for reading the count and getting all keys is quite bad.
- Add tests
- Fixes #1526
