### PR TITLE
Expand private key jwt test client with an ECDSA key

### DIFF
--- a/clients/src/ConsolePrivateKeyJwtClient/Program.cs
+++ b/clients/src/ConsolePrivateKeyJwtClient/Program.cs
@@ -29,7 +29,20 @@ namespace ConsolePrivateKeyJwtClient
                 "qi":"pG6J4dcUDrDndMxa-ee1yG4KjZqqyCQcmPAfqklI2LmnpRIjcK78scclvpboI3JQyg6RCEKVMwAhVtQM6cBcIO3JrHgqeYDblp5wXHjto70HVW6Z8kBruNx1AH9E8LzNvSRL-JVTFzBkJuNgzKQfD0G77tQRgJ-Ri7qu3_9o1M4"
             }
             """;
-        
+
+        private static string ecKey =
+            """
+            {
+                "kty":"EC",
+                "crv":"P-256",
+                "x":"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4",
+                "y":"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM",
+                "d":"870MB6gfuTJ4HtUnUvYMyJpr5eUZNP4Bk43bVdj3eAE",
+                "use":"enc",
+                "kid":"1"
+            }
+            """;
+
         public static async Task Main()
         {
             Console.Title = "Console Client Credentials Flow with JWT Assertion";
@@ -51,6 +64,15 @@ namespace ConsolePrivateKeyJwtClient
             
             Console.ReadLine();
             await CallServiceAsync(response.AccessToken);
+
+            // EC JsonWebKey
+            jwk = new JsonWebKey(ecKey);
+            response = await RequestTokenAsync(new SigningCredentials(jwk, "ES256"));
+            response.Show();
+            
+            Console.ReadLine();
+            await CallServiceAsync(response.AccessToken);
+
         }
 
         static async Task<TokenResponse> RequestTokenAsync(SigningCredentials credential)

--- a/hosts/Config/ClientsConsole.cs
+++ b/hosts/Config/ClientsConsole.cs
@@ -128,6 +128,21 @@ public static class ClientsConsole
                                 "n":"wWwQFtSzeRjjerpEM5Rmqz_DsNaZ9S1Bw6UbZkDLowuuTCjBWUax0vBMMxdy6XjEEK4Oq9lKMvx9JzjmeJf1knoqSNrox3Ka0rnxXpNAz6sATvme8p9mTXyp0cX4lF4U2J54xa2_S9NF5QWvpXvBeC4GAJx7QaSw4zrUkrc6XyaAiFnLhQEwKJCwUw4NOqIuYvYp_IXhw-5Ti_icDlZS-282PcccnBeOcX7vc21pozibIdmZJKqXNsL1Ibx5Nkx1F1jLnekJAmdaACDjYRLL_6n3W4wUp19UvzB1lGtXcJKLLkqB6YDiZNu16OSiSprfmrRXvYmvD8m6Fnl5aetgKw"
                             }
                             """
+                    },
+                    new Secret
+                    {
+                        Type = IdentityServerConstants.SecretTypes.JsonWebKey,
+                        Value =
+                            """
+                            {
+                                "kty":"EC",
+                                "crv":"P-256",
+                                "x":"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4",
+                                "y":"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM",
+                                "use":"enc",
+                                "kid":"1"
+                            }
+                            """
                     }
                 },
                 AllowedGrantTypes = GrantTypes.ClientCredentials,


### PR DESCRIPTION
A small addition to the Private Key JWT test client that adds an EC DSA jwk.