### PR TITLE
Compare PostLogoutRedirectUri against strings instead of objects

### DIFF
--- a/src/IdentityServer/Validation/Default/StrictRedirectUriValidator.cs
+++ b/src/IdentityServer/Validation/Default/StrictRedirectUriValidator.cs
@@ -65,7 +65,10 @@ public class StrictRedirectUriValidator : IRedirectUriValidator
     /// </returns>
     public virtual Task<bool> IsPostLogoutRedirectUriValidAsync(string requestedUri, Client client)
     {
-        return Task.FromResult(StringCollectionContainsString(client.PostLogoutRedirectUris, requestedUri));
+        return Task.FromResult(StringCollectionContainsString(
+            client.PostLogoutRedirectUris.Select(o => o.PostLogoutRedirectUri),
+            requestedUri
+        ));
     }
 
     /// <summary>


### PR DESCRIPTION
Compare PostLogoutRedirectUri against string of PostLogoutRedirectUris instead of the PostLogoutRedirectUri objects

**What issue does this PR address?**
PostLogoutRedirectUri was always invalid because it's trying to compare the redirect URI string against an array of objects instead of the strings in that object, since `Client.PostLogoutRedirectUris` was converted to an array of type `ClientPostLogoutRedirectUri ` from an array of strings.