### PR TITLE
Prevent infinite loop when max_age=0

### DIFF
--- a/src/IdentityServer/Constants.cs
+++ b/src/IdentityServer/Constants.cs
@@ -131,6 +131,12 @@ internal static class Constants
     /// </summary>
     public const string ProcessedPrompt = "suppressed_" + OidcConstants.AuthorizeRequest.Prompt;
 
+    /// <summary>
+    /// The name of the parameter passed to the authorize callback to indicate
+    /// max age that have already been used.
+    /// </summary>
+    public const string ProcessedMaxAge = "suppressed_" + OidcConstants.AuthorizeRequest.MaxAge;
+
     public static class KnownAcrValues
     {
         public const string HomeRealm = "idp:";

--- a/src/IdentityServer/Extensions/ValidatedAuthorizeRequestExtensions.cs
+++ b/src/IdentityServer/Extensions/ValidatedAuthorizeRequestExtensions.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using System.Collections.Specialized;
+using System.Globalization;
 
 #pragma warning disable 1591
 
@@ -47,6 +48,16 @@ public static class ValidatedAuthorizeRequestExtensions
             OidcConstants.PromptModes.SelectAccount,
             OidcConstants.PromptModes.Create
         }).ToArray();
+    }
+
+    public static void RemoveMaxAge(this ValidatedAuthorizeRequest request)
+    {
+        request.Raw.Remove("max_age");
+
+        if (request.MaxAge.HasValue)
+        {
+            request.Raw.Add(Constants.ProcessedMaxAge, request.MaxAge.Value.ToString(CultureInfo.InvariantCulture));
+        }
     }
 
     public static string GetPrefixedAcrValue(this ValidatedAuthorizeRequest request, string prefix)

--- a/src/IdentityServer/ResponseHandling/Default/AuthorizeInteractionResponseGenerator.cs
+++ b/src/IdentityServer/ResponseHandling/Default/AuthorizeInteractionResponseGenerator.cs
@@ -244,8 +244,11 @@ public class AuthorizeInteractionResponseGenerator : IAuthorizeInteractionRespon
             var authTime = request.Subject.GetAuthenticationTime();
             if (Clock.UtcNow.UtcDateTime > authTime.AddSeconds(request.MaxAge.Value))
             {
-                // Remove the max_age parameter to prevent (infinite) loop
-                request.Raw.Remove("max_age");
+                // Remove the max_age=0 parameter to prevent (infinite) loop
+                if (request.MaxAge.Value == 0)
+                {
+                    request.RemoveMaxAge();
+                }
 
                 Logger.LogInformation("Showing login: Requested MaxAge exceeded.");
 

--- a/src/IdentityServer/ResponseHandling/Default/AuthorizeInteractionResponseGenerator.cs
+++ b/src/IdentityServer/ResponseHandling/Default/AuthorizeInteractionResponseGenerator.cs
@@ -244,6 +244,9 @@ public class AuthorizeInteractionResponseGenerator : IAuthorizeInteractionRespon
             var authTime = request.Subject.GetAuthenticationTime();
             if (Clock.UtcNow.UtcDateTime > authTime.AddSeconds(request.MaxAge.Value))
             {
+                // Remove the max_age parameter to prevent (infinite) loop
+                request.Raw.Remove("max_age");
+
                 Logger.LogInformation("Showing login: Requested MaxAge exceeded.");
 
                 return new InteractionResponse { IsLogin = true };


### PR DESCRIPTION
When the authorize endpoint is called with `max_age=0` parameter it is copied to the callback returnUrl. So after successful login the user is redirected to the login page again (with the max_age parameter again in the returnUrl).

I believe, that the parameter should be handled similar way as the prompt=login:

```
if (request.PromptModes.Contains(OidcConstants.PromptModes.Create))
{
    Logger.LogInformation("Showing create account: request contains prompt=create");
    request.RemovePrompt();
    result = new InteractionResponse
    {
        IsCreateAccount = true
    };
}
```

My proposal is to remove the parameter from the further chain:

```
request.Raw.Remove("max_age");
```

Potentially, it could be done only when `MaxAge==0`.