### PR TITLE
Configure httponly

### DIFF
--- a/src/IdentityServer/Configuration/DependencyInjection/ConfigureInternalCookieOptions.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/ConfigureInternalCookieOptions.cs
@@ -31,6 +31,7 @@ internal class ConfigureInternalCookieOptions : IConfigureNamedOptions<CookieAut
             options.Cookie.Name = IdentityServerConstants.DefaultCookieAuthenticationScheme;
             options.Cookie.IsEssential = true;
             options.Cookie.SameSite = _idsrv.Authentication.CookieSameSiteMode;
+            options.Cookie.HttpOnly = _idsrv.Authentication.CookieHttpOnly;
 
             options.LoginPath = ExtractLocalUrl(_idsrv.UserInteraction.LoginUrl);
             options.LogoutPath = ExtractLocalUrl(_idsrv.UserInteraction.LogoutUrl);
@@ -51,6 +52,7 @@ internal class ConfigureInternalCookieOptions : IConfigureNamedOptions<CookieAut
             // hold onto them and send on the next redirect to the callback page.
             // see: https://brockallen.com/2019/01/11/same-site-cookies-asp-net-core-and-external-authentication-providers/
             options.Cookie.SameSite = _idsrv.Authentication.CookieSameSiteMode;
+            options.Cookie.HttpOnly = _idsrv.Authentication.CookieHttpOnly;
         }
     }
 

--- a/src/IdentityServer/Configuration/DependencyInjection/Options/AuthenticationOptions.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/Options/AuthenticationOptions.cs
@@ -34,6 +34,11 @@ public class AuthenticationOptions
     /// Specifies the SameSite mode for the internal authentication and temp cookie
     /// </summary>
     public SameSiteMode CookieSameSiteMode { get; set; } = SameSiteMode.None;
+    
+    /// <summary>
+    /// Specifies the HttpOnly setting for the internal authentication and temp cookie
+    /// </summary>
+    public bool CookieHttpOnly { get; set; } = false;
 
     /// <summary>
     /// Indicates if user must be authenticated to accept parameters to end session endpoint. Defaults to false.

--- a/src/IdentityServer/Configuration/DependencyInjection/Options/AuthenticationOptions.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/Options/AuthenticationOptions.cs
@@ -62,6 +62,11 @@ public class AuthenticationOptions
     /// Gets or sets the SameSite mode of the cookie used for the check session endpoint. Defaults to SameSiteMode.None.
     /// </summary>
     public SameSiteMode CheckSessionCookieSameSiteMode { get; set; } = SameSiteMode.None;
+    
+    /// <summary>
+    /// Gets or sets the HttpOnly setting of the cookie used for the check session endpoint. Defaults to false.
+    /// </summary>
+    public bool CheckSessionCookieHttpOnly { get; set; } = false;
 
     /// <summary>
     /// If set, will require frame-src CSP headers being emitted on the end session callback endpoint which renders iframes to clients for front-channel sign out notification.

--- a/src/IdentityServer/Services/Default/DefaultUserSession.cs
+++ b/src/IdentityServer/Services/Default/DefaultUserSession.cs
@@ -83,6 +83,14 @@ public class DefaultUserSession : IUserSession
     /// The SameSite mode of the check session cookie.
     /// </value>
     protected SameSiteMode CheckSessionCookieSameSiteMode => Options.Authentication.CheckSessionCookieSameSiteMode;
+    
+    /// <summary>
+    /// Gets the HttpOnly setting of the check session cookie.
+    /// </summary>
+    /// <value>
+    /// The HttpOnly setting of the check session cookie.
+    /// </value>
+    protected bool CheckSessionCookieHttpOnly => Options.Authentication.CheckSessionCookieHttpOnly;
 
     /// <summary>
     /// The principal
@@ -268,7 +276,7 @@ public class DefaultUserSession : IUserSession
 
         var options = new CookieOptions
         {
-            HttpOnly = false,
+            HttpOnly = CheckSessionCookieHttpOnly,
             Secure = secure,
             Path = path,
             IsEssential = true,


### PR DESCRIPTION
**What issue does this PR address?**

Currently the HttpOnly property of a cookie is not configurable

**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
