### PR TITLE
Bump OpenTelemetry dependencies

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -76,14 +76,14 @@
         <PackageReference Update="Microsoft.EntityFrameworkCore.Design" Version="$(EntityFrameworkVersion)" PrivateAssets="All"/>
 
         <!-- open telemetry -->
-        <PackageReference Update="OpenTelemetry" Version="1.6.0" />
-        <PackageReference Update="OpenTelemetry.Exporter.Console" Version="1.6.0" />
-        <PackageReference Update="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.6.0" />
-        <PackageReference Update="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.6.0-rc.1" />
-        <PackageReference Update="OpenTelemetry.Extensions.Hosting" Version="1.6.0" />
-        <PackageReference Update="OpenTelemetry.Instrumentation.AspNetCore" Version="1.5.1-beta.1" />
-        <PackageReference Update="OpenTelemetry.Instrumentation.Http" Version="1.5.1-beta.1" />
-        <PackageReference Update="OpenTelemetry.Instrumentation.SqlClient" Version="1.0.0-rc9" />
+        <PackageReference Update="OpenTelemetry" Version="1.8.1" />
+        <PackageReference Update="OpenTelemetry.Exporter.Console" Version="1.8.1" />
+        <PackageReference Update="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
+        <PackageReference Update="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.8.0-rc.1" />
+        <PackageReference Update="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
+        <PackageReference Update="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
+        <PackageReference Update="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
+        <PackageReference Update="OpenTelemetry.Instrumentation.SqlClient" Version="1.8.0-beta.1" />
 
     </ItemGroup>
 


### PR DESCRIPTION
Most of the packages are listed with a security vulernability that is only fixed in 1.8.1, so all them are bumped to that version. Except those packages that do not have a 1.8.1 released
