### PR TITLE
Anders/warn non distributed cache

### DIFF
--- a/src/IdentityServer/Configuration/DependencyInjection/ConfigureOpenIdConnectOptions.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/ConfigureOpenIdConnectOptions.cs
@@ -4,6 +4,9 @@
 
 using Duende.IdentityServer.Infrastructure;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System;
 using System.Linq;
@@ -21,12 +24,26 @@ internal class ConfigureOpenIdConnectOptions : IPostConfigureOptions<OpenIdConne
         _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
     }
 
+    private static bool warnedInMemory = false;
+
     public void PostConfigure(string name, OpenIdConnectOptions options)
     {
         // no schemes means configure them all
         if (_schemes.Length == 0 || _schemes.Contains(name))
         {
             options.StateDataFormat = new DistributedCacheStateDataFormatter(_serviceProvider, name);
+        }
+
+        var distributedCacheService = _serviceProvider.GetRequiredService<IDistributedCache>();
+
+        if (distributedCacheService is MemoryDistributedCache && !warnedInMemory)
+        {
+            var logger = _serviceProvider
+                .GetRequiredService<ILogger<ConfigureOpenIdConnectOptions>>();
+
+            logger.LogInformation("You have enabled the OidcStateDataFormatterCache but the distributed cache registered is the default memory based implementation. This will store any OIDC state in memory on the server that initiated the request. If the response is processed on another server it will fail. If you are running in production, you want to switch to a real distributed cache that is shared between all nodes.");
+
+            warnedInMemory = true;
         }
     }
 }

--- a/src/IdentityServer/Configuration/DependencyInjection/ConfigureOpenIdConnectOptions.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/ConfigureOpenIdConnectOptions.cs
@@ -34,16 +34,19 @@ internal class ConfigureOpenIdConnectOptions : IPostConfigureOptions<OpenIdConne
             options.StateDataFormat = new DistributedCacheStateDataFormatter(_serviceProvider, name);
         }
 
-        var distributedCacheService = _serviceProvider.GetRequiredService<IDistributedCache>();
-
-        if (distributedCacheService is MemoryDistributedCache && !warnedInMemory)
+        if (!warnedInMemory)
         {
-            var logger = _serviceProvider
-                .GetRequiredService<ILogger<ConfigureOpenIdConnectOptions>>();
+            var distributedCacheService = _serviceProvider.GetRequiredService<IDistributedCache>();
 
-            logger.LogInformation("You have enabled the OidcStateDataFormatterCache but the distributed cache registered is the default memory based implementation. This will store any OIDC state in memory on the server that initiated the request. If the response is processed on another server it will fail. If you are running in production, you want to switch to a real distributed cache that is shared between all nodes.");
+            if (distributedCacheService is MemoryDistributedCache)
+            {
+                var logger = _serviceProvider
+                    .GetRequiredService<ILogger<ConfigureOpenIdConnectOptions>>();
 
-            warnedInMemory = true;
+                logger.LogInformation("You have enabled the OidcStateDataFormatterCache but the distributed cache registered is the default memory based implementation. This will store any OIDC state in memory on the server that initiated the request. If the response is processed on another server it will fail. If you are running in production, you want to switch to a real distributed cache that is shared between all nodes.");
+
+                warnedInMemory = true;
+            }
         }
     }
 }


### PR DESCRIPTION
Log (info level) if OIDC state data formatter is enabled with in memory distributed cache.

I've had a few cases in support where the Oidc state data formatter has been enabled but the distributed cache is the default memory based version. IdentityServer (unfortunately?) adds the in memory implementation as a fallback so it is easy to miss this. A warning message similar to the ones we have for in memory persisted grants should help.