### PR TITLE
Fix null reference exception in event service when httpcontext missing

### DIFF
--- a/src/IdentityServer/Services/Default/DefaultEventService.cs
+++ b/src/IdentityServer/Services/Default/DefaultEventService.cs
@@ -111,9 +111,17 @@ public class DefaultEventService : IEventService
     /// <returns></returns>
     protected virtual async Task PrepareEventAsync(Event evt)
     {
-        evt.ActivityId = Context.HttpContext.TraceIdentifier;
         evt.TimeStamp = Clock.UtcNow.DateTime;
         evt.ProcessId = Process.GetCurrentProcess().Id;
+
+        if (Context.HttpContext?.TraceIdentifier != null)
+        {
+            evt.ActivityId = Context.HttpContext.TraceIdentifier;
+        }
+        else
+        {
+            evt.ActivityId = "unknown";
+        }
 
         if (Context.HttpContext?.Connection.LocalIpAddress != null)
         {

--- a/test/IdentityServer.UnitTests/Common/MockEventSink.cs
+++ b/test/IdentityServer.UnitTests/Common/MockEventSink.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Duende.IdentityServer.Events;
+using Duende.IdentityServer.Services;
+
+namespace UnitTests.Common;
+
+internal class MockEventSink : IEventSink
+{
+    public List<Event> Events { get; } = [];
+
+    public Task PersistAsync(Event evt)
+    {
+        Events.Add(evt);
+        return Task.CompletedTask;
+    }
+}

--- a/test/IdentityServer.UnitTests/Common/NullHttpContextAccessor.cs
+++ b/test/IdentityServer.UnitTests/Common/NullHttpContextAccessor.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+using Microsoft.AspNetCore.Http;
+
+namespace UnitTests.Common;
+
+/// <summary>
+/// An implementation of IHttpContextAccessor that always returns null, to
+/// simulate situations where there is no http context.
+/// </summary>
+internal class NullHttpContextAccessor : IHttpContextAccessor
+{
+    public HttpContext HttpContext 
+    { 
+        get
+        {
+            return null;
+        } 
+        set
+        {
+            // Deliberate no-op
+        }
+    }
+}

--- a/test/IdentityServer.UnitTests/Services/Default/DefaultEventServiceTests.cs
+++ b/test/IdentityServer.UnitTests/Services/Default/DefaultEventServiceTests.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using System.Threading.Tasks;
+using Duende.IdentityServer.Configuration;
+using Duende.IdentityServer.Events;
+using FluentAssertions;
+using UnitTests.Common;
+using UnitTests.Services.Default.KeyManagement;
+using Xunit;
+
+namespace UnitTests.Services.Default;
+
+public class DefaultEventServiceTests
+{
+    [Fact]
+    public async Task Raising_an_event_without_http_context_does_not_throw()
+    {
+        var options = new IdentityServerOptions();
+        options.Events.RaiseInformationEvents = true;
+
+        var sink = new MockEventSink();
+
+        var sut = new DefaultEventService(
+            options, 
+            // This is the most important part of this test. We want to ensure
+            // that we don't throw exceptions when there is no http context available.
+            new NullHttpContextAccessor(), 
+            sink,
+            new MockClock());
+
+        var evt = new TestEvent(id: 123);
+
+        await sut.RaiseAsync(evt);
+
+        sink.Events.Should().Contain(e => e.Id == 123);
+    }
+
+   
+}
+
+internal class TestEvent : Event
+{
+    public TestEvent(int id = 0, string message = "") 
+        : base(category: "Test", name: "Test", EventTypes.Information, id, message)
+    {
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/DuendeSoftware/Support/issues/614, which seems to have reappeared for events.
