### PR TITLE
Allow prompt parameter with PAR

### DIFF
--- a/src/EntityFramework.Storage/Stores/PushedAuthorizationRequestStore.cs
+++ b/src/EntityFramework.Storage/Stores/PushedAuthorizationRequestStore.cs
@@ -85,8 +85,6 @@ public class PushedAuthorizationRequestStore : IPushedAuthorizationRequestStore
         {
             await Context.SaveChangesAsync(CancellationTokenProvider.CancellationToken);
         }
-        // REVIEW - Is this exception possible, since we don't try to load (and then update) an existing entity?
-        // I think it isn't, but what happens if we somehow two calls to StoreAsync with the same PAR are made?
         catch (DbUpdateConcurrencyException ex)
         {
             Logger.LogWarning("exception updating {referenceValueHash} pushed authorization in database: {error}", par.ReferenceValueHash, ex.Message);

--- a/src/IdentityServer/Extensions/ValidatedAuthorizeRequestExtensions.cs
+++ b/src/IdentityServer/Extensions/ValidatedAuthorizeRequestExtensions.cs
@@ -17,6 +17,18 @@ namespace Duende.IdentityServer.Validation;
 
 public static class ValidatedAuthorizeRequestExtensions
 {
+    /// <summary>
+    /// Removes the prompt parameter from an authorize request. Use this method 
+    /// when processing an authorize request to indicate that the prompt parameter 
+    /// has been taken into account. Typically the prompt parameter will cause
+    /// UI to be displayed, such as the login screen, that should only be displayed 
+    /// once.
+    /// </summary>
+    // TODO - This method cannot easily interact with the PAR store, because it is an 
+    // extension method. This means that whenever this method is called, the PAR store also
+    // needs to be updated, with e.g, AuthorizeInteractionResponseGenerator.ProcessPromptInParAsync.
+    // Ideally, we should introduce a new abstraction that does both, and possibly deprecate
+    // RemovePrompt in favor of it.
     public static void RemovePrompt(this ValidatedAuthorizeRequest request)
     {
         var suppress = new StringBuilder();

--- a/src/IdentityServer/Validation/Default/RequestObjectValidator.cs
+++ b/src/IdentityServer/Validation/Default/RequestObjectValidator.cs
@@ -188,6 +188,7 @@ internal class RequestObjectValidator : IRequestObjectValidator
                     description: "expired pushed authorization request");
             }
         }
+        authorizeRequest.PushedAuthorizationExpiresAtUtc = pushedAuthorizationRequest.ExpiresAtUtc;
         return null;
     }
 

--- a/src/IdentityServer/Validation/Models/ValidatedAuthorizeRequest.cs
+++ b/src/IdentityServer/Validation/Models/ValidatedAuthorizeRequest.cs
@@ -6,6 +6,7 @@
 
 using Duende.IdentityServer.Extensions;
 using IdentityModel;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
@@ -259,6 +260,11 @@ public class ValidatedAuthorizeRequest : ValidatedRequest
     /// request_uri in that format is passed, the reference value portion will be extracted and saved here.
     /// </summary>
     public string? PushedAuthorizationReferenceValue { get; set; }
+
+    /// <summary>
+    /// The expiration time of the pushed authorization request, if one was used.
+    /// </summary>
+    public DateTime? PushedAuthorizationExpiresAtUtc { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating the context in which authorization

--- a/test/IdentityServer.UnitTests/ResponseHandling/AuthorizeInteractionResponseGenerator/AuthorizeInteractionResponseGeneratorTests.cs
+++ b/test/IdentityServer.UnitTests/ResponseHandling/AuthorizeInteractionResponseGenerator/AuthorizeInteractionResponseGeneratorTests.cs
@@ -30,7 +30,8 @@ public class AuthorizeInteractionResponseGeneratorTests
             _clock,
             TestLogger.Create<Duende.IdentityServer.ResponseHandling.AuthorizeInteractionResponseGenerator>(),
             _mockConsentService,
-            new MockProfileService());
+            new MockProfileService(),
+            null);
     }
 
 

--- a/test/IdentityServer.UnitTests/ResponseHandling/AuthorizeInteractionResponseGenerator/AuthorizeInteractionResponseGeneratorTests_Consent.cs
+++ b/test/IdentityServer.UnitTests/ResponseHandling/AuthorizeInteractionResponseGenerator/AuthorizeInteractionResponseGeneratorTests_Consent.cs
@@ -97,7 +97,8 @@ public class AuthorizeInteractionResponseGeneratorTests_Consent
             new StubClock(),
             TestLogger.Create<Duende.IdentityServer.ResponseHandling.AuthorizeInteractionResponseGenerator>(),
             _mockConsent,
-            _fakeUserService);
+            _fakeUserService,
+            null);
     }
 
     private static ResourceValidationResult GetValidatedResources(params string[] scopes)

--- a/test/IdentityServer.UnitTests/ResponseHandling/AuthorizeInteractionResponseGenerator/AuthorizeInteractionResponseGeneratorTests_Custom.cs
+++ b/test/IdentityServer.UnitTests/ResponseHandling/AuthorizeInteractionResponseGenerator/AuthorizeInteractionResponseGeneratorTests_Custom.cs
@@ -24,7 +24,7 @@ public class CustomAuthorizeInteractionResponseGenerator : Duende.IdentityServer
         IClock clock, 
         ILogger<Duende.IdentityServer.ResponseHandling.AuthorizeInteractionResponseGenerator> logger, 
         IConsentService consent, 
-        IProfileService profile) : base(options, clock, logger, consent, profile)
+        IProfileService profile) : base(options, clock, logger, consent, profile, null)
     {
     }
 

--- a/test/IdentityServer.UnitTests/ResponseHandling/AuthorizeInteractionResponseGenerator/AuthorizeInteractionResponseGeneratorTests_Login.cs
+++ b/test/IdentityServer.UnitTests/ResponseHandling/AuthorizeInteractionResponseGenerator/AuthorizeInteractionResponseGeneratorTests_Login.cs
@@ -31,7 +31,7 @@ public class AuthorizeInteractionResponseGeneratorTests_Login
             _clock,
             TestLogger.Create<Duende.IdentityServer.ResponseHandling.AuthorizeInteractionResponseGenerator>(),
             _mockConsentService,
-            new MockProfileService());
+            new MockProfileService(), null);
     }
 
     [Fact]


### PR DESCRIPTION
This fixes a bug that prevents prompt parameters from being used with Pushed Authorization (#1562). However, there are some changes that are right at the edge of how much we should do in a patch release, so we need to review this carefully.

## Issue Details
Normally prompt values are used in the authorization interaction response generator, and then "processed". The original parameter is removed and the old parameter value is recorded. However, with pushed authorization, the pushed authorize request is not updated in this process, so we never process the prompt and ultimately the user can't proceed past the UI that that prompt value sends them to.

## Solution
Update the par record when we remove the prompt in the interaction response generator.

## Issues
### Needed New Property in `ValidatedAuthorizeRequest`
To update the record efficiently using the APIs available today, we need to pass the complete record to the store. By the time we get to the response generator, we no longer the original record, so we recreate it from the data that we have in the validated request. The only piece of data that is missing is the expiration timestamp, so this change adds the par expiration to the validated authorize request (similar to the existing way that we track the par reference value).

### No dedicated update method on the store
There's no dedicated update method in the PAR store to make arbitrary updates to a pushed request. We have the existing `StoreAsync` method, and I'm using that. Our existing store implementation always tries to insert, so I've changed the EF store to instead update if we know of an existing pushed request. I had performance concerns here though - I didn't want to query the database every time we make an update to check if we needed to do an update or insert. So, I'm checking if we're already tracking the pushed request in the dbcontext, since we will have already loaded the pushed request at this point with any usage that we have. It does mean that if you were using the EF par store in some other context where the pushed request hadn't been loaded previously and wanted to make arbitrary updates to the par records, you'd have to go retrieve the record first. I think that slight inconvenience is okay though, because everything about that scenario sounds far-fetched. I'd also appreciate extra attention in review of this EF store update, just because it is a little unusual (at least for me).

The bigger discussion is that this arguably is extending the semantic of the store interface. If someone has a custom PAR store, they very well could run into the same need to change their implementation that I did. I think we should still do the change because
a) it only affects you if you are combining PAR and the prompt parameter, which is broken today
b) we never said explicitly in the documentation or xmldoc that `StoreAsync` was only an insert and not an insert or update. 

### New Dependency in `AuthorizeInteractionResponseGenerator`
In order for the response generator to update the PAR record, it fundamentally has to take a dependency on the PAR store, which it doesn't do today. This means that anyone with a derived custom response generator will have to make a code change to get this update to compile.

### `RemovePrompt` is an Extension Method
Finally, the `RemovePrompt` method that does the work of removing the prompt values from the validated request is an extension method. I would have liked to have changed that method to also update the store. But because it is an extension method, there isn't a good way to do this. So for now, whenever you call `RemovePrompt` you have to remember to also clean up the store. I'd like to add a new service that processes the prompt in the model and also updates the store in a future release. For now, we just have to remember (and I suppose, anyone calling `RemovePrompt` will have to too).