### PR TITLE
PAR - support processed params in authorize endpoint

### DIFF
--- a/src/IdentityServer/Endpoints/Results/AuthorizeInteractionPageResult.cs
+++ b/src/IdentityServer/Endpoints/Results/AuthorizeInteractionPageResult.cs
@@ -91,6 +91,16 @@ class AuthorizeInteractionPageHttpWriter : IHttpResponseWriter<AuthorizeInteract
                 returnUrl = returnUrl
                     .AddQueryString(OidcConstants.AuthorizeRequest.RequestUri, requestUri)
                     .AddQueryString(OidcConstants.AuthorizeRequest.ClientId, result.Request.ClientId);
+                var processedPrompt = result.Request.Raw[Constants.ProcessedPrompt];
+                if (processedPrompt != null)
+                {
+                    returnUrl = returnUrl.AddQueryString(Constants.ProcessedPrompt, processedPrompt);
+                }
+                var processedMaxAge = result.Request.Raw[Constants.ProcessedMaxAge];
+                if (processedMaxAge != null)
+                {
+                    returnUrl = returnUrl.AddQueryString(Constants.ProcessedMaxAge, processedMaxAge);
+                }
             } 
             else
             {

--- a/src/IdentityServer/Validation/Default/RequestObjectValidator.cs
+++ b/src/IdentityServer/Validation/Default/RequestObjectValidator.cs
@@ -150,7 +150,20 @@ internal class RequestObjectValidator : IRequestObjectValidator
         // Record the reference value, so we can know that PAR did happen
         request.PushedAuthorizationReferenceValue = GetReferenceValue(request);
         // Copy the PAR into the raw request so that validation will use the pushed parameters
+        // But keep the query parameters we add that indicate that we have processed 
+        // prompt and max_age, as those are not pushed
+        var processedPrompt = request.Raw[Constants.ProcessedPrompt];
+        var processedMaxAge = request.Raw[Constants.ProcessedMaxAge];
+
         request.Raw = pushedAuthorizationRequest.PushedParameters;
+        if (processedPrompt != null)
+        {
+            request.Raw[Constants.ProcessedPrompt] = processedPrompt;
+        }
+        if (processedMaxAge != null)
+        {
+            request.Raw[Constants.ProcessedMaxAge] = processedMaxAge;
+        }
 
         var bindingError = ValidatePushedAuthorizationBindingToClient(pushedAuthorizationRequest, request);
         if (bindingError != null)

--- a/test/IdentityServer.IntegrationTests/Common/IdentityServerPipeline.cs
+++ b/test/IdentityServer.IntegrationTests/Common/IdentityServerPipeline.cs
@@ -37,6 +37,8 @@ public class IdentityServerPipeline
     public const string LoginPage = BaseUrl + "/account/login";
     public const string LogoutPage = BaseUrl + "/account/logout";
     public const string ConsentPage = BaseUrl + "/account/consent";
+    public const string CreateAccountPage = BaseUrl + "/account/create";
+
     public const string ErrorPage = BaseUrl + "/home/error";
 
     public const string DeviceAuthorization = BaseUrl + "/connect/deviceauthorization";

--- a/test/IdentityServer.IntegrationTests/Endpoints/Authorize/PushedAuthorizationTests.cs
+++ b/test/IdentityServer.IntegrationTests/Endpoints/Authorize/PushedAuthorizationTests.cs
@@ -194,6 +194,8 @@ public class PushedAuthorizationTests
 
     [Theory]
     [InlineData("prompt", "login")]
+    [InlineData("prompt", "select_account")]
+    [InlineData("prompt", "create")]
     [InlineData("max_age", "0")]
     public async Task prompt_login_can_be_used_with_pushed_authorization(string parameterName, string parameterValue)
     {


### PR DESCRIPTION
Fixes #1562, which is a bug where the prompt (or max_age=0) parameter could not be used with PAR because we weren't respecting the processed flag.