### PR TITLE
Use SHA*.HashData() one-shot methods

### DIFF
--- a/src/IdentityServer/Extensions/HashExtensions.cs
+++ b/src/IdentityServer/Extensions/HashExtensions.cs
@@ -23,13 +23,10 @@ public static class HashExtensions
     {
         if (input.IsMissing()) return string.Empty;
 
-        using (var sha = SHA256.Create())
-        {
-            var bytes = Encoding.UTF8.GetBytes(input);
-            var hash = sha.ComputeHash(bytes);
+        var bytes = Encoding.UTF8.GetBytes(input);
+        var hash = SHA256.HashData(bytes);
 
-            return Convert.ToBase64String(hash);
-        }
+        return Convert.ToBase64String(hash);
     }
 
     /// <summary>
@@ -44,10 +41,7 @@ public static class HashExtensions
             return null;
         }
 
-        using (var sha = SHA256.Create())
-        {
-            return sha.ComputeHash(input);
-        }
+        return SHA256.HashData(input);
     }
 
     /// <summary>
@@ -59,12 +53,9 @@ public static class HashExtensions
     {
         if (input.IsMissing()) return string.Empty;
 
-        using (var sha = SHA512.Create())
-        {
-            var bytes = Encoding.UTF8.GetBytes(input);
-            var hash = sha.ComputeHash(bytes);
+        var bytes = Encoding.UTF8.GetBytes(input);
+        var hash = SHA512.HashData(bytes);
 
-            return Convert.ToBase64String(hash);
-        }
+        return Convert.ToBase64String(hash);
     }
 }

--- a/src/IdentityServer/Extensions/ValidatedAuthorizeRequestExtensions.cs
+++ b/src/IdentityServer/Extensions/ValidatedAuthorizeRequestExtensions.cs
@@ -155,12 +155,7 @@ public static class ValidatedAuthorizeRequestExtensions
         }
 
         var bytes = Encoding.UTF8.GetBytes(clientId + origin + sessionId + salt);
-        byte[] hash;
-
-        using (var sha = SHA256.Create())
-        {
-            hash = sha.ComputeHash(bytes);
-        }
+        var hash = SHA256.HashData(bytes);
 
         return Base64Url.Encode(hash) + "." + salt;
     }

--- a/src/IdentityServer/Models/Messages/ConsentRequest.cs
+++ b/src/IdentityServer/Models/Messages/ConsentRequest.cs
@@ -88,13 +88,10 @@ public class ConsentRequest
             var normalizedScopes = ScopesRequested?.OrderBy(x => x).Distinct().Aggregate((x, y) => x + "," + y);
             var value = $"{ClientId}:{Subject}:{Nonce}:{normalizedScopes}";
 
-            using (var sha = SHA256.Create())
-            {
-                var bytes = Encoding.UTF8.GetBytes(value);
-                var hash = sha.ComputeHash(bytes);
+            var bytes = Encoding.UTF8.GetBytes(value);
+            var hash = SHA256.HashData(bytes);
 
-                return Base64Url.Encode(hash);
-            }
+            return Base64Url.Encode(hash);
         }
     }
 }

--- a/src/IdentityServer/Stores/Default/DefaultGrantStore.cs
+++ b/src/IdentityServer/Stores/Default/DefaultGrantStore.cs
@@ -98,12 +98,9 @@ public class DefaultGrantStore<T>
         if (value.EndsWith(HexEncodingFormatSuffix))
         {
             // newer format >= v6; uses hex encoding to avoid collation issues
-            using (var sha = SHA256.Create())
-            {
-                var bytes = Encoding.UTF8.GetBytes(key);
-                var hash = sha.ComputeHash(bytes);
-                return BitConverter.ToString(hash).Replace("-", "");
-            }
+            var bytes = Encoding.UTF8.GetBytes(key);
+            var hash = SHA256.HashData(bytes);
+            return BitConverter.ToString(hash).Replace("-", "");
         }
 
         // old format <= v5

--- a/src/IdentityServer/Validation/Default/DefaultDPoPProofValidator.cs
+++ b/src/IdentityServer/Validation/Default/DefaultDPoPProofValidator.cs
@@ -249,9 +249,8 @@ public class DefaultDPoPProofValidator : IDPoPProofValidator
                 return;
             }
 
-            using var sha = SHA256.Create();
             var bytes = Encoding.UTF8.GetBytes(context.AccessToken);
-            var hash = sha.ComputeHash(bytes);
+            var hash = SHA256.HashData(bytes);
 
             var accessTokenHash = Base64Url.Encode(hash);
             if (accessTokenHash != result.AccessTokenHash)


### PR DESCRIPTION
Use `SHA*.HashData()` one-shot methods to avoid allocating `SHA*` objects.

This is something I just happened to notice while I was debugging an issue in something using IdentityServer in a sample and I stepped into the decompiled code.

The only usages of `SHA*.Create()` left after this change are these:

https://github.com/DuendeSoftware/IdentityServer/blob/e9860c6488f90e8fbc11a4452b9dd111dbfae933/src/IdentityServer/Configuration/CryptoHelper.cs#L84-L100

As this is a public method I left it as-is, but refactored the only caller within the codebase itself to use the one-shot methods and not depend on it anymore.
