### PR TITLE
remove unnecessary distinct method

### DIFF
--- a/src/IdentityServer/Extensions/HttpContextExtensions.cs
+++ b/src/IdentityServer/Extensions/HttpContextExtensions.cs
@@ -46,7 +46,6 @@ public static class HttpContextExtensions
             if (currentSubId == logoutMessage?.SubjectId)
             {
                 clientIds = clientIds.Union(await userSession.GetClientListAsync());
-                clientIds = clientIds.Distinct();
             }
 
             endSessionMsg = new LogoutNotificationContext

--- a/src/IdentityServer/Extensions/HttpContextExtensions.cs
+++ b/src/IdentityServer/Extensions/HttpContextExtensions.cs
@@ -40,10 +40,10 @@ public static class HttpContextExtensions
         // if we have a logout message, then that take precedence over the current user
         if (logoutMessage?.ClientIds?.Any() == true)
         {
-            var clientIds = logoutMessage?.ClientIds;
+            var clientIds = logoutMessage.ClientIds;
 
             // check if current user is same, since we might have new clients (albeit unlikely)
-            if (currentSubId == logoutMessage?.SubjectId)
+            if (currentSubId == logoutMessage.SubjectId)
             {
                 clientIds = clientIds.Union(await userSession.GetClientListAsync());
             }

--- a/src/IdentityServer/Services/Default/DefaultPersistedGrantService.cs
+++ b/src/IdentityServer/Services/Default/DefaultPersistedGrantService.cs
@@ -144,7 +144,7 @@ public class DefaultPersistedGrantService : IPersistedGrantService
             var match = list.FirstOrDefault(x => x.ClientId == other.ClientId);
             if (match != null)
             {
-                match.Scopes = match.Scopes.Union(other.Scopes).Distinct();
+                match.Scopes = match.Scopes.Union(other.Scopes);
 
                 if (match.CreationTime > other.CreationTime)
                 {


### PR DESCRIPTION
[Enumerable.Union](https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.union?view=net-8.0#system-linq-enumerable-union-1(system-collections-generic-ienumerable((-0))-system-collections-generic-ienumerable((-0)))) method already excludes duplicates.

> Returns
An [IEnumerable<T>](https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.ienumerable-1?view=net-8.0) that contains the elements from both input sequences, excluding duplicates.

---

```
IEnumerable<string> first = ["a", "b"];
IEnumerable<string> second = ["a", "c"];

var union = first.Union(second); // => [a, b, c]

var unionDistinct = first.Union(second).Distinct(); // => [a, b, c]

Debug.Assert(union.SequenceEqual(unionDistinct));
```
---
Some performance improvement:
```
[SimpleJob(RuntimeMoniker.Net80)]
[MemoryDiagnoser]
public class Benchmark
{
    private IEnumerable<string> list1 = ["a", "b"];
    private IEnumerable<string> list2 = ["a", "c"];

    [Benchmark]
    public void Union()
    {
        var union = list1.Union(list2);
    }

    [Benchmark]
    public void Union_Distinct()
    {
        var unionDistinct = list1.Union(list2).Distinct();
    }
}

void Main() => BenchmarkRunner.Run<Benchmark>();
```
```
// * Summary *

BenchmarkDotNet v0.13.12, Windows 10 (10.0.19045.4651/22H2/2022Update)
Intel Core i7-10700 CPU 2.90GHz, 1 CPU, 16 logical and 8 physical cores
.NET SDK 9.0.100-preview.2.24157.14
  [Host] : .NET 8.0.7 (8.0.724.31311), X64 RyuJIT AVX2

Job=.NET 8.0  Runtime=.NET 8.0  

| Method         | Mean     | Error    | StdDev   | Gen0   | Allocated |
|--------------- |---------:|---------:|---------:|-------:|----------:|
| Union          | 13.21 ns | 0.291 ns | 0.674 ns | 0.0086 |      72 B |
| Union_Distinct | 24.71 ns | 0.778 ns | 2.293 ns | 0.0162 |     136 B |
// * Hints *
Outliers
  Benchmark.Union: .NET 8.0 -> 5 outliers were removed (16.60 ns..17.69 ns)

// * Legends *
  Mean      : Arithmetic mean of all measurements
  Error     : Half of 99.9% confidence interval
  StdDev    : Standard deviation of all measurements
  Gen0      : GC Generation 0 collects per 1000 operations
  Allocated : Allocated memory per single operation (managed only, inclusive, 1KB = 1024B)
  1 ns      : 1 Nanosecond (0.000000001 sec)
```