### PR TITLE
use static equals method to avoid exception

### DIFF
--- a/src/IdentityServer/Test/TestUserStore.cs
+++ b/src/IdentityServer/Test/TestUserStore.cs
@@ -44,7 +44,7 @@ public class TestUserStore
                 return true;
             }
 
-            return user.Password.Equals(password);
+            return Equals(user.Password, password);
         }
 
         return false;


### PR DESCRIPTION
`user.Password` could be null.