### PR TITLE
Refactoring AuthenticationPropertiesExtensions

### DIFF
--- a/src/IdentityServer/Extensions/AuthenticationPropertiesExtensions.cs
+++ b/src/IdentityServer/Extensions/AuthenticationPropertiesExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 
@@ -100,10 +100,7 @@ public static class AuthenticationPropertiesExtensions
         var clients = properties.GetClientList();
         if (!clients.Contains(clientId))
         {
-            var update = clients.ToList();
-            update.Add(clientId);
-                
-            properties.SetClientList(update);
+            properties.SetClientList(clients.Append(clientId));
         }
     }
 

--- a/src/IdentityServer/Extensions/AuthenticationPropertiesExtensions.cs
+++ b/src/IdentityServer/Extensions/AuthenticationPropertiesExtensions.cs
@@ -26,12 +26,7 @@ public static class AuthenticationPropertiesExtensions
     /// <returns></returns>
     public static string GetSessionId(this AuthenticationProperties properties)
     {
-        if (properties?.Items.ContainsKey(SessionIdKey) == true)
-        {
-            return properties.Items[SessionIdKey];
-        }
-
-        return null;
+        return properties?.Items.TryGetValue(SessionIdKey, out var value) == true ? value : null;
     }
 
     /// <summary>

--- a/src/IdentityServer/Extensions/AuthenticationPropertiesExtensions.cs
+++ b/src/IdentityServer/Extensions/AuthenticationPropertiesExtensions.cs
@@ -47,13 +47,12 @@ public static class AuthenticationPropertiesExtensions
     /// <returns></returns>
     public static IEnumerable<string> GetClientList(this AuthenticationProperties properties)
     {
-        if (properties?.Items.ContainsKey(ClientListKey) == true)
+        if (properties?.Items.TryGetValue(ClientListKey, out var value) == true)
         {
-            var value = properties.Items[ClientListKey];
             return DecodeList(value);
         }
 
-        return Enumerable.Empty<string>();
+        return [];
     }
 
     /// <summary>


### PR DESCRIPTION
Use [Append](https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.append) method instead of [ToList](https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.tolist) and [Add](https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.add) methods.
```
[SimpleJob(RuntimeMoniker.Net80)]
[MemoryDiagnoser]
public class Benchmark
{
    private string clientId = "1";

    [Benchmark]
    public void ToList_Add()
    {
        IEnumerable<string> clients = [];

        var update = clients.ToList();
        update.Add(clientId);
    }

    [Benchmark]
    public void Append()
    {
        IEnumerable<string> clients = [];
        clients.Append(clientId);
    }
}

void Main() => BenchmarkRunner.Run<Benchmark>();
```
```
// * Summary *

BenchmarkDotNet v0.14.0, Windows 10 (10.0.19045.4780/22H2/2022Update)
Intel Core i7-10700 CPU 2.90GHz, 1 CPU, 16 logical and 8 physical cores
.NET SDK 8.0.401
  [Host] : .NET 8.0.8 (8.0.824.36612), X64 RyuJIT AVX2

Job=.NET 8.0  Runtime=.NET 8.0  

| Method     | Mean      | Error     | StdDev    | Median    | Gen0   | Allocated |
|----------- |----------:|----------:|----------:|----------:|-------:|----------:|
| ToList_Add | 28.061 ns | 0.4924 ns | 0.5473 ns | 28.045 ns | 0.0105 |      88 B |
| Append     |  8.149 ns | 0.1996 ns | 0.5499 ns |  7.959 ns | 0.0076 |      64 B |
// * Hints *
Outliers
  Benchmark.ToList_Add: .NET 8.0 -> 1 outlier  was  removed (31.57 ns)
  Benchmark.Append: .NET 8.0     -> 12 outliers were removed (11.61 ns..14.89 ns)

// * Legends *
  Mean      : Arithmetic mean of all measurements
  Error     : Half of 99.9% confidence interval
  StdDev    : Standard deviation of all measurements
  Median    : Value separating the higher half of all measurements (50th percentile)
  Gen0      : GC Generation 0 collects per 1000 operations
  Allocated : Allocated memory per single operation (managed only, inclusive, 1KB = 1024B)
  1 ns      : 1 Nanosecond (0.000000001 sec)
```

---

Use [TryGetValue](https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2.trygetvalue) method instead of [ContainsKey](https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2.containskey) method and [Indexer](https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2.item) ([CA1854](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1854)).
```
[SimpleJob(RuntimeMoniker.Net80)]
[MemoryDiagnoser]
public class Benchmark
{
    private IDictionary<string, string> items = new Dictionary<string, string>
    {
        ["1"] = "A"
    };

    private string clientListKey = "1";

    [Benchmark]
    public void ContainsKey_Indexer()
    {
        if (items.ContainsKey(clientListKey) == true)
        {
            var value = items[clientListKey];
        }
    }

    [Benchmark]
    public void TryGetValue()
    {
        if (items.TryGetValue(clientListKey, out var value) == true)
        {
        }
    }
}

void Main() => BenchmarkRunner.Run<Benchmark>();
```
```
// * Summary *

BenchmarkDotNet v0.14.0, Windows 10 (10.0.19045.4780/22H2/2022Update)
Intel Core i7-10700 CPU 2.90GHz, 1 CPU, 16 logical and 8 physical cores
.NET SDK 8.0.401
  [Host] : .NET 8.0.8 (8.0.824.36612), X64 RyuJIT AVX2

Job=.NET 8.0  Runtime=.NET 8.0  

| Method              | Mean     | Error    | StdDev   | Allocated |
|-------------------- |---------:|---------:|---------:|----------:|
| ContainsKey_Indexer | 19.34 ns | 0.226 ns | 0.200 ns |         - |
| TryGetValue         | 10.46 ns | 0.171 ns | 0.142 ns |         - |
// * Hints *
Outliers
  Benchmark.ContainsKey_Indexer: .NET 8.0 -> 1 outlier  was  removed (21.41 ns)
  Benchmark.TryGetValue: .NET 8.0         -> 2 outliers were removed (12.39 ns, 13.60 ns)

// * Legends *
  Mean      : Arithmetic mean of all measurements
  Error     : Half of 99.9% confidence interval
  StdDev    : Standard deviation of all measurements
  Allocated : Allocated memory per single operation (managed only, inclusive, 1KB = 1024B)
  1 ns      : 1 Nanosecond (0.000000001 sec)
```