### PR TITLE
Avoid multiple check adding clientid

### DIFF
--- a/src/IdentityServer/Services/Default/DefaultUserSession.cs
+++ b/src/IdentityServer/Services/Default/DefaultUserSession.cs
@@ -67,7 +67,7 @@ public class DefaultUserSession : IUserSession
     /// The name of the check session cookie.
     /// </value>
     protected string CheckSessionCookieName => Options.Authentication.CheckSessionCookieName;
-        
+
     /// <summary>
     /// Gets the domain of the check session cookie.
     /// </summary>
@@ -310,12 +310,8 @@ public class DefaultUserSession : IUserSession
         await AuthenticateAsync();
         if (Properties != null)
         {
-            var clientIds = Properties.GetClientList();
-            if (!clientIds.Contains(clientId))
-            {
-                Properties.AddClientId(clientId);
-                await UpdateSessionCookie();
-            }
+            Properties.AddClientId(clientId);
+            await UpdateSessionCookie();
         }
     }
 

--- a/test/IdentityServer.UnitTests/Services/Default/DefaultUserSessionTests.cs
+++ b/test/IdentityServer.UnitTests/Services/Default/DefaultUserSessionTests.cs
@@ -262,4 +262,19 @@ public class DefaultUserSessionTests
         var clients = await _subject.GetClientListAsync();
         clients.Should().Contain(new string[] { "client2", "client1" });
     }
+
+    [Fact]
+    public async Task adding_existing_client_should_not_add_new_client()
+    {
+        _mockAuthenticationHandler.Result = AuthenticateResult.Success(new AuthenticationTicket(_user, _props, "scheme"));
+
+        const string clientId = "client";
+        await _subject.AddClientIdAsync(clientId);
+        await _subject.AddClientIdAsync(clientId);
+        
+        var clients = await _subject.GetClientListAsync();
+        
+        _props.Items.Count.Should().Be(1);
+        clients.Should().BeEquivalentTo([clientId]);
+    }
 }


### PR DESCRIPTION
Reuse already existing check in the [AuthenticationPropertiesExtensions.AddClientId](https://github.com/DuendeSoftware/IdentityServer/blob/main/src/IdentityServer/Extensions/AuthenticationPropertiesExtensions.cs#L101) method.