### PR TITLE
Avoid unhandled argument null exception for refresh_token grant in token validator when scopes missing

### DIFF
--- a/src/IdentityServer/Validation/Default/TokenRequestValidator.cs
+++ b/src/IdentityServer/Validation/Default/TokenRequestValidator.cs
@@ -764,6 +764,15 @@ internal class TokenRequestValidator : ITokenRequestValidator
         }
 
         //////////////////////////////////////////////////////////
+        // validate scopes
+        //////////////////////////////////////////////////////////
+        if (_validatedRequest.RefreshToken.AuthorizedScopes == null)
+        {
+            LogError("Refresh token has no associated scopes");
+            return Invalid(OidcConstants.AuthorizeErrors.InvalidScope, "Invalid scope.");
+        }
+
+        //////////////////////////////////////////////////////////
         // resource indicator
         //////////////////////////////////////////////////////////
         var resourceIndicators = _validatedRequest.RefreshToken.AuthorizedResourceIndicators;


### PR DESCRIPTION

**What issue does this PR address?**

On call to /connect/token endpoint, Identity Server returns an HTML page due to an internal error instead of a response in JSON format.
[The related issue](https://github.com/DuendeSoftware/Support/issues/1409) is created.



**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
