### PR TITLE
Build updates in preparation for .net 9

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -42,7 +42,7 @@
         <PackageReference Update="Microsoft.IdentityModel.JsonWebTokens" Version="$(WilsonVersion)"/>
         <PackageReference Update="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="$(WilsonVersion)"/>
         <PackageReference Update="System.IdentityModel.Tokens.Jwt" Version="$(WilsonVersion)"/>
-        <PackageReference Update="Serilog.AspNetCore" Version="8.0.0"/>
+        <PackageReference Update="Serilog.AspNetCore" Version="8.0.2"/>
 
         <!--microsoft asp.net core -->
         <PackageReference Update="Microsoft.AspNetCore.DataProtection.Abstractions" Version="$(FrameworkVersion)"/>
@@ -69,6 +69,17 @@
         <PackageReference Update="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
         <PackageReference Update="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
         <PackageReference Update="OpenTelemetry.Instrumentation.SqlClient" Version="1.8.0-beta.1" />
+
+        <!-- Transitive Dependencies -->
+        <!-- These packages are all transitive dependencies that would
+             otherwise resolve to a version with a security vulnerabilitiy. In future, we
+             would like to update Microsoft.Data.SqlClient and 
+             Microsoft.EntityFrameworkCore, and remove these explicit dependencies (assuming
+             that future versions of the intermediate dependencies that don't have this
+             problem exist someday). -->
+        <PackageReference Update="Azure.Identity" Version="1.11.4" />
+        <PackageReference Update="System.Formats.Asn1" Version="8.0.1" />
+        <PackageReference Update="Microsoft.Data.SqlClient" Version="5.1.6" />
 
     </ItemGroup>
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -26,7 +26,7 @@
 
         <!-- testing -->
         <PackageReference Update="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(FrameworkVersion)" />
-        <PackageReference Update="CsQuery.NETStandard" Version="1.3.6.1" />
+        <PackageReference Update="AngleSharp" Version="1.1.2" />
         <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.8.0" />
 
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -19,9 +19,9 @@
 
         <!--tests -->
         <PackageReference Update="FluentAssertions" Version="6.5.1"/>
-        <PackageReference Update="FluentAssertions.Web" Version="1.2.5"/>
+        <PackageReference Update="FluentAssertions.Web" Version="1.5.0"/>
         <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
-        <PackageReference Update="xunit" Version="2.6.2"/>
+        <PackageReference Update="xunit" Version="2.9.0"/>
         <PackageReference Update="xunit.runner.visualstudio" Version="2.5.4" PrivateAssets="All"/>
 
         <!-- testing -->
@@ -80,7 +80,7 @@
         <PackageReference Update="Azure.Identity" Version="1.11.4" />
         <PackageReference Update="System.Formats.Asn1" Version="8.0.1" />
         <PackageReference Update="Microsoft.Data.SqlClient" Version="5.1.6" />
-
+        <PackageReference Update="System.Text.Json" Version="8.0.4" />
     </ItemGroup>
 
     <Target Name="SetAssemblyVersion" AfterTargets="MinVer">

--- a/hosts/AspNetIdentity/Host.AspNetIdentity.csproj
+++ b/hosts/AspNetIdentity/Host.AspNetIdentity.csproj
@@ -24,6 +24,18 @@
     </ItemGroup>
 
     <ItemGroup>
+        <!-- The packages in this ItemGroup are all transitive dependencies that
+             would otherwise resolve to a version with a security vulnerabilitiy. 
+             In future, we would like to update Microsoft.Data.SqlClient and
+             Microsoft.EntityFrameworkCore, and remove these explicit dependencies
+             (assuming that future versions of the intermediate dependencies that
+             don't have this problem exist someday). -->
+        <PackageReference Include="Azure.Identity" />
+        <PackageReference Include="System.Formats.Asn1" />
+        <PackageReference Include="Microsoft.Data.SqlClient" />
+    </ItemGroup>
+
+    <ItemGroup>
         <ProjectReference
             Include="..\..\src\AspNetIdentity\Duende.IdentityServer.AspNetIdentity.csproj" />
     </ItemGroup>

--- a/hosts/Configuration/Host.Configuration.csproj
+++ b/hosts/Configuration/Host.Configuration.csproj
@@ -37,6 +37,18 @@
     </ItemGroup>
 
     <ItemGroup>
+        <!-- The packages in this ItemGroup are all transitive dependencies that
+             would otherwise resolve to a version with a security vulnerabilitiy. 
+             In future, we would like to update Microsoft.Data.SqlClient and
+             Microsoft.EntityFrameworkCore, and remove these explicit dependencies
+             (assuming that future versions of the intermediate dependencies that
+             don't have this problem exist someday). -->
+        <PackageReference Include="Azure.Identity" />
+        <PackageReference Include="System.Formats.Asn1" />
+        <PackageReference Include="Microsoft.Data.SqlClient" />
+    </ItemGroup>
+
+    <ItemGroup>
         <ProjectReference Include="..\..\src\IdentityServer\Duende.IdentityServer.csproj" />
         <ProjectReference Include="..\..\src\Configuration\Duende.IdentityServer.Configuration.csproj" />
     </ItemGroup>

--- a/hosts/EntityFramework/Host.EntityFramework.csproj
+++ b/hosts/EntityFramework/Host.EntityFramework.csproj
@@ -23,6 +23,18 @@
     </ItemGroup>
 
     <ItemGroup>
+        <!-- The packages in this ItemGroup are all transitive dependencies that
+             would otherwise resolve to a version with a security vulnerabilitiy. 
+             In future, we would like to update Microsoft.Data.SqlClient and
+             Microsoft.EntityFrameworkCore, and remove these explicit dependencies
+             (assuming that future versions of the intermediate dependencies that
+             don't have this problem exist someday). -->
+        <PackageReference Include="Azure.Identity" />
+        <PackageReference Include="System.Formats.Asn1" />
+        <PackageReference Include="Microsoft.Data.SqlClient" />
+    </ItemGroup>
+
+    <ItemGroup>
         <ProjectReference Include="..\..\src\Configuration\Duende.IdentityServer.Configuration.csproj" />
         <ProjectReference Include="..\..\src\Configuration.EntityFramework\Duende.IdentityServer.Configuration.EntityFramework.csproj" />
         <ProjectReference Include="..\..\src\EntityFramework\Duende.IdentityServer.EntityFramework.csproj" />

--- a/hosts/EntityFramework/Pages/Admin/Clients/ClientRepository.cs
+++ b/hosts/EntityFramework/Pages/Admin/Clients/ClientRepository.cs
@@ -24,7 +24,7 @@ public class CreateClientModel : ClientSummaryModel
     public string Secret { get; set; } = default!;
 }
 
-public class ClientModel : CreateClientModel, IValidatableObject
+public class EditClientModel : CreateClientModel, IValidatableObject
 {
     [Required]
     public string AllowedScopes { get; set; } = default!;
@@ -91,7 +91,7 @@ public class ClientRepository
         return await result.ToArrayAsync();
     }
 
-    public async Task<ClientModel?> GetByIdAsync(string id)
+    public async Task<EditClientModel?> GetByIdAsync(string id)
     {
         var client = await _context.Clients
             .Include(x => x.AllowedGrantTypes)
@@ -103,7 +103,7 @@ public class ClientRepository
 
         if (client == null) return null;
 
-        return new ClientModel
+        return new EditClientModel
         {
             ClientId = client.ClientId,
             Name = client.ClientName,
@@ -146,7 +146,7 @@ public class ClientRepository
         await _context.SaveChangesAsync();
     }
 
-    public async Task UpdateAsync(ClientModel model)
+    public async Task UpdateAsync(EditClientModel model)
     {
         ArgumentNullException.ThrowIfNull(model);
         var client = await _context.Clients

--- a/hosts/EntityFramework/Pages/Admin/Clients/Edit.cshtml.cs
+++ b/hosts/EntityFramework/Pages/Admin/Clients/Edit.cshtml.cs
@@ -19,7 +19,7 @@ public class EditModel : PageModel
     }
 
     [BindProperty]
-    public ClientModel InputModel { get; set; } = default!;
+    public EditClientModel InputModel { get; set; } = default!;
     [BindProperty]
     public string? Button { get; set; }
 

--- a/migrations/IdentityServerDb/IdentityServerDb.csproj
+++ b/migrations/IdentityServerDb/IdentityServerDb.csproj
@@ -10,6 +10,19 @@
     </ItemGroup>
 
     <ItemGroup>
+        <!-- The packages in this ItemGroup are all transitive dependencies that
+             would otherwise resolve to a version with a security vulnerabilitiy. 
+             In future, we would like to update Microsoft.Data.SqlClient and
+             Microsoft.EntityFrameworkCore, and remove these explicit dependencies
+             (assuming that future versions of the intermediate dependencies that
+             don't have this problem exist someday). -->
+        <PackageReference Include="Azure.Identity" />
+        <PackageReference Include="System.Formats.Asn1" />
+        <PackageReference Include="Microsoft.Data.SqlClient" />
+        <PackageReference Include="System.Text.Json" />
+    </ItemGroup>
+    
+    <ItemGroup>
         <ProjectReference Include="..\..\src\EntityFramework.Storage\Duende.IdentityServer.EntityFramework.Storage.csproj" />
         <ProjectReference Include="..\..\src\IdentityServer\Duende.IdentityServer.csproj" />
     </ItemGroup>

--- a/test/Configuration.IntegrationTests/Configuration.IntegrationTests.csproj
+++ b/test/Configuration.IntegrationTests/Configuration.IntegrationTests.csproj
@@ -23,9 +23,9 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" />
-    <PackageReference Include="CsQuery.NETStandard" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
+    <PackageReference Include="AngleSharp" />
   </ItemGroup>
 </Project>

--- a/test/EntityFramework.IntegrationTests/EntityFramework.IntegrationTests.csproj
+++ b/test/EntityFramework.IntegrationTests/EntityFramework.IntegrationTests.csproj
@@ -16,6 +16,20 @@
     </ItemGroup>
 
     <ItemGroup>
+        <!-- The packages in this ItemGroup are all transitive dependencies that
+             would otherwise resolve to a version with a security vulnerabilitiy. 
+             In future, we would like to update Microsoft.Data.SqlClient and
+             Microsoft.EntityFrameworkCore, and remove these explicit dependencies
+             (assuming that future versions of the intermediate dependencies that
+             don't have this problem exist someday). -->
+        <PackageReference Include="Azure.Identity" />
+        <PackageReference Include="System.Formats.Asn1" />
+        <PackageReference Include="Microsoft.Data.SqlClient" />
+        <PackageReference Include="System.Text.Json" />
+    </ItemGroup>
+
+
+    <ItemGroup>
         <ProjectReference Include="..\..\src\EntityFramework\Duende.IdentityServer.EntityFramework.csproj" />
     </ItemGroup>
 </Project>

--- a/test/EntityFramework.Storage.IntegrationTests/EntityFramework.Storage.IntegrationTests.csproj
+++ b/test/EntityFramework.Storage.IntegrationTests/EntityFramework.Storage.IntegrationTests.csproj
@@ -20,6 +20,19 @@
     </ItemGroup>
 
     <ItemGroup>
+        <!-- The packages in this ItemGroup are all transitive dependencies that
+             would otherwise resolve to a version with a security vulnerabilitiy. 
+             In future, we would like to update Microsoft.Data.SqlClient and
+             Microsoft.EntityFrameworkCore, and remove these explicit dependencies
+             (assuming that future versions of the intermediate dependencies that
+             don't have this problem exist someday). -->
+        <PackageReference Include="Azure.Identity" />
+        <PackageReference Include="System.Formats.Asn1" />
+        <PackageReference Include="Microsoft.Data.SqlClient" />
+        <PackageReference Include="System.Text.Json" />
+    </ItemGroup>
+    
+    <ItemGroup>
         <ProjectReference Include="..\..\src\EntityFramework.Storage\Duende.IdentityServer.EntityFramework.Storage.csproj" />
         <ProjectReference Include="..\..\src\IdentityServer\Duende.IdentityServer.csproj" />
         <ProjectReference Include="..\..\src\Storage\Duende.IdentityServer.Storage.csproj" />

--- a/test/EntityFramework.Storage.UnitTests/EntityFramework.Storage.UnitTests.csproj
+++ b/test/EntityFramework.Storage.UnitTests/EntityFramework.Storage.UnitTests.csproj
@@ -14,6 +14,15 @@
     </ItemGroup>
 
     <ItemGroup>
+        <!-- This package is a transitive dependency that would otherwise resolve 
+             to a version with a security vulnerabilitiy. 
+             In future, we would like to update Microsoft.EntityFrameworkCore.Sqlite,
+             and remove this explicit dependency (assuming that future versions of 
+             the sqlite package that doesn't have this problem exist someday). -->
+        <PackageReference Include="System.Text.Json" />
+    </ItemGroup>
+
+    <ItemGroup>
         <ProjectReference Include="..\..\src\EntityFramework.Storage\Duende.IdentityServer.EntityFramework.Storage.csproj" />
     </ItemGroup>
 

--- a/test/IdentityServer.IntegrationTests/IdentityServer.IntegrationTests.csproj
+++ b/test/IdentityServer.IntegrationTests/IdentityServer.IntegrationTests.csproj
@@ -23,6 +23,11 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="System.Net.Http" Version="4.3.4" />
+        <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+    </ItemGroup>
+
+    <ItemGroup>
         <None Update="identityserver_testing.cer">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </None>

--- a/test/IdentityServer.IntegrationTests/IdentityServer.IntegrationTests.csproj
+++ b/test/IdentityServer.IntegrationTests/IdentityServer.IntegrationTests.csproj
@@ -13,9 +13,7 @@
         <PackageReference Include="Microsoft.AspNetCore.TestHost" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
         <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" />
-
-        <PackageReference Include="CsQuery.NETStandard" Version="1.3.6.1" />
-
+        <PackageReference Include="AngleSharp" />
         <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />
         <PackageReference Include="FluentAssertions" />

--- a/test/IdentityServer.UnitTests/Validation/IsLocalUrlTests.cs
+++ b/test/IdentityServer.UnitTests/Validation/IsLocalUrlTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Duende.IdentityServer.Configuration;
 using Duende.IdentityServer.Extensions;
 using Duende.IdentityServer.Services;
@@ -61,7 +62,7 @@ public class IsLocalUrlTests
 
     [Theory]
     [MemberData(nameof(TestCases))]
-    public async void GetAuthorizationContextAsync(string returnUrl, bool expected)
+    public async Task GetAuthorizationContextAsync(string returnUrl, bool expected)
     {
         var interactionService = new DefaultIdentityServerInteractionService(null, null, null, null, null, null, null, 
             GetReturnUrlParser(), new LoggerFactory().CreateLogger<DefaultIdentityServerInteractionService>());
@@ -105,7 +106,7 @@ public class IsLocalUrlTests
 
     [Theory]
     [MemberData(nameof(TestCases))]
-    public async void OidcReturnUrlParser_ParseAsync(string returnUrl, bool expected)
+    public async Task OidcReturnUrlParser_ParseAsync(string returnUrl, bool expected)
     {
         var oidcParser = GetOidcReturnUrlParser();
         var actual = await oidcParser.ParseAsync(returnUrl);
@@ -138,7 +139,7 @@ public class IsLocalUrlTests
 
     [Theory]
     [MemberData(nameof(TestCases))]
-    public async void ReturnUrlParser_ParseAsync(string returnUrl, bool expected)
+    public async Task ReturnUrlParser_ParseAsync(string returnUrl, bool expected)
     {
         var parser = GetReturnUrlParser();
         var actual = await parser.ParseAsync(returnUrl);

--- a/test/IdentityServer.UnitTests/Validation/Secrets/BasicAuthenticationCredentialParsing.cs
+++ b/test/IdentityServer.UnitTests/Validation/Secrets/BasicAuthenticationCredentialParsing.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Net.Http;
 using System.Text;
+using System.Threading.Tasks;
 using Duende.IdentityServer;
 using Duende.IdentityServer.Configuration;
 using Duende.IdentityServer.Validation;
@@ -31,7 +32,7 @@ public class BasicAuthenticationSecretParsing
 
     [Fact]
     [Trait("Category", Category)]
-    public async void EmptyContext()
+    public async Task EmptyContext()
     {
         var context = new DefaultHttpContext();
 
@@ -42,7 +43,7 @@ public class BasicAuthenticationSecretParsing
 
     [Fact]
     [Trait("Category", Category)]
-    public async void Valid_BasicAuthentication_Request()
+    public async Task Valid_BasicAuthentication_Request()
     {
         var context = new DefaultHttpContext();
 
@@ -67,7 +68,7 @@ public class BasicAuthenticationSecretParsing
     [InlineData("cl+ ient", "se+cret")]
     [InlineData("cl+ ient", "se+ cret")]
     [InlineData("client:urn", "secret")]
-    public async void Valid_BasicAuthentication_Request_in_various_Formats_Manual(string userName, string password)
+    public async Task Valid_BasicAuthentication_Request_in_various_Formats_Manual(string userName, string password)
     {
         Encoding encoding = Encoding.UTF8;
         var context = new DefaultHttpContext();
@@ -94,7 +95,7 @@ public class BasicAuthenticationSecretParsing
     [InlineData("cl+ ient", "se+cret")]
     [InlineData("cl+ ient", "se+ cret")]
     [InlineData("client:urn", "secret")]
-    public async void Valid_BasicAuthentication_Request_in_various_Formats_IdentityModel(string userName, string password)
+    public async Task Valid_BasicAuthentication_Request_in_various_Formats_IdentityModel(string userName, string password)
     {
         Encoding encoding = Encoding.UTF8;
         var context = new DefaultHttpContext();
@@ -112,7 +113,7 @@ public class BasicAuthenticationSecretParsing
 
     [Fact]
     [Trait("Category", Category)]
-    public async void Valid_BasicAuthentication_Request_With_UserName_Only_And_Colon_For_Optional_ClientSecret()
+    public async Task Valid_BasicAuthentication_Request_With_UserName_Only_And_Colon_For_Optional_ClientSecret()
     {
         var context = new DefaultHttpContext();
             
@@ -129,7 +130,7 @@ public class BasicAuthenticationSecretParsing
 
     [Fact]
     [Trait("Category", Category)]
-    public async void BasicAuthentication_Request_With_Empty_Basic_Header()
+    public async Task BasicAuthentication_Request_With_Empty_Basic_Header()
     {
         var context = new DefaultHttpContext();
 
@@ -142,7 +143,7 @@ public class BasicAuthenticationSecretParsing
 
     [Fact]
     [Trait("Category", Category)]
-    public async void Valid_BasicAuthentication_Request_ClientId_Too_Long()
+    public async Task Valid_BasicAuthentication_Request_ClientId_Too_Long()
     {
         var context = new DefaultHttpContext();
 
@@ -159,7 +160,7 @@ public class BasicAuthenticationSecretParsing
 
     [Fact]
     [Trait("Category", Category)]
-    public async void Valid_BasicAuthentication_Request_ClientSecret_Too_Long()
+    public async Task Valid_BasicAuthentication_Request_ClientSecret_Too_Long()
     {
         var context = new DefaultHttpContext();
 
@@ -185,7 +186,7 @@ public class BasicAuthenticationSecretParsing
     [InlineData(107)]
     [InlineData(108)]
     [Trait("Category", Category)]
-    public async void Valid_BasicAuthentication_Request_Maximum_Url_Encoded_Values_Should_Work(int maxLength)
+    public async Task Valid_BasicAuthentication_Request_Maximum_Url_Encoded_Values_Should_Work(int maxLength)
     {
         var parser = CreateParser(maxLength);
 
@@ -229,7 +230,7 @@ public class BasicAuthenticationSecretParsing
     [InlineData(107)]
     [InlineData(108)]
     [Trait("Category", Category)]
-    public async void Valid_BasicAuthentication_Request_Authorization_Header_Too_Long_Should_Fail(int maxLength)
+    public async Task Valid_BasicAuthentication_Request_Authorization_Header_Too_Long_Should_Fail(int maxLength)
     {
         var parser = CreateParser(maxLength);
 
@@ -249,7 +250,7 @@ public class BasicAuthenticationSecretParsing
 
     [Fact]
     [Trait("Category", Category)]
-    public async void BasicAuthentication_Request_With_Empty_Basic_Header_Variation()
+    public async Task BasicAuthentication_Request_With_Empty_Basic_Header_Variation()
     {
         var context = new DefaultHttpContext();
 
@@ -262,7 +263,7 @@ public class BasicAuthenticationSecretParsing
 
     [Fact]
     [Trait("Category", Category)]
-    public async void BasicAuthentication_Request_With_Unknown_Scheme()
+    public async Task BasicAuthentication_Request_With_Unknown_Scheme()
     {
         var context = new DefaultHttpContext();
 
@@ -275,7 +276,7 @@ public class BasicAuthenticationSecretParsing
 
     [Fact]
     [Trait("Category", Category)]
-    public async void BasicAuthentication_Request_With_Malformed_Credentials_NoBase64_Encoding()
+    public async Task BasicAuthentication_Request_With_Malformed_Credentials_NoBase64_Encoding()
     {
         var context = new DefaultHttpContext();
 
@@ -288,7 +289,7 @@ public class BasicAuthenticationSecretParsing
 
     [Fact]
     [Trait("Category", Category)]
-    public async void BasicAuthentication_Request_With_Malformed_Credentials_Base64_Encoding_UserName_Only()
+    public async Task BasicAuthentication_Request_With_Malformed_Credentials_Base64_Encoding_UserName_Only()
     {
         var context = new DefaultHttpContext();
 

--- a/test/IdentityServer.UnitTests/Validation/Secrets/ClientAssertionSecretParsing.cs
+++ b/test/IdentityServer.UnitTests/Validation/Secrets/ClientAssertionSecretParsing.cs
@@ -6,6 +6,7 @@ using System.IdentityModel.Tokens.Jwt;
 using System.IO;
 using System.Security.Claims;
 using System.Text;
+using System.Threading.Tasks;
 using Duende.IdentityServer;
 using Duende.IdentityServer.Configuration;
 using Duende.IdentityServer.Validation;
@@ -29,7 +30,7 @@ public class ClientAssertionSecretParsing
     }
 
     [Fact]
-    public async void EmptyContext()
+    public async Task EmptyContext()
     {
         var context = new DefaultHttpContext();
         context.Request.Body = new MemoryStream();
@@ -41,7 +42,7 @@ public class ClientAssertionSecretParsing
     }
 
     [Fact]
-    public async void Valid_ClientAssertion()
+    public async Task Valid_ClientAssertion()
     {
         var context = new DefaultHttpContext();
 
@@ -62,7 +63,7 @@ public class ClientAssertionSecretParsing
     }
 
     [Fact]
-    public async void Missing_ClientAssertionType()
+    public async Task Missing_ClientAssertionType()
     {
         var context = new DefaultHttpContext();
 
@@ -77,7 +78,7 @@ public class ClientAssertionSecretParsing
     }
 
     [Fact]
-    public async void Missing_ClientAssertion()
+    public async Task Missing_ClientAssertion()
     {
         var context = new DefaultHttpContext();
 
@@ -92,7 +93,7 @@ public class ClientAssertionSecretParsing
     }
 
     [Fact]
-    public async void Malformed_PostBody()
+    public async Task Malformed_PostBody()
     {
         var context = new DefaultHttpContext();
         var body = "malformed";
@@ -106,7 +107,7 @@ public class ClientAssertionSecretParsing
     }
 
     [Fact]
-    public async void ClientId_TooLong()
+    public async Task ClientId_TooLong()
     {
         var context = new DefaultHttpContext();
 
@@ -122,7 +123,7 @@ public class ClientAssertionSecretParsing
     }
 
     [Fact]
-    public async void ClientAssertion_TooLong()
+    public async Task ClientAssertion_TooLong()
     {
         var context = new DefaultHttpContext();
 

--- a/test/IdentityServer.UnitTests/Validation/Secrets/FormPostCredentialParsing.cs
+++ b/test/IdentityServer.UnitTests/Validation/Secrets/FormPostCredentialParsing.cs
@@ -4,6 +4,7 @@
 
 using System.IO;
 using System.Text;
+using System.Threading.Tasks;
 using Duende.IdentityServer;
 using Duende.IdentityServer.Configuration;
 using Duende.IdentityServer.Validation;
@@ -30,7 +31,7 @@ public class FormPostCredentialExtraction
 
     [Fact]
     [Trait("Category", Category)]
-    public async void EmptyContext()
+    public async Task EmptyContext()
     {
         var context = new DefaultHttpContext();
         context.Request.Body = new MemoryStream();
@@ -42,7 +43,7 @@ public class FormPostCredentialExtraction
 
     [Fact]
     [Trait("Category", Category)]
-    public async void Valid_PostBody()
+    public async Task Valid_PostBody()
     {
         var context = new DefaultHttpContext();
 
@@ -60,7 +61,7 @@ public class FormPostCredentialExtraction
 
     [Fact]
     [Trait("Category", Category)]
-    public async void ClientId_Too_Long()
+    public async Task ClientId_Too_Long()
     {
         var context = new DefaultHttpContext();
 
@@ -77,7 +78,7 @@ public class FormPostCredentialExtraction
 
     [Fact]
     [Trait("Category", Category)]
-    public async void ClientSecret_Too_Long()
+    public async Task ClientSecret_Too_Long()
     {
         var context = new DefaultHttpContext();
 
@@ -94,7 +95,7 @@ public class FormPostCredentialExtraction
 
     [Fact]
     [Trait("Category", Category)]
-    public async void Missing_ClientId()
+    public async Task Missing_ClientId()
     {
         var context = new DefaultHttpContext();
 
@@ -110,7 +111,7 @@ public class FormPostCredentialExtraction
 
     [Fact]
     [Trait("Category", Category)]
-    public async void Missing_ClientSecret()
+    public async Task Missing_ClientSecret()
     {
         var context = new DefaultHttpContext();
 
@@ -127,7 +128,7 @@ public class FormPostCredentialExtraction
 
     [Fact]
     [Trait("Category", Category)]
-    public async void Malformed_PostBody()
+    public async Task Malformed_PostBody()
     {
         var context = new DefaultHttpContext();
 


### PR DESCRIPTION
This PR prepares the repo for .net 9.

_Note that this only affects our development hosts and test projects, not any published package's dependency. All our current packages have no transitive security vulnerabilities as of now._

- Update Serilog to 8.0.2. This pulls in the right version of System.Text.Json in most cases.
- Pin versions of Azure.Identity (1.11.4), System.Formats.Asn1 (8.0.1), Microsoft.Data.SqlClient (5.1.6) and System.Text.Json. These are depended on by EF and Sql client packages, and there's no update to those packages available that wouldn't give us a vulnerable version. Hopefully someday those packages will update such that this is no longer needed.
- Rename ClientModel. The new System.ClientModel library is a new dependency that we get from updating Azure.Identity, and its namespace name conflicts with our existing class name. There's no good way to resolve the ambiguity, short of just renaming the model. We need to do the same in the templates. (https://github.com/DuendeSoftware/IdentityServer.Templates/issues/56)
- Convert CsQuery to AngleSharp in test projects. These are libraries for doing DOM manipulation in C#. CsQuery is no longer maintained, and it has some messy dependencies. AngleSharp is an easy replacement.