### PR TITLE
EnableBackchannelAuthenticationEndpoint options

### DIFF
--- a/src/IdentityServer/Extensions/EndpointOptionsExtensions.cs
+++ b/src/IdentityServer/Extensions/EndpointOptionsExtensions.cs
@@ -23,6 +23,7 @@ internal static class EndpointOptionsExtensions
             IdentityServerConstants.EndpointNames.Token => options.EnableTokenEndpoint,
             IdentityServerConstants.EndpointNames.UserInfo => options.EnableUserInfoEndpoint,
             IdentityServerConstants.EndpointNames.PushedAuthorization => options.EnablePushedAuthorizationEndpoint,
+            IdentityServerConstants.EndpointNames.BackchannelAuthentication => options.EnableBackchannelAuthenticationEndpoint,
             _ => true
         };
     }

--- a/test/IdentityServer.UnitTests/Extensions/EndpointOptionsExtensionsTests.cs
+++ b/test/IdentityServer.UnitTests/Extensions/EndpointOptionsExtensionsTests.cs
@@ -144,6 +144,19 @@ public class EndpointOptionsExtensionsTests
                 CreateTestEndpoint(IdentityServerConstants.EndpointNames.PushedAuthorization)));
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void IsEndpointEnabledShouldReturnExpectedForBackchannelAuthenticationEndpoint(bool expectedIsEndpointEnabled)
+    {
+        _options.EnableBackchannelAuthenticationEndpoint = expectedIsEndpointEnabled;
+
+        Assert.Equal(
+            expectedIsEndpointEnabled,
+            _options.IsEndpointEnabled(
+                CreateTestEndpoint(IdentityServerConstants.EndpointNames.BackchannelAuthentication)));
+    }    
+
     private Endpoint CreateTestEndpoint(string name)
     {
         return new Endpoint(name, "", null);


### PR DESCRIPTION
**What issue does this PR address?**
EnableBackchannelAuthenticationEndpoint options should be taken into account for allowing calls the /connect/ciba endpoint.
