### PR TITLE
Fall back to other token types when given incorrect hint

### DIFF
--- a/src/IdentityServer/Validation/Default/IntrospectionRequestValidator.cs
+++ b/src/IdentityServer/Validation/Default/IntrospectionRequestValidator.cs
@@ -239,7 +239,6 @@ internal class IntrospectionRequestValidator : IIntrospectionRequestValidator
     /// </summary>
     private async Task<IEnumerable<Claim>> GetAccessTokenClaimsAsync(string token)
     {
-        // TODO - Should we validate that the api resource is among the token's audiences during introspection? 
         var tokenValidationResult = await _tokenValidator.ValidateAccessTokenAsync(token);
         if (!tokenValidationResult.IsError)
         {

--- a/src/IdentityServer/Validation/Default/IntrospectionRequestValidator.cs
+++ b/src/IdentityServer/Validation/Default/IntrospectionRequestValidator.cs
@@ -80,11 +80,19 @@ internal class IntrospectionRequestValidator : IIntrospectionRequestValidator
         {
             if (Constants.SupportedTokenTypeHints.Contains(hint))
             {
-                _logger.LogDebug("Token type hint found in request: {tokenTypeHint}", hint);
+                if(_logger.IsEnabled(LogLevel.Debug))
+                {
+                    var sanitized = hint.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
+                    _logger.LogDebug("Token type hint found in request: {tokenTypeHint}", sanitized);
+                }
             }
             else
             {
-                _logger.LogDebug("Unsupported token type hint found in request: {tokenTypeHint}", hint);
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    var sanitized = hint.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
+                    _logger.LogDebug("Unsupported token type hint found in request: {tokenTypeHint}", sanitized);
+                }
                 hint = null; // Discard an unknown hint, in line with RFC 7662
             }
         }

--- a/test/IdentityServer.IntegrationTests/Endpoints/Introspection/IntrospectionTests.cs
+++ b/test/IdentityServer.IntegrationTests/Endpoints/Introspection/IntrospectionTests.cs
@@ -162,7 +162,6 @@ public class IntrospectionTests
         scopes.First().Value.Should().Be("api1");
     }
 
-
     [Theory]
     [Trait("Category", Category)]
     [InlineData("ro.client", Constants.TokenTypeHints.RefreshToken)]


### PR DESCRIPTION
When the token type hint parameter is incorrect, we now fall back and try the other type of token (either refresh or access). But, we only do this for clients - apis cannot use refresh tokens, so they still get a response of { "isActive": false } if they attempt to introspect a refresh token. In either case, bogus token_type_hints are not an error anymore, either.

For reference, RFC 7662 Section 2.1:
> If the server is unable to locate the token using the given hint, it MUST extend its search across all of its supported token types.

Resolves #1578 