### PR TITLE
Delete retired keys even if they are un-unprotectable 

### DIFF
--- a/test/IdentityServer.UnitTests/Services/Default/KeyManagement/MockSigningKeyProtector.cs
+++ b/test/IdentityServer.UnitTests/Services/Default/KeyManagement/MockSigningKeyProtector.cs
@@ -28,8 +28,27 @@ class MockSigningKeyProtector : ISigningKeyProtector
             Id = key.Id,
             Algorithm = key.Algorithm,
             IsX509Certificate = key.HasX509Certificate,
-            Created = DateTime.UtcNow,
+            Created = key.Created,
             Data = _dataProtector.Protect(KeySerializer.Serialize(key)),
+        };
+    }
+
+    /// <summary>
+    /// Simulate a situation where a signing key was protected in the past with a signing key that is no longer available
+    /// </summary>
+    public SerializedKey ProtectAndLoseDataProtectionKey(KeyContainer key)
+    {
+        var provider = new EphemeralDataProtectionProvider();
+        var badProtector = provider.CreateProtector("unavailable-when-we-unprotect");
+
+        ProtectWasCalled = true;
+        return new SerializedKey
+        {
+            Id = key.Id,
+            Algorithm = key.Algorithm,
+            IsX509Certificate = key.HasX509Certificate,
+            Created = key.Created,
+            Data = badProtector.Protect(KeySerializer.Serialize(key)),
         };
     }
 

--- a/test/IdentityServer.UnitTests/Services/Default/KeyManagement/MockSigningKeyProtector.cs
+++ b/test/IdentityServer.UnitTests/Services/Default/KeyManagement/MockSigningKeyProtector.cs
@@ -4,13 +4,21 @@
 
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services.KeyManagement;
+using Microsoft.AspNetCore.DataProtection;
 using System;
 
 namespace UnitTests.Services.Default.KeyManagement;
 
 class MockSigningKeyProtector : ISigningKeyProtector
 {
+    private IDataProtector _dataProtector;
     public bool ProtectWasCalled { get; set; }
+    
+    public MockSigningKeyProtector()
+    {
+        var provider = new EphemeralDataProtectionProvider();
+        _dataProtector = provider.CreateProtector("test");
+    }
 
     public SerializedKey Protect(KeyContainer key)
     {
@@ -21,12 +29,12 @@ class MockSigningKeyProtector : ISigningKeyProtector
             Algorithm = key.Algorithm,
             IsX509Certificate = key.HasX509Certificate,
             Created = DateTime.UtcNow,
-            Data = KeySerializer.Serialize(key),
+            Data = _dataProtector.Protect(KeySerializer.Serialize(key)),
         };
     }
 
     public KeyContainer Unprotect(SerializedKey key)
     {
-        return KeySerializer.Deserialize<RsaKeyContainer>(key.Data);
+        return KeySerializer.Deserialize<RsaKeyContainer>(_dataProtector.Unprotect(key.Data));
     }
 }


### PR DESCRIPTION
Retired signing keys will now be deleted by the key manager even if they are data protected and cannot be unprotected.

Resolves #1572 