### PR TITLE
fix nullable in IsNullOrEmpty

### DIFF
--- a/src/IdentityServer/Extensions/IEnumerableExtensions.cs
+++ b/src/IdentityServer/Extensions/IEnumerableExtensions.cs
@@ -2,6 +2,8 @@
 // See LICENSE in the project root for license information.
 
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -15,19 +17,14 @@ namespace Duende.IdentityServer.Extensions;
 public static class IEnumerableExtensions
 {
     [DebuggerStepThrough]
-    public static bool IsNullOrEmpty<T>([NotNullWhen(false)]this IEnumerable<T> list)
+    public static bool IsNullOrEmpty<T>([NotNullWhen(false)]this IEnumerable<T>? list)
     {
         if (list == null)
         {
             return true;
         }
 
-        if (!list.Any())
-        {
-            return true;
-        }
-
-        return false;
+        return !list.Any();
     }
 
     public static bool HasDuplicates<T, TProp>(this IEnumerable<T> list, Func<T, TProp> selector)

--- a/src/Storage/Extensions/IEnumerableExtensions.cs
+++ b/src/Storage/Extensions/IEnumerableExtensions.cs
@@ -2,8 +2,11 @@
 // See LICENSE in the project root for license information.
 
 
+#nullable enable
+
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 #pragma warning disable 1591
@@ -13,18 +16,13 @@ namespace Duende.IdentityServer.Extensions;
 internal static class IEnumerableExtensions
 {
     [DebuggerStepThrough]
-    public static bool IsNullOrEmpty<T>(this IEnumerable<T> list)
+    public static bool IsNullOrEmpty<T>([NotNullWhen(false)] this IEnumerable<T>? list)
     {
         if (list == null)
         {
             return true;
         }
 
-        if (!list.Any())
-        {
-            return true;
-        }
-
-        return false;
+        return !list.Any();
     }
 }


### PR DESCRIPTION
better nullability hints for callers of IsNullOrEmpty and do a direct return of `!list.Any()`