### PR TITLE
remove redundant allocation in ProtectedResourceErrorResult

### DIFF
--- a/src/IdentityServer/Endpoints/Results/ProtectedResourceErrorResult.cs
+++ b/src/IdentityServer/Endpoints/Results/ProtectedResourceErrorResult.cs
@@ -62,12 +62,12 @@ internal class ProtectedResourceErrorHttpWriter : IHttpResponseWriter<ProtectedR
         var errorString = string.Format($"error=\"{error}\"");
         if (errorDescription.IsMissing())
         {
-            context.Response.Headers.Append(HeaderNames.WWWAuthenticate, new StringValues(new[] { "Bearer realm=\"IdentityServer\"", errorString }).ToString());
+            context.Response.Headers.Append(HeaderNames.WWWAuthenticate, new StringValues(new[] { "Bearer realm=\"IdentityServer\"", errorString }));
         }
         else
         {
             var errorDescriptionString = string.Format($"error_description=\"{errorDescription}\"");
-            context.Response.Headers.Append(HeaderNames.WWWAuthenticate, new StringValues(new[] { "Bearer realm=\"IdentityServer\"", errorString, errorDescriptionString }).ToString());
+            context.Response.Headers.Append(HeaderNames.WWWAuthenticate, new StringValues(new[] { "Bearer realm=\"IdentityServer\"", errorString, errorDescriptionString }));
         }
 
         return Task.CompletedTask;


### PR DESCRIPTION
This is a double alloc. since the previous code was converting a StringValues to a string. then internal to Headers.Append it will then wrap that string in a StringValues 