### PR TITLE
Filter OperationCanceled instead of TaskCanceled logs

### DIFF
--- a/src/IdentityServer/Configuration/DependencyInjection/Options/LoggingOptions.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/Options/LoggingOptions.cs
@@ -70,5 +70,10 @@ public class LoggingOptions
     /// Called when the IdentityServer middleware detects an unhandled exception, and is used to determine if the exception is logged.
     /// Returns true to emit the log, false to suppress.
     /// </summary>
-    public Func<HttpContext, Exception, bool> UnhandledExceptionLoggingFilter = (context, exception) => !(context.RequestAborted.IsCancellationRequested && exception is TaskCanceledException);
+    public Func<HttpContext, Exception, bool> UnhandledExceptionLoggingFilter = (context, exception) =>
+    {
+        var result = !(context.RequestAborted.IsCancellationRequested && exception is OperationCanceledException);
+        return result;
+    };
+    
 }

--- a/test/IdentityServer.IntegrationTests/Hosting/IdentityServerMiddlewareTests..cs
+++ b/test/IdentityServer.IntegrationTests/Hosting/IdentityServerMiddlewareTests..cs
@@ -1,0 +1,82 @@
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Duende.IdentityServer.Hosting;
+using FluentAssertions;
+using IntegrationTests.Common;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+
+namespace IntegrationTests.Hosting;
+
+public class FailRouter : IEndpointRouter
+{
+    private readonly Type _exceptionType;
+    public FailRouter(Type exceptionType)
+    {
+        _exceptionType = exceptionType;
+    }
+
+    public IEndpointHandler Find(HttpContext context)
+    {
+        throw (Exception) _exceptionType.GetConstructor([]).Invoke(null);
+    }
+}
+
+public class IdentityServerMiddlewareTests
+{
+    private IdentityServerPipeline _pipeline = new IdentityServerPipeline();
+    public static readonly TheoryData<Type, bool> ExceptionFilteringTestCases = new TheoryData<Type, bool>
+    {
+        { typeof(TaskCanceledException), true },
+        { typeof(OperationCanceledException), true },
+        { typeof(Exception), false },
+        { typeof(InvalidOperationException), false },
+        { typeof(ArgumentException), false },
+        { typeof(NullReferenceException), false }
+
+    };
+
+    [Theory]
+    [MemberData(nameof(ExceptionFilteringTestCases))]
+    public async Task expected_exception_types_are_filtered_from_logs_when_incoming_requests_are_canceled(Type t, bool filteringExpected)
+    {
+        // Set up the pipeline so that we will throw some exception. Throwing in
+        // the router specifically is not important - that is just a convenient
+        // place to throw an exception.
+        _pipeline.OnPostConfigureServices += svcs =>
+        {
+            svcs.AddTransient<IEndpointRouter>(_ => new FailRouter(t));
+        };
+        _pipeline.Initialize(enableLogging: true);
+
+        // First we make a request that is canceled. Filtered exception types are only filtered for canceled Http requests.
+        var source = new CancellationTokenSource();
+        var token = source.Token;
+        source.Cancel();
+        var canceledHttpRequest = async () => await _pipeline.BackChannelClient.GetAsync(IdentityServerPipeline.DiscoveryEndpoint, token);
+
+        // The middleware will always throw
+        var exceptionShould = await canceledHttpRequest.Should().ThrowAsync<Exception>();
+
+        // The middleware will log most exceptions, but not TaskCanceled or OperationCanceled
+        if (filteringExpected)
+        {
+            _pipeline.MockLogger.LogMessages.Should().NotContain(m => m.StartsWith("Unhandled exception: "));
+        }
+        else
+        {
+            _pipeline.MockLogger.LogMessages.Should().Contain(m => m.StartsWith("Unhandled exception: "));
+        }
+
+        // Now reset the log messages so that we can verify that we always log for requests that are not canceled
+        _pipeline.MockLogger.LogMessages.Clear();
+        var notCanceledRequest = async () => await _pipeline.BackChannelClient.GetAsync(IdentityServerPipeline.DiscoveryKeysEndpoint, CancellationToken.None);
+        await notCanceledRequest.Should().ThrowAsync<Exception>();
+        _pipeline.MockLogger.LogMessages.Should().Contain(m => m.StartsWith("Unhandled exception: "));
+    }
+}


### PR DESCRIPTION
When an http request is canceled, we'll get some sort of cancellation related exception. There are reports that this sometimes is raised as OperationCanceled instead of TaskCanceled, and since OperationCanceled is the base class, it is simpler to filter that instead.

**What issue does this PR address?**
Closes #1587 


**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
