### PR TITLE
Add option for strict validation of assertion audiences

### DIFF
--- a/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
+++ b/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
@@ -70,6 +70,11 @@ public class IdentityServerOptions
     public bool StrictJarValidation { get; set; } = false;
 
     /// <summary>
+    /// When clients authenticate with private_key_jwt assertions, validate the audience of the assertion strictly: the audience must be this IdentityServer's issuer identifier as a single string.
+    /// </summary>
+    public bool StrictClientAssertionAudienceValidation { get; set; } = false;
+
+    /// <summary>
     /// Specifies if a user's tenant claim is compared to the tenant acr_values parameter value to determine if the login page is displayed. Defaults to false.
     /// </summary>
     public bool ValidateTenantOnAuthorization { get; set; } = false;

--- a/identity-server/src/IdentityServer/Validation/Default/PrivateKeyJwtSecretValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/Default/PrivateKeyJwtSecretValidator.cs
@@ -89,20 +89,7 @@ public class PrivateKeyJwtSecretValidator : ISecretValidator
             return fail;
         }
 
-        var validAudiences = new[]
-        {
-            // token endpoint URL
-            string.Concat(_urls.BaseUrl.EnsureTrailingSlash(), ProtocolRoutePaths.Token),
-            // issuer URL + token (legacy support)
-            string.Concat((await _issuerNameService.GetCurrentAsync()).EnsureTrailingSlash(), ProtocolRoutePaths.Token),
-            // issuer URL
-            await _issuerNameService.GetCurrentAsync(),
-            // CIBA endpoint: https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html#auth_request
-            string.Concat(_urls.BaseUrl.EnsureTrailingSlash(), ProtocolRoutePaths.BackchannelAuthentication),
-            // PAR endpoint: https://datatracker.ietf.org/doc/html/rfc9126#name-request
-            string.Concat(_urls.BaseUrl.EnsureTrailingSlash(), ProtocolRoutePaths.PushedAuthorization),
-            
-        }.Distinct();
+        var issuer = await _issuerNameService.GetCurrentAsync();
 
         var tokenValidationParameters = new TokenValidationParameters
         {
@@ -111,15 +98,46 @@ public class PrivateKeyJwtSecretValidator : ISecretValidator
 
             ValidIssuer = parsedSecret.Id,
             ValidateIssuer = true,
-
-            ValidAudiences = validAudiences,
-            ValidateAudience = true,
-
+            
             RequireSignedTokens = true,
             RequireExpirationTime = true,
 
             ClockSkew = TimeSpan.FromMinutes(5)
         };
+        
+        if (_options.StrictClientAssertionAudienceValidation)
+        {
+            // New strict audience validation requires that the audience be the issuer identifier, disallows multiple
+            // audiences in an array, and even disallows wrapping even a single audience in an array 
+            tokenValidationParameters.AudienceValidator = (audiences, token, parameters) =>
+            {
+                // There isn't a particularly nice way to distinguish between a claim that is a single string wrapped in
+                // an array and just a single string when using a JsonWebToken. The jwt.GetClaim function and jwt.Claims
+                // collection both convert that into a string valued claim. However, GetPayloadValue<object> does not do
+                // any type inferencing, so we can call that, and then check if the result is actually a string
+                var audValue = ((JsonWebToken)token).GetPayloadValue<object>("aud");
+                return audValue is string audString &&
+                       AudiencesMatch(audString, issuer);
+            };
+        }
+        else
+        {
+            tokenValidationParameters.ValidateAudience = true;
+            tokenValidationParameters.ValidAudiences = new[]
+            {
+                // token endpoint URL
+                string.Concat(_urls.BaseUrl.EnsureTrailingSlash(), ProtocolRoutePaths.Token),
+                // issuer URL + token (legacy support)
+                string.Concat((await _issuerNameService.GetCurrentAsync()).EnsureTrailingSlash(), ProtocolRoutePaths.Token),
+                // issuer URL
+                issuer,
+                // CIBA endpoint: https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html#auth_request
+                string.Concat(_urls.BaseUrl.EnsureTrailingSlash(), ProtocolRoutePaths.BackchannelAuthentication),
+                // PAR endpoint: https://datatracker.ietf.org/doc/html/rfc9126#name-request
+                string.Concat(_urls.BaseUrl.EnsureTrailingSlash(), ProtocolRoutePaths.PushedAuthorization),
+            
+            }.Distinct();
+        }
 
         var handler = new JsonWebTokenHandler() { MaximumTokenSizeInBytes = _options.InputLengthRestrictions.Jwt };
         var result = await handler.ValidateTokenAsync(jwtTokenString, tokenValidationParameters);
@@ -161,5 +179,51 @@ public class PrivateKeyJwtSecretValidator : ISecretValidator
         }
 
         return success;
+    }
+    
+    // AudiencesMatch and AudiencesMatchIgnoringTrailingSlash are based on code from 
+    // https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/bef98ca10ae55603ce6d37dfb7cd5af27791527c/src/Microsoft.IdentityModel.Tokens/Validators.cs#L158-L193
+    private bool AudiencesMatch(string tokenAudience, string validAudience)
+    {
+        if (validAudience.Length == tokenAudience.Length)
+        {
+            if (string.Equals(validAudience, tokenAudience))
+            {
+                return true;
+            }
+        }
+
+        return AudiencesMatchIgnoringTrailingSlash(tokenAudience, validAudience);
+    }
+            
+    private bool AudiencesMatchIgnoringTrailingSlash(string tokenAudience, string validAudience)
+    {
+        int length = -1;
+
+        if (validAudience.Length == tokenAudience.Length + 1 &&
+            validAudience.EndsWith("/", StringComparison.InvariantCulture))
+        {
+            length = validAudience.Length - 1;
+        }
+        else if (tokenAudience.Length == validAudience.Length + 1 &&
+                 tokenAudience.EndsWith("/", StringComparison.InvariantCulture))
+        {
+            length = tokenAudience.Length - 1;
+        }
+
+        // the length of the audiences is different by more than 1 and neither ends in a "/"
+        if (length == -1)
+        {
+            return false;
+        }
+
+        if (string.CompareOrdinal(validAudience, 0, tokenAudience, 0, length) == 0)
+        {
+            _logger.LogInformation("Audience Validated.Audience: '{audience}'", tokenAudience);
+
+            return true;
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
Adds a new option that will enforce that the only private_key_jwt audience allowed is the issuer identifier, and that it is a string - not an array of a single value.

The audience of private key jwts has historically been somewhat open to implementation in various OAuth and OpenId specs. Some specs have said to use the issuer identifier, others the token endpoint or other endpoints, and some say to accept all. However, there is currently an effort from IETF and OpenID foundation to make audience requirements consistent across all specifications, which will be accomplished by only accepting the issuer identifier. The most recent FAPI (financial grade API) specification requires this strict validation, and other specifications are in the process of being updated as well.