### PR TITLE
Remove ReadKey at shutdown

### DIFF
--- a/identity-server/hosts/AspNetIdentity/Program.cs
+++ b/identity-server/hosts/AspNetIdentity/Program.cs
@@ -34,7 +34,6 @@ try
         {
             var usage = app.Services.GetRequiredService<LicenseUsageSummary>();
             Console.Write(Summary(usage));
-            Console.ReadKey();
         });
     }
 

--- a/identity-server/hosts/Configuration/Program.cs
+++ b/identity-server/hosts/Configuration/Program.cs
@@ -47,7 +47,6 @@ try
         {
             var usage = app.Services.GetRequiredService<LicenseUsageSummary>();
             Console.Write(Summary(usage));
-            Console.ReadKey();
         });
     }
 

--- a/identity-server/hosts/EntityFramework-dotnet9/Program.cs
+++ b/identity-server/hosts/EntityFramework-dotnet9/Program.cs
@@ -34,7 +34,6 @@ try
         {
             var usage = app.Services.GetRequiredService<LicenseUsageSummary>();
             Console.Write(Summary(usage));
-            Console.ReadKey();
         });
     }
 

--- a/identity-server/hosts/EntityFramework/Program.cs
+++ b/identity-server/hosts/EntityFramework/Program.cs
@@ -34,7 +34,6 @@ try
         {
             var usage = app.Services.GetRequiredService<LicenseUsageSummary>();
             Console.Write(Summary(usage));
-            Console.ReadKey();
         });
     }
 

--- a/identity-server/hosts/main/Program.cs
+++ b/identity-server/hosts/main/Program.cs
@@ -34,7 +34,6 @@ try
         {
             var usage = app.Services.GetRequiredService<LicenseUsageSummary>();
             Console.Write(Summary(usage));
-            Console.ReadKey();
         });
     }
 

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Program.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Program.cs
@@ -39,7 +39,6 @@ try
         {
             var usage = app.Services.GetRequiredService<LicenseUsageSummary>();
             Console.Write(Summary(usage));
-            Console.ReadKey();
         });
     }
 

--- a/identity-server/templates/src/IdentityServerEmpty/Program.cs
+++ b/identity-server/templates/src/IdentityServerEmpty/Program.cs
@@ -29,7 +29,6 @@ try
         {
             var usage = app.Services.GetRequiredService<LicenseUsageSummary>();
             Console.Write(Summary(usage));
-            Console.ReadKey();
         });
     }
 

--- a/identity-server/templates/src/IdentityServerEntityFramework/Program.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Program.cs
@@ -39,7 +39,6 @@ try
         {
             var usage = app.Services.GetRequiredService<LicenseUsageSummary>();
             Console.Write(Summary(usage));
-            Console.ReadKey();
         });
     }
 

--- a/identity-server/templates/src/IdentityServerInMem/Program.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Program.cs
@@ -29,7 +29,6 @@ try
         {
             var usage = app.Services.GetRequiredService<LicenseUsageSummary>();
             Console.Write(Summary(usage));
-            Console.ReadKey();
         });
     }
 


### PR DESCRIPTION
A ReadKey call at shutdown is only sensible in vscode with an external terminal style debugger. With the integratedTerminal, there is no need for this. And in rider and Visual Studio, it is just better this way.
