### PR TITLE
Add informational version to assembly info diagnostic entry

### DIFF
--- a/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/AssemblyInfoDiagnosticEntry.cs
+++ b/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/AssemblyInfoDiagnosticEntry.cs
@@ -44,6 +44,7 @@ internal class AssemblyInfoDiagnosticEntry : IDiagnosticEntry
         var assemblies = GetAssemblyInfo();
         writer.WriteStartObject("AssemblyInfo");
         writer.WriteString("DotnetVersion", RuntimeInformation.FrameworkDescription);
+        writer.WriteString("IdentityServerVersion", typeof(AssemblyInfoDiagnosticEntry).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()!.InformationalVersion);
 
         writer.WriteStartArray("Assemblies");
         foreach (var assembly in assemblies.Where(assembly => assembly.GetName().Name != null &&

--- a/identity-server/test/IdentityServer.UnitTests/Licensing/v2/DiagnosticEntries/AssemblyInfoDiagnosticEntryTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Licensing/v2/DiagnosticEntries/AssemblyInfoDiagnosticEntryTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text.Json;
 using Duende.IdentityServer.Licensing.V2.Diagnostics.DiagnosticEntries;
@@ -74,5 +75,19 @@ public class AssemblyInfoDiagnosticEntryTests
 
         var assemblyInfo = result.RootElement.GetProperty("AssemblyInfo");
         assemblyInfo.GetProperty("DotnetVersion").GetString().ShouldBe(RuntimeInformation.FrameworkDescription);
+    }
+
+    [Fact]
+    public async Task Should_Include_IdentityServer_Informational_Version()
+    {
+        var subject = new AssemblyInfoDiagnosticEntry();
+
+        var result = await DiagnosticEntryTestHelper.WriteEntryToJson(subject);
+
+        var assemblyInfo = result.RootElement.GetProperty("AssemblyInfo");
+        var expectedVersion = typeof(AssemblyInfoDiagnosticEntry).Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()!
+            .InformationalVersion;
+        assemblyInfo.GetProperty("IdentityServerVersion").GetString().ShouldBe(expectedVersion);
     }
 }


### PR DESCRIPTION
**What issue does this PR address?**
Per a request from customer success, these changes add the information version of IdentityServer to the existing assembly info diagnostic entry


**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
