### PR TITLE
Fix port of mvc jar uri jwt

### DIFF
--- a/identity-server/clients/src/MvcJarUriJwt/AssertionService.cs
+++ b/identity-server/clients/src/MvcJarUriJwt/AssertionService.cs
@@ -32,12 +32,12 @@ public class AssertionService(IConfiguration configuration)
         var now = DateTime.UtcNow;
 
         var token = new JwtSecurityToken(
-            "mvc.jar.jwt",
+            "mvc.jar-uri.jwt",
             configuration["is-host"] + "/connect/token",
             new List<Claim>()
             {
                 new Claim(JwtClaimTypes.JwtId, Guid.NewGuid().ToString()),
-                new Claim(JwtClaimTypes.Subject, "mvc.jar.jwt"),
+                new Claim(JwtClaimTypes.Subject, "mvc.jar-uri.jwt"),
                 new Claim(JwtClaimTypes.IssuedAt, ((DateTimeOffset) now).ToUnixTimeSeconds().ToString(), ClaimValueTypes.Integer64)
             },
             now,
@@ -62,7 +62,7 @@ public class AssertionService(IConfiguration configuration)
         }
 
         var token = new JwtSecurityToken(
-            "mvc.jar.jwt",
+            "mvc.jar-uri.jwt",
             configuration["is-host"],
             claims,
             now,

--- a/identity-server/clients/src/MvcJarUriJwt/HostingExtensions.cs
+++ b/identity-server/clients/src/MvcJarUriJwt/HostingExtensions.cs
@@ -46,7 +46,7 @@ internal static class HostingExtensions
                 options.Authority = authority;
                 options.RequireHttpsMetadata = false;
 
-                options.ClientId = "mvc.jar.jwt";
+                options.ClientId = "mvc.jar-uri.jwt";
 
                 // code flow + PKCE (PKCE is turned on by default)
                 options.ResponseType = "code";

--- a/identity-server/clients/src/MvcJarUriJwt/OidcEvents.cs
+++ b/identity-server/clients/src/MvcJarUriJwt/OidcEvents.cs
@@ -36,7 +36,7 @@ public class OidcEvents : OpenIdConnectEvents
         context.ProtocolMessage.Parameters.Clear();
         context.ProtocolMessage.ClientId = clientId;
         context.ProtocolMessage.RedirectUri = redirectUri;
-        context.ProtocolMessage.SetParameter("request_uri", $"https://localhost:44304/ro?id={id}");
+        context.ProtocolMessage.SetParameter("request_uri", $"https://localhost:44305/ro?id={id}");
 
         return Task.CompletedTask;
     }

--- a/identity-server/clients/src/MvcJarUriJwt/Properties/launchSettings.json
+++ b/identity-server/clients/src/MvcJarUriJwt/Properties/launchSettings.json
@@ -6,7 +6,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "https://localhost:44304/"
+      "applicationUrl": "https://localhost:44305/"
     }
   }
 }

--- a/identity-server/hosts/Shared/Configuration/ClientsWeb.cs
+++ b/identity-server/hosts/Shared/Configuration/ClientsWeb.cs
@@ -46,7 +46,7 @@ public static class ClientsWeb
 
                 AllowedScopes = allowedScopes
             },
-                
+
             ///////////////////////////////////////////
             // MVC Automatic Token Management Sample
             //////////////////////////////////////////
@@ -72,7 +72,7 @@ public static class ClientsWeb
 
                 AllowedScopes = allowedScopes
             },
-                
+
             ///////////////////////////////////////////
             // MVC Code Flow Sample
             //////////////////////////////////////////
@@ -153,7 +153,7 @@ public static class ClientsWeb
 
                 AllowedScopes = allowedScopes
             },
-                
+
             ///////////////////////////////////////////
             // MVC Code Flow with JAR/JWT Sample
             //////////////////////////////////////////
@@ -185,6 +185,43 @@ public static class ClientsWeb
                 RedirectUris = { "https://localhost:44304/signin-oidc" },
                 FrontChannelLogoutUri = "https://localhost:44304/signout-oidc",
                 PostLogoutRedirectUris = { "https://localhost:44304/signout-callback-oidc" },
+
+                AllowOfflineAccess = true,
+
+                AllowedScopes = allowedScopes
+            },
+
+            ///////////////////////////////////////////
+            // MVC Code Flow with JAR URI/JWT Sample
+            //////////////////////////////////////////
+            new Client
+            {
+                ClientId = "mvc.jar-uri.jwt",
+                ClientName = "MVC Code Flow with JAR/JWT",
+
+                ClientSecrets =
+                {
+                    new Secret
+                    {
+                        Type = IdentityServerConstants.SecretTypes.JsonWebKey,
+                        Value =
+                            """
+                            {
+                                "e":"AQAB",
+                                "kid":"ZzAjSnraU3bkWGnnAqLapYGpTyNfLbjbzgAPbbW2GEA",
+                                "kty":"RSA",
+                                "n":"wWwQFtSzeRjjerpEM5Rmqz_DsNaZ9S1Bw6UbZkDLowuuTCjBWUax0vBMMxdy6XjEEK4Oq9lKMvx9JzjmeJf1knoqSNrox3Ka0rnxXpNAz6sATvme8p9mTXyp0cX4lF4U2J54xa2_S9NF5QWvpXvBeC4GAJx7QaSw4zrUkrc6XyaAiFnLhQEwKJCwUw4NOqIuYvYp_IXhw-5Ti_icDlZS-282PcccnBeOcX7vc21pozibIdmZJKqXNsL1Ibx5Nkx1F1jLnekJAmdaACDjYRLL_6n3W4wUp19UvzB1lGtXcJKLLkqB6YDiZNu16OSiSprfmrRXvYmvD8m6Fnl5aetgKw"
+                            }
+                            """
+                    }
+                },
+
+                AllowedGrantTypes = GrantTypes.Code,
+                RequireRequestObject = true,
+
+                RedirectUris = { "https://localhost:44305/signin-oidc" },
+                FrontChannelLogoutUri = "https://localhost:44305/signout-oidc",
+                PostLogoutRedirectUris = { "https://localhost:44305/signout-callback-oidc" },
 
                 AllowOfflineAccess = true,
 


### PR DESCRIPTION
MvcJarJwt and MvcJarUriJwt were sharing ports, preventing them from both running in aspire.

This PR fixes the config of MvcJarUriJwt to allow both. 

