### PR TITLE
Address CA2249 Violations

### DIFF
--- a/identity-server/src/Directory.Build.props
+++ b/identity-server/src/Directory.Build.props
@@ -21,6 +21,6 @@
     Currently all existing warnings are suppressed. We will remove them as we address them. But this configuration
     allows us to prevent new warnings from being introduced while we work on the existing ones.
     -->
-    <NoWarn>$(NoWarn);CA1002;CA1008;CA1031;CA1034;CA1040;CA1051;CA1054;CA1055;CA1056;CA1062;CA1716;CA1724;CA1725;CA1727;CA1819;CA1848;CA1851;CA2201;CA2007;CA2208;CA2227;CA2234;CA2249;CA2253;CA2254;CA2263;CA5404;CA5394;</NoWarn>
+    <NoWarn>$(NoWarn);CA1002;CA1008;CA1031;CA1034;CA1040;CA1051;CA1054;CA1055;CA1056;CA1062;CA1716;CA1724;CA1725;CA1727;CA1819;CA1848;CA1851;CA2201;CA2007;CA2208;CA2227;CA2234;CA2253;CA2254;CA2263;CA5404;CA5394;</NoWarn>
   </PropertyGroup>
 </Project>

--- a/identity-server/src/IdentityServer/Extensions/NameValueCollectionExtensions.cs
+++ b/identity-server/src/IdentityServer/Extensions/NameValueCollectionExtensions.cs
@@ -122,7 +122,7 @@ internal static class NameValueCollectionExtensions
 
     internal static string ConvertFormUrlEncodedSpacesToUrlEncodedSpaces(string str)
     {
-        if ((str != null) && (str.IndexOf('+', StringComparison.InvariantCulture) >= 0))
+        if ((str != null) && (str.Contains('+', StringComparison.InvariantCulture)))
         {
             str = str.Replace("+", "%20", StringComparison.InvariantCulture);
         }


### PR DESCRIPTION
**What issue does this PR address?**
Removes [CA2249](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2249) from the NoWarn list and addresses the resulting violation.


**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
