### PR TITLE
allow management endpoints to be overwritten manually

### DIFF
--- a/bff/src/Bff/BffApplicationBuilderExtensions.cs
+++ b/bff/src/Bff/BffApplicationBuilderExtensions.cs
@@ -65,10 +65,15 @@ public static class BffApplicationBuilderExtensions
         }
         app.UseEndpoints(endpoints =>
         {
-            if (!endpoints.AlreadyMappedManagementEndpoint(bffOptions.LoginPath, "Login"))
-            {
-                endpoints.MapBffManagementEndpoints();
-            }
+            // Mapping the management endpoints. 
+            endpoints.MapBffManagementLoginEndpoint();
+#pragma warning disable CS0618 // Type or member is obsolete
+            endpoints.MapBffManagementSilentLoginEndpoints();
+#pragma warning restore CS0618 // Type or member is obsolete
+            endpoints.MapBffManagementLogoutEndpoint();
+            endpoints.MapBffManagementUserEndpoint();
+            endpoints.MapBffManagementBackchannelEndpoint();
+            endpoints.MapBffDiagnosticsEndpoint();
         });
         app.UseBffIndexPages();
         return app;

--- a/bff/src/Bff/Endpoints/ISilentLoginEndpoint.cs
+++ b/bff/src/Bff/Endpoints/ISilentLoginEndpoint.cs
@@ -7,4 +7,6 @@ namespace Duende.Bff.Endpoints;
 /// <summary>
 /// Service for handling silent login requests
 /// </summary>
+[Obsolete(
+    "The silent login endpoint will be removed in a future version. Silent login is now handled by passing the prompt=none parameter to the login endpoint.")]
 public interface ISilentLoginEndpoint : IBffEndpoint;

--- a/bff/src/Bff/Endpoints/Internal/DefaultSilentLoginEndpoint.cs
+++ b/bff/src/Bff/Endpoints/Internal/DefaultSilentLoginEndpoint.cs
@@ -13,7 +13,9 @@ namespace Duende.Bff.Endpoints.Internal;
 /// <summary>
 /// Service for handling silent login requests
 /// </summary>
+#pragma warning disable CS0618 // Type or member is obsolete
 internal class DefaultSilentLoginEndpoint(IOptions<BffOptions> options, ILogger<DefaultSilentLoginEndpoint> logger) : ISilentLoginEndpoint
+#pragma warning restore CS0618 // Type or member is obsolete
 {
     /// <summary>
     /// The BFF options

--- a/bff/src/Bff/Otel/LogMessages.cs
+++ b/bff/src/Bff/Otel/LogMessages.cs
@@ -257,8 +257,8 @@ internal static partial class LogMessages
 
     [LoggerMessage(
         message:
-        $"Already mapped {{{OTelParameters.Name}}} endpoint, so the call to MapBffManagementEndpoints will be ignored. If you're using BffOptions.AutomaticallyRegisterBffMiddleware, you don't need to call endpoints.MapBffManagementEndpoints()")]
-    public static partial void AlreadyMappedManagementEndpoint(this ILogger logger, LogLevel logLevel, string name);
+        $"Management endpoints are automatically mapped, so the call to MapBffManagementEndpoints will be ignored. If you're using BffOptions.AutomaticallyRegisterBffMiddleware, you don't need to call endpoints.MapBffManagementEndpoints()")]
+    public static partial void AlreadyMappedManagementEndpoints(this ILogger logger, LogLevel logLevel);
 
     [LoggerMessage(
         message: "Authenticating scheme: {Scheme}")]

--- a/bff/test/Bff.Tests/Headers/GeneralTests.cs
+++ b/bff/test/Bff.Tests/Headers/GeneralTests.cs
@@ -106,6 +106,6 @@ public class GeneralTests(ITestOutputHelper output) : BffTestBase(output)
         // And we can log in, which means the login endpoint was registered
         await Bff.BrowserClient.Login();
 
-        Context.LogMessages.ToString().ShouldContain("Already mapped Login endpoint");
+        Context.LogMessages.ToString().ShouldContain("Management endpoints are automatically mapped");
     }
 }

--- a/bff/test/Bff.Tests/PublicApiVerificationTests.VerifyPublicApi_Bff.verified.txt
+++ b/bff/test/Bff.Tests/PublicApiVerificationTests.VerifyPublicApi_Bff.verified.txt
@@ -465,6 +465,8 @@ namespace Duende.Bff.Endpoints
         bool IsValidAsync(System.Uri returnUrl);
     }
     public interface ISilentLoginCallbackEndpoint : Duende.Bff.Endpoints.IBffEndpoint { }
+    [System.Obsolete(("The silent login endpoint will be removed in a future version. Silent login is no" +
+        "w handled by passing the prompt=none parameter to the login endpoint."))]
     public interface ISilentLoginEndpoint : Duende.Bff.Endpoints.IBffEndpoint { }
     public interface IUserEndpoint : Duende.Bff.Endpoints.IBffEndpoint { }
 }

--- a/bff/test/Hosts.Tests/AppHost.cs
+++ b/bff/test/Hosts.Tests/AppHost.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+// This file is here ONLY to make sure ncrunch works without a reference to
+// the aspire project. 
+
+#if DEBUG_NCRUNCH
+namespace Projects
+{
+    public class Hosts_AppHost{}
+}
+#endif

--- a/shared/Xunit.Playwright/Duende.Xunit.Playwright.csproj
+++ b/shared/Xunit.Playwright/Duende.Xunit.Playwright.csproj
@@ -8,6 +8,10 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_ncrunch|AnyCPU'">
+    <DefineConstants>$(DefineConstants);DEBUG_NCRUNCH</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="AngleSharp" />
     <PackageReference Include="Serilog" />

--- a/shared/Xunit.Playwright/Duende.Xunit.Playwright.v3.ncrunchproject
+++ b/shared/Xunit.Playwright/Duende.Xunit.Playwright.v3.ncrunchproject
@@ -1,0 +1,5 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <UseBuildConfiguration>Debug_NCrunch</UseBuildConfiguration>
+  </Settings>
+</ProjectConfiguration>


### PR DESCRIPTION
**What issue does this PR address?**
In V3, you could extend the management endpoints by inheriting from the default functionality. 

In V4, this is no longer possible as the default impl is internal. You can replace the endpoint entirely (via DI). But if you want to extend the functionality, this was a bit clunky:

            app.Use(async (c, n) =>
            {
                if (c.Request.Path.StartsWithSegments("/bff/login"))
                {
                    loginCalled = true;
                    await c.RequestServices.GetRequiredService<ILoginEndpoint>().ProcessRequestAsync(c);
                    return;
                }
                await n();
            });

Make sure that this is possible:

            app.MapGet(Bff.BffOptions.LoginPath, c =>
            {
                loginCalled = true;
                return c.RequestServices.GetRequiredService<ILoginEndpoint>().ProcessRequestAsync(c);
            });

fixes: https://github.com/DuendeSoftware/issues/issues/533

Also, this PR marks the ISilentLoginEndpoint as obsolete. The implementation was already marked as obsolete, but this was an internal implementation. 

**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
