### PR TITLE
Extract Playwright test lib

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -67,7 +67,7 @@
     <PackageVersion Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.1.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.4.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.1" />

--- a/bff/bff.slnf
+++ b/bff/bff.slnf
@@ -32,7 +32,9 @@
       "bff\\templates\\src\\BffLocalApi\\BffLocalApi.csproj",
       "bff\\templates\\src\\BffRemoteApi\\BffRemoteApi.csproj",
       "bff\\test\\Bff.Tests\\Bff.Tests.csproj",
-      "bff\\test\\Hosts.Tests\\Hosts.Tests.csproj"
+      "bff\\test\\Hosts.Tests\\Hosts.Tests.csproj",
+      "shared\\Xunit.Playwright\\Duende.Xunit.Playwright.csproj",
+      "shared\\ShouldlyExtensions\\ShouldlyExtensions.csproj"
     ]
   }
 }

--- a/bff/hosts/Hosts.ServiceDefaults/BffAppHostRoutes.cs
+++ b/bff/hosts/Hosts.ServiceDefaults/BffAppHostRoutes.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using Duende.Xunit.Playwright;
+
+namespace Hosts.ServiceDefaults;
+
+public class BffAppHostRoutes : IAppHostServiceRoutes
+{
+    public string[] ServiceNames => AppHostServices.All;
+
+    public Uri UrlTo(string clientName)
+    {
+        var url = clientName switch
+        {
+            AppHostServices.Bff => "https://localhost:5002",
+            AppHostServices.BffBlazorPerComponent => "https://localhost:5105",
+            AppHostServices.BffMultiFrontend => "https://localhost:5005",
+            AppHostServices.BffBlazorWebassembly => "https://localhost:5006",
+            AppHostServices.TemplateBffBlazor => "https://localhost:7035",
+            _ => throw new InvalidOperationException("client not configured")
+        };
+        return new Uri(url);
+    }
+}

--- a/bff/hosts/Hosts.ServiceDefaults/Hosts.ServiceDefaults.csproj
+++ b/bff/hosts/Hosts.ServiceDefaults/Hosts.ServiceDefaults.csproj
@@ -19,6 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\shared\Xunit.Playwright\Duende.Xunit.Playwright.csproj" />
     <ProjectReference Include="..\..\src\Bff\Bff.csproj" />
   </ItemGroup>
 

--- a/bff/test/Hosts.Tests/BffBlazorWebAssemblyTests.cs
+++ b/bff/test/Hosts.Tests/BffBlazorWebAssemblyTests.cs
@@ -1,7 +1,8 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
-using Duende.Hosts.Tests.TestInfra.Retries;
+using Duende.Xunit.Playwright;
+using Duende.Xunit.Playwright.Retries;
 using Hosts.ServiceDefaults;
 using Hosts.Tests.PageModels;
 using Hosts.Tests.TestInfra;
@@ -9,8 +10,8 @@ using Xunit.Abstractions;
 
 namespace Hosts.Tests;
 
-public class BffBlazorWebAssemblyTests(ITestOutputHelper output, AppHostFixture fixture)
-    : PlaywrightTestBase(output, fixture)
+public class BffBlazorWebAssemblyTests(ITestOutputHelper output, BffHostTestFixture fixture)
+    : BffPlaywrightTestBase(output, fixture)
 {
     public async Task<WebAssemblyPageModel> GoToHome()
     {

--- a/bff/test/Hosts.Tests/BffTests.cs
+++ b/bff/test/Hosts.Tests/BffTests.cs
@@ -1,18 +1,21 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
+using Duende.Xunit.Playwright;
 using Hosts.ServiceDefaults;
 using Hosts.Tests.TestInfra;
+using Projects;
 using Xunit.Abstractions;
 
 namespace Hosts.Tests;
 
-public class BffTests : IntegrationTestBase
+[Collection(BffAppHostCollection.CollectionName)]
+public class BffTests : IntegrationTestBase<Hosts_AppHost>
 {
     private readonly HttpClient _httpClient;
     private readonly BffClient _bffClient;
 
-    public BffTests(ITestOutputHelper output, AppHostFixture fixture) : base(output: output, fixture: fixture)
+    public BffTests(ITestOutputHelper output, BffHostTestFixture fixture) : base(output: output, fixture: fixture)
     {
         _httpClient = CreateHttpClient(AppHostServices.Bff);
         _bffClient = new BffClient(CreateHttpClient(AppHostServices.Bff));
@@ -28,7 +31,6 @@ public class BffTests : IntegrationTestBase
     [SkippableFact]
     public async Task Can_initiate_login()
     {
-
         var response = await _httpClient.GetAsync("/");
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
 

--- a/bff/test/Hosts.Tests/BlazorPerComponentTests.cs
+++ b/bff/test/Hosts.Tests/BlazorPerComponentTests.cs
@@ -1,7 +1,8 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
-using Duende.Hosts.Tests.TestInfra.Retries;
+using Duende.Xunit.Playwright;
+using Duende.Xunit.Playwright.Retries;
 using Hosts.ServiceDefaults;
 using Hosts.Tests.PageModels;
 using Hosts.Tests.TestInfra;
@@ -9,8 +10,8 @@ using Xunit.Abstractions;
 
 namespace Hosts.Tests;
 
-public class BlazorPerComponentTests(ITestOutputHelper output, AppHostFixture fixture)
-    : PlaywrightTestBase(output, fixture)
+public class BlazorPerComponentTests(ITestOutputHelper output, BffHostTestFixture fixture)
+    : BffPlaywrightTestBase(output, fixture)
 {
 
     public async Task<PerComponentPageModel> GoToHome()

--- a/bff/test/Hosts.Tests/Hosts.Tests.csproj
+++ b/bff/test/Hosts.Tests/Hosts.Tests.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <Configurations>Debug;Release;Debug_ncrunch</Configurations>
+    <RootNamespace>Hosts.Tests</RootNamespace>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_ncrunch|AnyCPU'">
@@ -12,7 +13,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-
     <PackageReference Include="AngleSharp" />
     <PackageReference Include="Serilog" />
     <PackageReference Include="Serilog.Extensions.Logging" />
@@ -22,11 +22,9 @@
     <PackageReference Include="Aspire.Hosting.Testing" />
     <PackageReference Include="Xunit.SkippableFact" />
     <PackageReference Include="Microsoft.Playwright.Xunit" />
-
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)' != 'Debug_NCrunch'">
-
     <ProjectReference Include="..\..\hosts\Hosts.AppHost\Hosts.AppHost.csproj" />
     <Using Include="Aspire.Hosting.ApplicationModel" />
     <Using Include="Aspire.Hosting.Testing" />
@@ -37,6 +35,10 @@
     <Using Include="System.Net" />
     <Using Include="Microsoft.Extensions.DependencyInjection" />
     <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\shared\Xunit.Playwright\Duende.Xunit.Playwright.csproj" />
   </ItemGroup>
 
 </Project>

--- a/bff/test/Hosts.Tests/Templates/BffBlazorTemplateTests.cs
+++ b/bff/test/Hosts.Tests/Templates/BffBlazorTemplateTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
+using Duende.Xunit.Playwright;
 using Hosts.ServiceDefaults;
 using Hosts.Tests.PageModels;
 using Hosts.Tests.TestInfra;
@@ -8,8 +9,8 @@ using Xunit.Abstractions;
 
 namespace Hosts.Tests.Templates;
 
-public class BffBlazorTemplateTests(ITestOutputHelper output, AppHostFixture fixture)
-    : PlaywrightTestBase(output, fixture)
+public class BffBlazorTemplateTests(ITestOutputHelper output, BffHostTestFixture fixture)
+    : BffPlaywrightTestBase(output, fixture)
 {
     public async Task<WebAssemblyPageModel> GoToHome()
     {

--- a/bff/test/Hosts.Tests/TestInfra/BffAppHostCollection.cs
+++ b/bff/test/Hosts.Tests/TestInfra/BffAppHostCollection.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+namespace Hosts.Tests.TestInfra;
+
+[CollectionDefinition(CollectionName)]
+public class BffAppHostCollection : ICollectionFixture<BffHostTestFixture>
+{
+    public const string CollectionName = "apphost collection";
+    // This class has no code, and is never created. Its purpose is simply
+    // to be the place to apply [CollectionDefinition] and all the
+    // ICollectionFixture<> interfaces.
+}

--- a/bff/test/Hosts.Tests/TestInfra/BffHostTestFixture.cs
+++ b/bff/test/Hosts.Tests/TestInfra/BffHostTestFixture.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using Duende.Xunit.Playwright;
+using Hosts.ServiceDefaults;
+using Projects;
+
+namespace Hosts.Tests.TestInfra;
+
+public class BffHostTestFixture() : AppHostFixture<Hosts_AppHost>(new BffAppHostRoutes())
+{
+}

--- a/bff/test/Hosts.Tests/TestInfra/BffPlaywrightTestBase.cs
+++ b/bff/test/Hosts.Tests/TestInfra/BffPlaywrightTestBase.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using Duende.Xunit.Playwright;
+using Projects;
+using Xunit.Abstractions;
+
+namespace Hosts.Tests.TestInfra;
+
+[Collection(BffAppHostCollection.CollectionName)]
+public class BffPlaywrightTestBase : PlaywrightTestBase<Hosts_AppHost>
+{
+    public BffPlaywrightTestBase(ITestOutputHelper output, AppHostFixture<Hosts_AppHost> fixture) : base(output, fixture)
+    {
+    }
+}

--- a/bff/test/Hosts.Tests/readme.md
+++ b/bff/test/Hosts.Tests/readme.md
@@ -12,9 +12,6 @@ dotnet build
 pwsh bin/Debug/net9.0/playwright.ps1 install --with-deps
 ```
 
-
-
-
 The actual tests have been written in such a way that they only need an HTTP client to work. If you don't do anything,
 then the system will start an aspire test host, run the tests, then kill the aspire host again.
 

--- a/products.slnx
+++ b/products.slnx
@@ -166,6 +166,7 @@
   </Folder>
   <Folder Name="/shared/">
     <Project Path="shared/ShouldlyExtensions/ShouldlyExtensions.csproj" />
+    <Project Path="shared/Xunit.Playwright/Duende.Xunit.Playwright.csproj" />
   </Folder>
   <Folder Name="/templates/">
     <Project Path="templates/build/build.csproj" />

--- a/shared/Xunit.Playwright/AutoFollowRedirectHandler.cs
+++ b/shared/Xunit.Playwright/AutoFollowRedirectHandler.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.Extensions.Logging;
 
-namespace Hosts.Tests.TestInfra;
+namespace Duende.Xunit.Playwright;
 
 public class AutoFollowRedirectHandler(ILogger<AutoFollowRedirectHandler> logger) : DelegatingHandler
 {

--- a/shared/Xunit.Playwright/CloningHttpMessageHandler.cs
+++ b/shared/Xunit.Playwright/CloningHttpMessageHandler.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
-namespace Hosts.Tests.TestInfra;
+namespace Duende.Xunit.Playwright;
 
 public class CloningHttpMessageHandler(HttpClient innerHttpClient) : HttpMessageHandler
 {

--- a/shared/Xunit.Playwright/CookieHandler.cs
+++ b/shared/Xunit.Playwright/CookieHandler.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.Net.Http.Headers;
 
-namespace Hosts.Tests.TestInfra;
+namespace Duende.Xunit.Playwright;
 
 public class CookieHandler : DelegatingHandler
 {

--- a/shared/Xunit.Playwright/DelegateDisposable.cs
+++ b/shared/Xunit.Playwright/DelegateDisposable.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
-namespace Hosts.Tests.TestInfra;
+namespace Duende.Xunit.Playwright;
 
 public class DelegateDisposable(Action onDispose) : IDisposable
 {

--- a/shared/Xunit.Playwright/DelegateTextWriter.cs
+++ b/shared/Xunit.Playwright/DelegateTextWriter.cs
@@ -3,7 +3,7 @@
 
 using System.Text;
 
-namespace Hosts.Tests.TestInfra;
+namespace Duende.Xunit.Playwright;
 
 public class DelegateTextWriter : TextWriter
 {

--- a/shared/Xunit.Playwright/Duende.Xunit.Playwright.csproj
+++ b/shared/Xunit.Playwright/Duende.Xunit.Playwright.csproj
@@ -1,0 +1,36 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Duende.Xunit.Playwright</RootNamespace>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AngleSharp" />
+    <PackageReference Include="Serilog" />
+    <PackageReference Include="Serilog.Extensions.Logging" />
+    <PackageReference Include="Serilog.Sinks.TextWriter" />
+    <PackageReference Include="Serilog.Sinks.XUnit" />
+    <PackageReference Include="Serilog.AspNetCore" />
+    <PackageReference Include="Aspire.Hosting.Testing" />
+    <PackageReference Include="Xunit.SkippableFact" />
+    <PackageReference Include="Microsoft.Playwright.Xunit" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="xunit.core" />
+  </ItemGroup>
+
+
+
+  <ItemGroup>
+    <Using Include="Microsoft.Extensions.DependencyInjection" />
+    <Using Include="System.Net" />
+    <Using Include="Shouldly"/>
+    <Using Include="Xunit" />
+    <Using Include="Aspire.Hosting.ApplicationModel" />
+    <Using Include="Aspire.Hosting.Testing" />
+  </ItemGroup>
+
+</Project>

--- a/shared/Xunit.Playwright/IAppHostServiceRoutes.cs
+++ b/shared/Xunit.Playwright/IAppHostServiceRoutes.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+namespace Duende.Xunit.Playwright;
+
+/// <summary>
+/// This interface describes all the services in an AppHost and provides Urls to services in the host for external code.
+/// </summary>
+public interface IAppHostServiceRoutes
+{
+    public string[] ServiceNames { get; }
+    public Uri UrlTo(string clientName);
+}

--- a/shared/Xunit.Playwright/IntegrationTestBase.cs
+++ b/shared/Xunit.Playwright/IntegrationTestBase.cs
@@ -3,14 +3,13 @@
 
 using Xunit.Abstractions;
 
-namespace Hosts.Tests.TestInfra;
+namespace Duende.Xunit.Playwright;
 
-[Collection(AppHostCollection.CollectionName)]
-public class IntegrationTestBase : IDisposable
+public class IntegrationTestBase<THost> : IDisposable where THost : class
 {
     private readonly IDisposable _loggingScope;
 
-    public IntegrationTestBase(ITestOutputHelper output, AppHostFixture fixture)
+    public IntegrationTestBase(ITestOutputHelper output, AppHostFixture<THost> fixture)
     {
         Output = output;
         Fixture = fixture;
@@ -23,13 +22,13 @@ public class IntegrationTestBase : IDisposable
         {
 #if DEBUG_NCRUNCH
             // Running in NCrunch. NCrunch cannot build the aspire project, so it needs
-            // to be started manually. 
+            // to be started manually.
             Skip.If(true, "When running the Host.Tests using NCrunch, you must start the Hosts.AppHost project manually. IE: dotnet run -p bff/samples/Hosts.AppHost. Or start without debugging from the UI. ");
 #endif
         }
     }
 
-    public AppHostFixture Fixture { get; }
+    public AppHostFixture<THost> Fixture { get; }
 
     public ITestOutputHelper Output { get; }
 

--- a/shared/Xunit.Playwright/PlaywrightTestBase.cs
+++ b/shared/Xunit.Playwright/PlaywrightTestBase.cs
@@ -2,13 +2,12 @@
 // See LICENSE in the project root for license information.
 
 using System.Reflection;
-using Hosts.Tests.TestInfra;
 using Microsoft.Playwright;
 using Microsoft.Playwright.Xunit;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
-namespace Hosts.Tests;
+namespace Duende.Xunit.Playwright;
 
 public class Defaults
 {
@@ -17,12 +16,11 @@ public class Defaults
 }
 
 [WithTestName]
-[Collection(AppHostCollection.CollectionName)]
-public class PlaywrightTestBase : PageTest, IDisposable
+public class PlaywrightTestBase<THost> : PageTest, IDisposable where THost : class
 {
     private readonly IDisposable _loggingScope;
 
-    public PlaywrightTestBase(ITestOutputHelper output, AppHostFixture fixture)
+    public PlaywrightTestBase(ITestOutputHelper output, AppHostFixture<THost> fixture)
     {
         Output = output;
         Fixture = fixture;
@@ -36,7 +34,7 @@ public class PlaywrightTestBase : PageTest, IDisposable
         {
 #if DEBUG_NCRUNCH
             // Running in NCrunch. NCrunch cannot build the aspire project, so it needs
-            // to be started manually. 
+            // to be started manually.
             Skip.If(true, "When running the Host.Tests using NCrunch, you must start the Hosts.AppHost project manually. IE: dotnet run -p bff/samples/Hosts.AppHost. Or start without debugging from the UI. ");
 #endif
         }
@@ -58,7 +56,7 @@ public class PlaywrightTestBase : PageTest, IDisposable
     public override async Task DisposeAsync()
     {
         var path = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? Environment.CurrentDirectory;
-        // if path ends with /bin/{build configuration}/{dotnetversion}, then strip that from the path. 
+        // if path ends with /bin/{build configuration}/{dotnetversion}, then strip that from the path.
         var bin = Path.GetFullPath(Path.Combine(path, "../../"));
         if (bin.EndsWith("\\bin\\") || bin.EndsWith("/bin/"))
         {
@@ -82,14 +80,14 @@ public class PlaywrightTestBase : PageTest, IDisposable
         Locale = "en-US",
         ColorScheme = ColorScheme.Light,
 
-        // We need to ignore https errors to make this work on the build server. 
+        // We need to ignore https errors to make this work on the build server.
         // Even though we use dotnet dev-certs https --trust on the build agent,
-        // it still claims the certs are invalid. 
+        // it still claims the certs are invalid.
         IgnoreHTTPSErrors = true,
     };
 
 
-    public AppHostFixture Fixture { get; }
+    public AppHostFixture<THost> Fixture { get; }
 
     public ITestOutputHelper Output { get; }
 

--- a/shared/Xunit.Playwright/RequestLoggingHandler.cs
+++ b/shared/Xunit.Playwright/RequestLoggingHandler.cs
@@ -4,7 +4,7 @@
 using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 
-namespace Hosts.Tests.TestInfra;
+namespace Duende.Xunit.Playwright;
 
 public class RequestLoggingHandler(
     ILogger<RequestLoggingHandler> log,

--- a/shared/Xunit.Playwright/Retries/RetryableFact.cs
+++ b/shared/Xunit.Playwright/Retries/RetryableFact.cs
@@ -3,7 +3,7 @@
 
 using Xunit.Sdk;
 
-namespace Duende.Hosts.Tests.TestInfra.Retries;
+namespace Duende.Xunit.Playwright.Retries;
 
 [XunitTestCaseDiscoverer(
     typeName: "Duende.Hosts.Tests.TestInfra.Retries.RetryableTestDiscoverer",

--- a/shared/Xunit.Playwright/Retries/RetryableTestCase.cs
+++ b/shared/Xunit.Playwright/Retries/RetryableTestCase.cs
@@ -4,7 +4,7 @@
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
-namespace Duende.Hosts.Tests.TestInfra.Retries;
+namespace Duende.Xunit.Playwright.Retries;
 
 public class RetryableTestCase(
     IMessageSink sink,

--- a/shared/Xunit.Playwright/Retries/RetryableTestDiscoverer.cs
+++ b/shared/Xunit.Playwright/Retries/RetryableTestDiscoverer.cs
@@ -4,7 +4,7 @@
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
-namespace Duende.Hosts.Tests.TestInfra.Retries;
+namespace Duende.Xunit.Playwright.Retries;
 
 public class RetryableTestDiscoverer(IMessageSink messageSink) : IXunitTestCaseDiscoverer
 {

--- a/shared/Xunit.Playwright/WriteTestOutput.cs
+++ b/shared/Xunit.Playwright/WriteTestOutput.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
-namespace Hosts.Tests.TestInfra;
+namespace Duende.Xunit.Playwright;
 
 public delegate void WriteTestOutput(string message);


### PR DESCRIPTION
This moves the test infrastructure for the aspire/playwright tests into a shared library. Intention is to use that shared lib in IdentityServer to build similar tests there.