### PR TITLE
Fix issue that openid connect handlers are not registered correctly if only relying on config. 

### DIFF
--- a/bff/src/Bff/BffBuilderExtensions.cs
+++ b/bff/src/Bff/BffBuilderExtensions.cs
@@ -51,6 +51,7 @@ public static class BffBuilderExtensions
         builder.Services.AddSingleton<BffLicense>(sp => sp.GetRequiredService<LicenseAccessor<BffLicense>>().Current);
         builder.Services.TryAddSingleton<LicenseValidator>();
         builder.Services.AddDistributedMemoryCache();
+
         // IMPORTANT: The BffConfigureOpenIdConnectOptions MUST be called before calling
         // AddOpenIdConnectAccessTokenManagement because both configure the same options
         // The AddOpenIdConnectAccessTokenManagement adds OR wraps the BackchannelHttpHandler

--- a/bff/src/Bff/DynamicFrontends/BffConfigureOpenIdConnectOptions.cs
+++ b/bff/src/Bff/DynamicFrontends/BffConfigureOpenIdConnectOptions.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
+using Duende.Bff.AccessTokenManagement;
 using Duende.Bff.Configuration;
+using Duende.Bff.Internal;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.Extensions.Options;
 
@@ -10,6 +12,7 @@ namespace Duende.Bff.DynamicFrontends;
 internal class BffConfigureOpenIdConnectOptions(
     TimeProvider timeProvider,
     CurrentFrontendAccessor currentFrontendAccessor,
+    ActiveOpenIdConnectAuthenticationScheme activeOpenIdConnectScheme,
     IOptions<BffConfiguration> bffConfiguration,
     IOptions<BffOptions> bffOptions
     ) : IConfigureNamedOptions<OpenIdConnectOptions>
@@ -18,6 +21,11 @@ internal class BffConfigureOpenIdConnectOptions(
 
     public void Configure(string? name, OpenIdConnectOptions options)
     {
+        if (!activeOpenIdConnectScheme.ShouldConfigureScheme(Scheme.ParseOrDefault(name)))
+        {
+            return;
+        }
+
         // Normally, this is added by AuthenticationBuilder.PostConfigureAuthenticationSchemeOptions
         // but this is private API, so we need to do it ourselves.
         options.TimeProvider = timeProvider;

--- a/bff/src/Bff/DynamicFrontends/Internal/FrontendSelectionMiddleware.cs
+++ b/bff/src/Bff/DynamicFrontends/Internal/FrontendSelectionMiddleware.cs
@@ -11,6 +11,7 @@ namespace Duende.Bff.DynamicFrontends.Internal;
 internal class FrontendSelectionMiddleware(
     RequestDelegate next,
     ILogger<FrontendSelectionMiddleware> logger,
+    IFrontendCollection frontends,
     FrontendSelector frontendSelector)
 {
     public async Task InvokeAsync(HttpContext context)
@@ -30,7 +31,14 @@ internal class FrontendSelectionMiddleware(
         }
         else
         {
-            logger.NoFrontendSelected(LogLevel.Debug);
+            if (frontends.Count > 0)
+            {
+                logger.NoFrontendSelected(LogLevel.Debug);
+            }
+            else
+            {
+                logger.MultiFrontendDisabled(LogLevel.Trace);
+            }
             await next(context);
         }
     }

--- a/bff/src/Bff/DynamicFrontends/Internal/OpenIdConnectCallbackMiddleware.cs
+++ b/bff/src/Bff/DynamicFrontends/Internal/OpenIdConnectCallbackMiddleware.cs
@@ -9,33 +9,36 @@ using Microsoft.Extensions.Options;
 
 namespace Duende.Bff.DynamicFrontends.Internal;
 
+/// <summary>
+/// This middleware performs the openid connect callback processing. This happens in two situations:
+/// 1. A frontend is selected.
+/// 2. No frontend is selected, but there is a default BFF OIDC scheme configured.
+/// </summary>
 internal class OpenIdConnectCallbackMiddleware(RequestDelegate next,
     CurrentFrontendAccessor selector)
 {
     public async Task InvokeAsync(HttpContext context)
     {
-        if (!selector.TryGet(out var frontend))
+        var oidcOptionsFactory = context.RequestServices.GetRequiredService<IOptionsFactory<OpenIdConnectOptions>>();
+
+        var scheme = selector.TryGet(out var frontend)
+                ? frontend.OidcSchemeName // A frontend is selected, use its scheme
+                : BffAuthenticationSchemes.BffOpenIdConnect; // rely on the default scheme
+
+        var options = oidcOptionsFactory.Create(scheme);
+
+        if (options.ClientId == null || options.Authority == null)
         {
+            // See if the scheme has been configured. if not, just resume as normally
             await next(context);
             return;
         }
 
-        var oidcOptionsFactory = context.RequestServices.GetRequiredService<IOptionsFactory<OpenIdConnectOptions>>();
-        var options = oidcOptionsFactory.Create(frontend.OidcSchemeName);
-
-        if (context.Request.Path.StartsWithSegments(options.CallbackPath, StringComparison.OrdinalIgnoreCase))
+        if (IsOidcCallbackPath(context, options))
         {
+            // Currently processing a signin or signout callback
             var handlers = context.RequestServices.GetRequiredService<IAuthenticationHandlerProvider>();
-            if (await handlers.GetHandlerAsync(context, frontend.OidcSchemeName) is IAuthenticationRequestHandler handler)
-            {
-                await handler.HandleRequestAsync();
-                return;
-            }
-        }
-        if (context.Request.Path.StartsWithSegments(options.SignedOutCallbackPath, StringComparison.OrdinalIgnoreCase))
-        {
-            var handlers = context.RequestServices.GetRequiredService<IAuthenticationHandlerProvider>();
-            if (await handlers.GetHandlerAsync(context, frontend.OidcSchemeName) is IAuthenticationRequestHandler handler)
+            if (await handlers.GetHandlerAsync(context, scheme) is IAuthenticationRequestHandler handler)
             {
                 await handler.HandleRequestAsync();
                 return;
@@ -43,5 +46,12 @@ internal class OpenIdConnectCallbackMiddleware(RequestDelegate next,
         }
 
         await next(context);
+    }
+
+    private static bool IsOidcCallbackPath(HttpContext context, OpenIdConnectOptions options)
+    {
+        var path = context.Request.Path;
+        return path.StartsWithSegments(options.CallbackPath, StringComparison.OrdinalIgnoreCase)
+            || path.StartsWithSegments(options.SignedOutCallbackPath, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/bff/src/Bff/Otel/LogMessages.cs
+++ b/bff/src/Bff/Otel/LogMessages.cs
@@ -89,8 +89,12 @@ internal static partial class LogMessages
         Scheme scheme);
 
     [LoggerMessage(
-        $"No frontend selected.")]
+        $"None of the configured frontends matched the selection criteria.")]
     public static partial void NoFrontendSelected(this ILogger logger, LogLevel logLevel);
+
+    [LoggerMessage(
+        $"BFF is not configured to work with multiple frontends.")]
+    public static partial void MultiFrontendDisabled(this ILogger logger, LogLevel logLevel);
 
     [LoggerMessage(
         $"Selected frontend '{{{OTelParameters.Frontend}}}'")]

--- a/bff/test/Bff.Tests/Configuration/BffBuilderTests.cs
+++ b/bff/test/Bff.Tests/Configuration/BffBuilderTests.cs
@@ -249,8 +249,9 @@ public class BffBuilderTests
 
         var found = frontends.First(x => x.Name == The.FrontendName);
 
-        var oidcOptionsFactory = provider.GetRequiredService<IOptionsFactory<OpenIdConnectOptions>>();
-        var openIdConnectOptions = oidcOptionsFactory.Create(frontends.First().OidcSchemeName);
+        var factory = provider.GetRequiredService<IOptionsFactory<OpenIdConnectOptions>>();
+
+        var openIdConnectOptions = factory.Create(BffAuthenticationSchemes.BffOpenIdConnect);
 
         ValidateOpenIdConnectOptions(openIdConnectOptions, The.CallbackPath.ToString());
 
@@ -445,9 +446,11 @@ public class BffBuilderTests
         services.AddBff().LoadConfiguration(configuration);
         var provider = services.BuildServiceProvider();
 
-        var options = provider.GetRequiredService<IOptions<OpenIdConnectOptions>>();
+        var factory = provider.GetRequiredService<IOptionsFactory<OpenIdConnectOptions>>();
 
-        ValidateOpenIdConnectOptions(options.Value, The.CallbackPath.ToString());
+        var options = factory.Create(BffAuthenticationSchemes.BffOpenIdConnect);
+
+        ValidateOpenIdConnectOptions(options, The.CallbackPath.ToString());
     }
 
     [Fact]


### PR DESCRIPTION
**What issue does this PR address?**

There are several ways how you can configure the BFF. Turns out, if you only load configuration data, then the openid connect pipeline doesn't get configured correctly. This is because the openid connect callback middleware get's skipped.

This pr does the following:
* Also invoke the OpenIdConnectCallbackMiddleware if the BffAuthenticationSchemes.BffOpenIdConnect is used. 
* this caused the BffConfigureOpenIdConnectOptions to misfire. It should have only executed if ActiveOpenIdConnectAuthenticationScheme.ShouldConfigureScheme()


fixes https://github.com/DuendeSoftware/issues/issues/541
fixes: https://github.com/orgs/DuendeSoftware/discussions/320


**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
