### PR TITLE
Return BffServicesBuilder from AddServerSideSessions

### DIFF
--- a/bff/src/Bff/BffBuilderExtensions.cs
+++ b/bff/src/Bff/BffBuilderExtensions.cs
@@ -55,7 +55,7 @@ public static class BffBuilderExtensions
         // IMPORTANT: The BffConfigureOpenIdConnectOptions MUST be called before calling
         // AddOpenIdConnectAccessTokenManagement because both configure the same options
         // The AddOpenIdConnectAccessTokenManagement adds OR wraps the BackchannelHttpHandler
-        // to add DPoP support. However, our code can also add a backchannel handler. 
+        // to add DPoP support. However, our code can also add a backchannel handler.
         builder.Services.AddSingleton<IConfigureOptions<OpenIdConnectOptions>, BffConfigureOpenIdConnectOptions>();
         builder.Services.AddOpenIdConnectAccessTokenManagement();
 
@@ -123,7 +123,7 @@ public static class BffBuilderExtensions
         // Add a scheme provider that will inject authentication schemes that are needed for the BFF
         builder.Services.AddTransient<IAuthenticationSchemeProvider, BffAuthenticationSchemeProvider>();
 
-        // Configure the AspNet Core Authentication settings if no 
+        // Configure the AspNet Core Authentication settings if no
         // .AddAuthentication().AddCookie().AddOpenIdConnect() was added
         builder.Services.AddSingleton<IPostConfigureOptions<AuthenticationOptions>, BffConfigureAuthenticationOptions>();
 
@@ -195,12 +195,13 @@ public static class BffBuilderExtensions
     /// </summary>
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
-    public static IBffBuilder AddServerSideSessions<T>(this IBffServicesBuilder builder)
+    public static IBffServicesBuilder AddServerSideSessions<T>(this IBffServicesBuilder builder)
         where T : class, IUserSessionStore
     {
         ArgumentNullException.ThrowIfNull(builder);
         builder.Services.AddTransient<IUserSessionStore, T>();
-        return builder.AddServerSideSessions();
+        builder.AddServerSideSessions();
+        return builder;
     }
 
     public static T AddFrontends<T>(this T builder, params BffFrontend[] frontends)

--- a/bff/test/Bff.Tests/PublicApiVerificationTests.VerifyPublicApi_Bff.verified.txt
+++ b/bff/test/Bff.Tests/PublicApiVerificationTests.VerifyPublicApi_Bff.verified.txt
@@ -1,4 +1,4 @@
-namespace Duende.Bff.AccessTokenManagement
+﻿namespace Duende.Bff.AccessTokenManagement
 {
     [System.Text.Json.Serialization.JsonConverter(typeof(Duende.Bff.Internal.StringValueJsonConverter<Duende.Bff.AccessTokenManagement.AccessToken>))]
     public readonly struct AccessToken : System.IEquatable<Duende.Bff.AccessTokenManagement.AccessToken>
@@ -160,7 +160,7 @@ namespace Duende.Bff
     {
         public static T AddFrontends<T>(this T builder, params Duende.Bff.DynamicFrontends.BffFrontend[] frontends)
             where T : Duende.Bff.Builder.IBffServicesBuilder { }
-        public static Duende.Bff.Builder.IBffBuilder AddServerSideSessions<T>(this Duende.Bff.Builder.IBffServicesBuilder builder)
+        public static Duende.Bff.Builder.IBffServicesBuilder AddServerSideSessions<T>(this Duende.Bff.Builder.IBffServicesBuilder builder)
             where T :  class, Duende.Bff.SessionManagement.SessionStore.IUserSessionStore { }
         public static T AddServerSideSessions<T>(this T builder)
             where T : Duende.Bff.Builder.IBffServicesBuilder { }


### PR DESCRIPTION
**What issue does this PR address?**

Allows users to leverage the other extension methods such as `AddBlazorServer` after calling `AddServerSideSessions`.

**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
